### PR TITLE
vc-intrinsics-0.11.0

### DIFF
--- a/intel-packages/intel-makedepends-stage-1/intel-makedepends/vc-intrinsics/PKGBUILD
+++ b/intel-packages/intel-makedepends-stage-1/intel-makedepends/vc-intrinsics/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Daniel Bermond <dbermond@archlinux.org>
 
 pkgname=vc-intrinsics
-pkgver=0.10.1
+pkgver=0.11.0
 pkgrel=1
 pkgdesc="Set of new intrinsics on top of core LLVM IR instructions that represent SIMD semantics of a program targeting GPU"
 arch=(x86_64)
@@ -10,7 +10,7 @@ url="https://github.com/intel/vc-intrinsics"
 license=(MIT)
 makedepends=(cmake python llvm git)
 # From IGC release notes or latest release
-_commit=dafb9926e5047a052ef5263dd4ec4fe5f178e5e0
+_commit=dd72efa3b4aafdbbf599e6f3c6f8c55450e348de
 source=(git+${url}.git#commit=$_commit)
 sha256sums=('SKIP')
 


### PR DESCRIPTION
Release: https://github.com/intel/vc-intrinsics/releases/tag/v0.11.0   
 - Support latest LLVM top-of-trunk updates 
 - Support new pass manager 
 - Clean-up target platform names list