### PR TITLE
systemd-boot-manager: Prefer asynchronous discard for Btrfs instead of normal discard

### DIFF
--- a/systemd-boot-manager/sdboot-manage
+++ b/systemd-boot-manager/sdboot-manage
@@ -115,7 +115,7 @@ generate_entries() {
                     sdoptions="root=UUID=${srcdev_uuid} rw rootflags=subvol=${srcdev_fsroot}"
                 fi
                 if [[ ${CDISCARD,,} == "yes" ]]; then
-                    sdoptions="${sdoptions},discard"
+                    sdoptions="${sdoptions},discard=async"
                 fi
                 ;;
             *)


### PR DESCRIPTION
Synchronized discard is terrible