### PR TITLE
New package: nvlax-git

### DIFF
--- a/nvlax-git/.SRCINFO
+++ b/nvlax-git/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = nvlax-git
+	pkgdesc = Future-proof NvENC & NvFBC patcher
+	pkgver = r11.b3699ad
+	pkgrel = 5
+	url = https://github.com/illnyang/nvlax
+	arch = x86_64
+	license = GPL
+	makedepends = cmake
+	makedepends = git
+	depends = nvidia-utils
+	provides = nvlax
+	provides = nvlax-git
+	conflicts = nvlax
+	options = !ccache
+	source = nvlax::git+https://github.com/illnyang/nvlax.git
+	source = nvlax-upgrade.hook
+	source = nvlax-install.hook
+	sha256sums = SKIP
+	sha256sums = 347ba347a37f70c008be340c40cd55fff8588ce7aa3dd1dd7ef0241bd2f5e09a
+	sha256sums = 120488c0831ae4b347432c46add9f56f146f69580ebedfece4bb4ed947fb12df
+
+pkgname = nvlax-git

--- a/nvlax-git/PKGBUILD
+++ b/nvlax-git/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Vasiliy Stelmachenok <ventureo@yandex.ru>
+# Contributor: mfcmquintela <mfcmquintela@gmail.com>
+# Contributor: lazerl0rd <lazerl0rd@thezest.dev>
+
+_gitname=nvlax
+pkgname=$_gitname-git
+pkgver=r11.b3699ad
+pkgrel=5
+pkgdesc='Future-proof NvENC & NvFBC patcher'
+arch=('x86_64')
+url='https://github.com/illnyang/nvlax'
+license=('GPL')
+depends=('nvidia-utils')
+makedepends=('cmake' 'git')
+provides=('nvlax' 'nvlax-git')
+conflicts=('nvlax')
+options=(!ccache)
+source=("$_gitname"::"git+https://github.com/illnyang/${_gitname}.git"
+        'nvlax-upgrade.hook'
+        'nvlax-install.hook')
+sha256sums=('SKIP'
+            '347ba347a37f70c008be340c40cd55fff8588ce7aa3dd1dd7ef0241bd2f5e09a'
+            '120488c0831ae4b347432c46add9f56f146f69580ebedfece4bb4ed947fb12df')
+
+prepare() {
+  cd $_gitname
+
+  # Fixes: https://github.com/illnyang/nvlax/issues/11
+  sed -i 's|CPMAddPackage("gh:zyantific/zydis#master")|CPMAddPackage("gh:zyantific/zydis#55dd08c210722aed81b38132f5fd4a04ec1943b5")|g' CMakeLists.txt
+  sed -i '23s/GIT_TAG\smaster/GIT_TAG b65e7cca03ec4cd91f1d7125e717d01635ea81ba/' CMakeLists.txt
+  sed -i '62s/GIT_TAG\smaster/GIT_TAG 833b8b7ea49aea540a49f07ad08bf0bae1faac32/' CMakeLists.txt
+}
+
+pkgver() {	
+  cd "${srcdir}/$_gitname"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "${srcdir}/$_gitname"
+  cmake -B build
+  make -C build
+}
+
+package() {
+  cd "${srcdir}/$_gitname"
+  install -Dm755 build/nvlax_encode -t "$pkgdir/usr/bin"
+  install -Dm755 build/nvlax_fbc    -t "$pkgdir/usr/bin"
+  install -Dm644 LICENSE   "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+
+  # Auto applying hooks
+  install -Dm644 "${srcdir}/nvlax-install.hook" -t "$pkgdir/usr/share/libalpm/hooks"
+  install -Dm644 "${srcdir}/nvlax-upgrade.hook" -t "$pkgdir/usr/share/libalpm/hooks"
+}

--- a/nvlax-git/nvlax-install.hook
+++ b/nvlax-git/nvlax-install.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Operation = Install
+Type = Package
+Target = nvlax
+Target = nvlax-git
+
+[Action]
+Description = Applying nvlax
+When = PostTransaction
+Exec = /bin/sh -c 'nvlax_encode -i /usr/lib/libnvidia-encode.so -o /usr/lib/libnvidia-encode.so; nvlax_fbc -i /usr/lib/libnvidia-fbc.so -o /usr/lib/libnvidia-fbc.so'
+NeedsTargets

--- a/nvlax-git/nvlax-upgrade.hook
+++ b/nvlax-git/nvlax-upgrade.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = File
+Target = usr/lib/libnvidia-encode.so.*
+Target = usr/lib/libnvidia-fbc.so.*
+
+[Action]
+Description = Re-Applying nvlax
+When = PostTransaction
+Exec = /bin/sh -c 'nvlax_encode -i /usr/lib/libnvidia-encode.so -o /usr/lib/libnvidia-encode.so; nvlax_fbc -i /usr/lib/libnvidia-fbc.so -o /usr/lib/libnvidia-fbc.so'
+NeedsTargets


### PR DESCRIPTION
Although upstream seems to be dead, nvlax still works fine for new driver versions and we don't have to wait for an nvidia-patch.

I'm really not sure if we really need hooks for auto-apply.

@ptr1337 