### PR TITLE
Sunshine

### DIFF
--- a/sunshine/PKGBUILD
+++ b/sunshine/PKGBUILD
@@ -1,0 +1,49 @@
+# Edit on github: https://github.com/LizardByte/Sunshine/tree/nightly/packaging/linux/aur/PKGBUILD
+# Reference: https://wiki.archlinux.org/title/PKGBUILD
+
+pkgname='sunshine'
+pkgver=0.18.4
+pkgrel=1
+pkgdesc="Sunshine is a self-hosted game stream host for Moonlight."
+arch=('x86_64' 'aarch64')
+url=https://app.lizardbyte.dev
+license=('GPL3')
+
+depends=('avahi' 'boost-libs' 'curl' 'libevdev' 'libmfx' 'libpulse' 'libva' 'libvdpau' 'libx11' 'libxcb' 'libxfixes' 'libxrandr' 'libxtst' 'numactl' 'openssl' 'opus' 'udev')
+makedepends=('boost' 'cmake' 'git' 'make' 'nodejs' 'npm')
+optdepends=('cuda: NvFBC capture support'
+            'libcap'
+            'libdrm')
+
+provides=('sunshine')
+
+source=("$pkgname::git+https://github.com/LizardByte/Sunshine.git#commit=0dfbcfdbc4a996fc6431387fd227525e7ec57684")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "$pkgname"
+    git submodule update --recursive --init
+}
+
+build() {
+    pushd "$pkgname"
+    npm install
+    popd
+
+    export CFLAGS="${CFLAGS/-Werror=format-security/}"
+    export CXXFLAGS="${CXXFLAGS/-Werror=format-security/}"
+
+    cmake \
+        -S "$pkgname" \
+        -B build \
+        -Wno-dev \
+        -D CMAKE_INSTALL_PREFIX=/usr \
+        -D SUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine \
+        -D SUNSHINE_ASSETS_DIR="share/sunshine"
+
+    make -C build
+}
+
+package() {
+    make -C build install DESTDIR="$pkgdir"
+}


### PR DESCRIPTION
I added Sunshine to our repositories because the developer LizardByte dropped AUR support, he releases PKGBUILDs on GitHub along with Windows, Debian, and Fedora builds. 

So it's easy to maintain, we only need to copy PKGBUILDs and that's it. I accept to maintain Sunshine.
https://aur.archlinux.org/packages/sunshine#comment-902986

>In order to simplify maintenance of Sunshine, we have decided to drop support of this AUR package, since we are now publishing a pre-compiled pkg.tar.zst package as well as the PKGBUILD file to our GitHub releases. If someone would like to take over the AUR it would be ideal if there is communication with us in our Discord. Please reach out if you're interested. Thanks!

**NVIDIA GeForce gamestream is dead** and **Sunshine** is an open-source alternative to use on any GPU, even non-NVIDIA GPUs, or only on CPU.
https://www.nvidia.com/en-us/geforce/forums/gamestream/19/506467/gamestream-is-ending-on-mid-feb-2023/

So I believe this can also bring a lot of new users for CachyOS or just for repositories. If you accept with that @ptr1337 I can also inform the LizardByte developer about the availability of Sunshine through cachyos repositories.

Edit: Build of Sunshine takes just a few minutes on my overheated laptop :)