### PR TITLE
Add Armcord-git.

### DIFF
--- a/armcord-git/PKGBUILD
+++ b/armcord-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="ArmCord dev build using the system electron. ArmCord is a custom client
 pkgver=r977.bcb54b4
 pkgrel=1
 
-arch=("x86_64_v3")
+arch=("x86_64")
 url="https://github.com/ArmCord/ArmCord"
 license=("custom:OSL-3.0")
 

--- a/armcord-git/PKGBUILD
+++ b/armcord-git/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: NextWork123 <nextworks@protonmail.com>
+# Maintainer: Vendicated <vendicated at riseup dot net>
+
+
+pkgname=armcord-git
+pkgdesc="ArmCord dev build using the system electron. ArmCord is a custom client designed to enhance your Discord experience while keeping everything lightweight"
+pkgver=r977.bcb54b4
+pkgrel=1
+
+arch=("x86_64_v3")
+url="https://github.com/ArmCord/ArmCord"
+license=("custom:OSL-3.0")
+
+makedepends=("git" "nodejs" "npm")
+depends=("electron26-bin")  # Use electron26-bin instead of electron
+optdepends=(
+  'libnotify: Notifications'
+  'xdg-utils: Open links, files, etc'
+)
+
+install="notes.install"
+
+provides=("armcord")
+conflicts=("armcord")
+
+source=(
+  "${pkgname}::git+${url}.git"
+  "armcord.desktop"
+  "armcord-launcher.sh"
+  "notes.install"
+)
+sha256sums=('SKIP'
+            'a964b66a4829eb2fe86a0fa4841a67a9fd3264dfea960aa4cacf2a64c0200d93'
+            '4641036d93004de59bf6115fdc0e05baea23246759a11a37113f396bf72d127c'
+            '7a07b934a281292476b8bfa6ff96fed60c528d7f03b371211ac58b2848c17657')
+
+pkgver() {
+	cd "$pkgname"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "$pkgname"
+  npx pnpm install --frozen-lockfile --ignore-scripts
+  npm run packageQuick --optimize_for_size
+}
+
+package() {
+  cd "$srcdir"
+
+  install -Dm 644 "$pkgname/dist/"*"-unpacked/resources/app.asar" "$pkgdir/usr/share/armcord/app.asar"
+
+  install -Dm 755 "armcord-launcher.sh" "$pkgdir/usr/bin/armcord"
+  install -Dm 644 "armcord.desktop" "$pkgdir/usr/share/applications/armcord.desktop" 
+
+  install -Dm 644 "$pkgname/build/icon.png" "$pkgdir/usr/share/pixmaps/armcord.png"
+  install -Dm 644 "$pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/armcord-git/armcord-launcher.sh
+++ b/armcord-git/armcord-launcher.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+electron=/usr/lib/electron26/electron
+
+CONFIG=${XDG_CONFIG_HOME:-~/.config}
+FLAGS="$CONFIG/armcord-flags.conf"
+
+# Allow users to override command-line options
+if [ -f "$FLAGS" ]; then
+  USER_FLAGS="$(cat "$FLAGS")"
+fi
+
+# shellcheck disable=SC2086 # USER_FLAGS has to be unquoted
+"$electron" /usr/share/armcord/app.asar $USER_FLAGS "$@"

--- a/armcord-git/armcord.desktop
+++ b/armcord-git/armcord.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=ArmCord
+Comment=ArmCord is a custom client designed to enhance your Discord experience while keeping everything lightweight
+GenericName=Internet Messenger
+Type=Application
+Exec=/usr/bin/armcord
+Icon=armcord
+Categories=Network;InstantMessaging;
+StartupWMClass=armcord
+Keywords=discord;armcord;vencord;shelter;electron;

--- a/armcord-git/notes.install
+++ b/armcord-git/notes.install
@@ -1,0 +1,22 @@
+BOLD='\033[1m'
+RESET='\033[0m'
+
+post_install() {
+  echo
+  printf "${BOLD}ArmCord successfully installed!${RESET}\n"
+  echo
+  printf "By default, ArmCord will run with ${BOLD}/usr/bin/electron26${RESET}:\n"  # Changed electron to electron26
+  # --no-sandbox flag is needed as otherwise electron segfaults due to being ran as root
+  # why does this script run as root anyway????????
+  # doesn't that mean packages can just nuke your system here, making the entire "makepkg must not be run as root"
+  # stuff senseless?
+  electron26 --version --no-sandbox  # Changed electron to electron26
+  echo
+  echo "You may use a custom electron, for example a more recent version."
+  printf "To do so, simply change the ${BOLD}electron26${RESET} variable in ${BOLD}/usr/bin/armcord${RESET}\n"  # Changed electron to electron26
+  echo "using your favorite text editor!"
+  echo
+  printf "You can also pass custom flags to ArmCord by adding them to ${BOLD}${XDG_CONFIG_HOME:-~/.config}/armcord-flags.conf${RESET}\n"
+  echo "See https://www.electronjs.org/docs/latest/api/command-line-switches#electron-cli-flags"
+  echo
+}


### PR DESCRIPTION
Hello, I would like to add a modified PKGBUILD of armcord-git to our repository. Here's what I'm doing:

-  We already have `electron26-bin` in the repository, which we intend to leverage to address screen-sharing issues on Wayland.

-  The modified PKGBUILD will use `electron26-bin` by default, while still retaining the option for users to choose a different electron version if desired. (on `/usr/bin/armcord`)