### PR TITLE
Proton-cachyos: Automate The Date Value with the use of API Github

### DIFF
--- a/proton-cachyos/PKGBUILD
+++ b/proton-cachyos/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=proton-cachyos
 _commit=$(curl -s https://api.github.com/repos/ValveSoftware/Proton/commits?sha=experimental_7.0 | grep '"sha"' | head -n 1 | cut -d '"' -f 4)
 _raw_date=$(curl -s https://api.github.com/repos/ValveSoftware/Proton/commits/$_commit | grep '"date"' | cut -d '"' -f 4)
 _date=$(echo $_raw_date | cut -d '-' -f 1-3 | tr -d '-' | cut -d 'T' -f 1)
-_srctag=7.0-$_date
+pkgver=7.0.$_date
 pkgver=${_srctag//-/.}
 _geckover=2.47.3
 _monover=7.4.0

--- a/proton-cachyos/PKGBUILD
+++ b/proton-cachyos/PKGBUILD
@@ -5,8 +5,10 @@
 _optimize=${_optimize-y}
 
 pkgname=proton-cachyos
-_srctag=7.0-20230201
-_commit=
+_commit=$(curl -s https://api.github.com/repos/ValveSoftware/Proton/commits?sha=experimental_7.0 | grep '"sha"' | head -n 1 | cut -d '"' -f 4)
+_raw_date=$(curl -s https://api.github.com/repos/ValveSoftware/Proton/commits/$_commit | grep '"date"' | cut -d '"' -f 4)
+_date=$(echo $_raw_date | cut -d '-' -f 1-3 | tr -d '-' | cut -d 'T' -f 1)
+_srctag=7.0-$_date
 pkgver=${_srctag//-/.}
 _geckover=2.47.3
 _monover=7.4.0


### PR DESCRIPTION
Hello,this function retrieves the SHA value of the latest commit in the "experimental_7.0" branch of the Proton repository from Github API. It then extracts the date of the commit and formats it as "7.0-YYYYMM". Finally, it replaces any hyphens in the date with dots and sets it as the value of the pkgver variable.

Best Regards,
NextWorks