### PR TITLE
New package: protonfixes-ge-git

### DIFF
--- a/protonfixes-ge-git/.SRCINFO
+++ b/protonfixes-ge-git/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = protonfixes-ge-git
+	pkgdesc = Protonfixes fork by GloriousEggroll (git)
+	pkgver = 1.0.15.r546.gfc74674
+	pkgrel = 1
+	url = https://github.com/GloriousEggroll/protonfixes
+	arch = any
+	license = bsd
+	makedepends = git
+	makedepends = python-setuptools
+	depends = libmspack
+	depends = winetricks
+	provides = protonfixes
+	conflicts = protonfixes
+	source = protonfixes-ge-git::git+https://github.com/GloriousEggroll/protonfixes.git
+	source = setup.py
+	sha256sums = SKIP
+	sha256sums = 58561f68aea810b6440b354d7d66860e6086bd23c6fd80e069a9e478fc7e4600
+
+pkgname = protonfixes-ge-git

--- a/protonfixes-ge-git/PKGBUILD
+++ b/protonfixes-ge-git/PKGBUILD
@@ -12,13 +12,13 @@ provides=('protonfixes')
 conflicts=('protonfixes')
 makedepends=(git python-setuptools)
 depends=(libmspack winetricks)
-source=($pkgname::git+https://github.com/GloriousEggroll/${_gitname}.git
+source=($_gitname::git+https://github.com/GloriousEggroll/${_gitname}.git
         setup.py)
 sha256sums=('SKIP'
-            '58561f68aea810b6440b354d7d66860e6086bd23c6fd80e069a9e478fc7e4600')
+            'ea220fffadfdf2748d5095e78958c50222f8c4c1f3aea40a66b386afbbcded74')
 
 pkgver() {
-    cd "${srcdir}/${pkgname}"
+    cd "${srcdir}/${_gitname}"
     git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 

--- a/protonfixes-ge-git/PKGBUILD
+++ b/protonfixes-ge-git/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Vasiliy Stelmachenok <ventureo@yandex.ru>
+_gitname=protonfixes
+_setup_ver=1
+pkgname=(protonfixes-ge-git)
+pkgver=1.0.15.r546.gfc74674
+pkgrel=1
+pkgdesc="Protonfixes fork by GloriousEggroll (git)"
+license=('bsd')
+arch=('any')
+url="https://github.com/GloriousEggroll/${_gitname}"
+provides=('protonfixes')
+conflicts=('protonfixes')
+makedepends=(git python-setuptools)
+depends=(libmspack winetricks)
+source=($pkgname::git+https://github.com/GloriousEggroll/${_gitname}.git
+        setup.py)
+sha256sums=('SKIP'
+            '58561f68aea810b6440b354d7d66860e6086bd23c6fd80e069a9e478fc7e4600')
+
+pkgver() {
+    cd "${srcdir}/${pkgname}"
+    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+    cd "${srcdir}"
+    python setup.py build
+}
+
+package() {
+    cd "${srcdir}"
+    python setup.py install --root="$pkgdir/" --optimize=1 --skip-build
+}

--- a/protonfixes-ge-git/setup.py
+++ b/protonfixes-ge-git/setup.py
@@ -1,0 +1,23 @@
+""" Install the protonfixes package
+"""
+import glob
+from setuptools import setup, find_packages
+
+setup(
+    name='protonfixes',
+    version=1.0.15
+    description='Protonfixes fork by GloriousEggroll',
+    url='https://github.com/GloriousEggroll/protonfixes.git',
+    author='Thomas Crider',
+    author_email='gloriouseggroll@gmail.com',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Topic :: Games/Entertainment',
+        'Operating System :: POSIX :: Linux',
+        'License :: OSI Approved :: BSD License',
+        ],
+    keywords='proton steam winetricks protonfixes',
+    packages=find_packages(),
+    zip_safe=False,
+    package_data={'protonfixes':['*.kv','gamefixes/verbs/*']},
+)

--- a/protonfixes-ge-git/setup.py
+++ b/protonfixes-ge-git/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='protonfixes',
-    version=1.0.15
+    version='1.0.15',
     description='Protonfixes fork by GloriousEggroll',
     url='https://github.com/GloriousEggroll/protonfixes.git',
     author='Thomas Crider',


### PR DESCRIPTION
Still WIP, I'm still not sure if it will use the system versions of winetricks and libmspack or if we should use the bundled versions from the repository, so testing is welcome. 

**Note:** this package is only needed for regular versions of proton/proton-experimental, proton-ge-custom already contains protonfixes.