### PR TITLE
test(sqlite3): adding sqlite-pgo draft for discussion

### DIFF
--- a/sqlite3/.SRCINFO
+++ b/sqlite3/.SRCINFO
@@ -93,7 +93,7 @@ build() {
   mv hits.csv ClickBench/sqlite/hits.csv
   cd ClickBench/sqlite
   LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb < create.sql
-  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb '.import --csv hits.csv hits'
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb '.import --csv hits.csv hits'
   wc -c mydb
 
   TRIES=3

--- a/sqlite3/.SRCINFO
+++ b/sqlite3/.SRCINFO
@@ -1,50 +1,160 @@
-pkgbase = sqlite
-	pkgdesc = A C library that implements an SQL database engine
-	pkgver = 3.44.2
-	pkgrel = 2
-	url = https://www.sqlite.org/
-	arch = x86_64
-	license = custom:Public Domain
-	makedepends = tcl
-	makedepends = readline
-	makedepends = zlib
-	options = !emptydirs
-	source = https://www.sqlite.org/2023/sqlite-src-3440200.zip
-	source = https://www.sqlite.org/2023/sqlite-doc-3440200.zip
-	source = sqlite-lemon-system-template.patch
-	source = license.txt
-	sha256sums = 73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27
-	sha256sums = 62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf
-	sha256sums = 55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97
-	sha256sums = 4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d
+# Maintainer: Andreas Radke <andyrtr@archlinux.org>
+# Contributor: Tom Newsom <Jeepster@gmx.co.uk>
 
-pkgname = sqlite
-	pkgdesc = A C library that implements an SQL database engine
-	depends = readline
-	depends = zlib
-	depends = glibc
-	provides = sqlite3=3.44.2
-	provides = libsqlite3.so
-	replaces = sqlite3
+pkgbase="sqlite"
+pkgname=('sqlite' 'sqlite-tcl' 'sqlite-analyzer' 'lemon' 'sqlite-doc')
+_srcver=3440200
+_docver=${_srcver}
+#_docver=3440000
+pkgver=3.44.2
+pkgrel=3
+pkgdesc="A C library that implements an SQL database engine"
+arch=('x86_64')
+license=('custom:Public Domain')
+url="https://www.sqlite.org/"
+makedepends=('tcl' 'readline' 'zlib')
+options=('!emptydirs')
+source=(https://www.sqlite.org/2023/sqlite-src-${_srcver}.zip
+        https://www.sqlite.org/2023/sqlite-doc-${_docver}.zip
+        sqlite-lemon-system-template.patch
+        license.txt
+        git+https://github.com/ClickHouse/ClickBench.git)
+# upstream now switched to sha3sums - currently not supported by makepkg
+sha256sums=('73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27'
+            '62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf'
+            '55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97'
+            '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d'
+            'SKIP')
 
-pkgname = sqlite-tcl
-	pkgdesc = sqlite Tcl Extension Architecture (TEA)
-	depends = sqlite
-	depends = glibc
-	provides = sqlite3-tcl=3.44.2
-	replaces = sqlite3-tcl
+prepare() {
+  cd sqlite-src-$_srcver
 
-pkgname = sqlite-analyzer
-	pkgdesc = An analysis program for sqlite3 database files
-	depends = sqlite
-	depends = tcl
-	depends = glibc
+  # patch taken from Fedora
+  # https://src.fedoraproject.org/rpms/sqlite/blob/master/f/sqlite.spec
+  patch -Np1 -i ../sqlite-lemon-system-template.patch
 
-pkgname = lemon
-	pkgdesc = A parser generator
-	depends = glibc
+  #autoreconf -vfi
+}
 
-pkgname = sqlite-doc
-	pkgdesc = most of the static HTML files that comprise this website, including all of the SQL Syntax and the C/C++ interface specs and other miscellaneous documentation
-	provides = sqlite3-doc=3.44.2
-	replaces = sqlite3-doc
+build() {
+  # this uses malloc_usable_size, which is incompatible with fortification level 3
+  export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+  export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+  
+
+  export CPPFLAGS="$CPPFLAGS \
+        -DSQLITE_ENABLE_COLUMN_METADATA=1 \
+        -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+        -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
+        -DSQLITE_ENABLE_FTS3_TOKENIZER=1 \
+        -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+        -DSQLITE_SECURE_DELETE \
+        -DSQLITE_ENABLE_STMTVTAB \
+        -DSQLITE_ENABLE_STAT4 \
+        -DSQLITE_MAX_VARIABLE_NUMBER=250000 \
+        -DSQLITE_MAX_EXPR_DEPTH=10000 \
+        -DSQLITE_ENABLE_MATH_FUNCTIONS"
+
+  # define PGO_PROFILE_DIR to use a custom directory for the profile data
+  export PGO_PROFILE_DIR=$PWD/pgo-data
+  mkdir -p ${PGO_PROFILE_DIR}
+
+  #echo "PGO_PROFILE_DIR: ${PGO_PROFILE_DIR}"
+
+  export CC=clang
+  #export CXX=clang++
+
+  export ORIG_CFLAGS="${CFLAGS}"
+  #export ORIG_CXXFLAGS="${CXXFLAGS}"
+
+  export CFLAGS+=" -g -fprofile-instr-generate"
+  #export CXXFLAGS+=" -g -fprofile-instr-generate"
+
+
+  # build sqlite
+  cd sqlite-src-$_srcver
+  ./configure --prefix=/usr \
+  --enable-shared \
+	--enable-fts3 \
+	--enable-fts4 \
+	--enable-fts5 \
+	--enable-rtree \
+	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+
+  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+  make
+  
+  export SQLITE_DIR=$PWD
+
+  # preparing PGO data
+  # using ClickHouse ClickBench scripts
+  cd ..
+  export ROOT_DIR=$PWD
+  mv hits.csv ClickBench/sqlite/hits.csv
+  cd ClickBench/sqlite
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb < create.sql
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb '.import --csv hits.csv hits'
+  wc -c mydb
+
+  TRIES=3
+
+  cat queries.sql | while read query; do
+      sync
+      echo 3 | sudo tee /proc/sys/vm/drop_caches
+
+      echo "$query";
+      for i in $(seq 1 $TRIES); do
+          LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb <<< "${query}"
+      done;
+  done;
+
+
+  cd $CURRENT_DIR
+
+  # merge the profile data
+  llvm-profdata merge -o merged.profdata ${PGO_PROFILE_DIR}/*.profraw
+
+  export CFLAGS="${ORIG_CFLAGS} -fprofile-instr-use=merged.profdata"
+  #export CXXFLAGS="${ORIG_CXXFLAGS} -fprofile-instr-use=/merged.profdata"
+
+  make clean
+  ./configure --prefix=/usr \
+  --enable-shared \
+  --enable-static \
+	--enable-fts3 \
+	--enable-fts4 \
+	--enable-fts5 \
+	--enable-rtree \
+	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+
+  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+  make
+
+  # build additional tools
+  make showdb showjournal showstat4 showwal sqldiff
+}
+
+package_sqlite() {
+  
+
+ pkgdesc="A C library that implements an SQL database engine"
+ depends=('readline' 'zlib' 'glibc')
+ provides=("sqlite3=$pkgver" 'libsqlite3.so')
+ replaces=("sqlite3")
+
+  cd sqlite-src-$_srcver
+  make DESTDIR="${pkgdir}" install
+
+  install -m755 showdb showjournal showstat4 showwal sqldiff "${pkgdir}"/usr/bin/
+
+  # install manpage
+  install -m755 -d "${pkgdir}"/usr/share/man/man1
+  install -m644 sqlite3.1 "${pkgdir}"/usr/share/man/man1/
+
+  # license - no linking required because pkgbase=pkgname
+  install -D -m644 "${srcdir}"/license.txt "${pkgdir}"/usr/share/licenses/${pkgbase}/license.txt
+
+  # split out tcl extension
+  mkdir "$srcdir"/tcl
+  mv "$pkgdir"/usr/lib/sqlite* "$srcdir"/tcl
+}

--- a/sqlite3/.SRCINFO
+++ b/sqlite3/.SRCINFO
@@ -1,0 +1,50 @@
+pkgbase = sqlite
+	pkgdesc = A C library that implements an SQL database engine
+	pkgver = 3.44.2
+	pkgrel = 2
+	url = https://www.sqlite.org/
+	arch = x86_64
+	license = custom:Public Domain
+	makedepends = tcl
+	makedepends = readline
+	makedepends = zlib
+	options = !emptydirs
+	source = https://www.sqlite.org/2023/sqlite-src-3440200.zip
+	source = https://www.sqlite.org/2023/sqlite-doc-3440200.zip
+	source = sqlite-lemon-system-template.patch
+	source = license.txt
+	sha256sums = 73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27
+	sha256sums = 62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf
+	sha256sums = 55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97
+	sha256sums = 4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d
+
+pkgname = sqlite
+	pkgdesc = A C library that implements an SQL database engine
+	depends = readline
+	depends = zlib
+	depends = glibc
+	provides = sqlite3=3.44.2
+	provides = libsqlite3.so
+	replaces = sqlite3
+
+pkgname = sqlite-tcl
+	pkgdesc = sqlite Tcl Extension Architecture (TEA)
+	depends = sqlite
+	depends = glibc
+	provides = sqlite3-tcl=3.44.2
+	replaces = sqlite3-tcl
+
+pkgname = sqlite-analyzer
+	pkgdesc = An analysis program for sqlite3 database files
+	depends = sqlite
+	depends = tcl
+	depends = glibc
+
+pkgname = lemon
+	pkgdesc = A parser generator
+	depends = glibc
+
+pkgname = sqlite-doc
+	pkgdesc = most of the static HTML files that comprise this website, including all of the SQL Syntax and the C/C++ interface specs and other miscellaneous documentation
+	provides = sqlite3-doc=3.44.2
+	replaces = sqlite3-doc

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -70,34 +70,19 @@ build() {
   export ORIG_CFLAGS="${CFLAGS}"
   export ORIG_CXXFLAGS="${CXXFLAGS}"
 
-<<<<<<< HEAD
   export CFLAGS+=" -fprofile-generate"
   export CXXFLAGS+=" -fprofile-generate"
-=======
-  export CFLAGS+=" -g -fprofile-generate"
-  #export CXXFLAGS+=" -g -fprofile-instr-generate"
->>>>>>> 9f1b1f49502cab8d656aae2fe8f38c477f1718d4
-
 
   # build sqlite
   cd sqlite-src-$_srcver
   cd sqlite-src-$_srcver
   ./configure --prefix=/usr \
-<<<<<<< HEAD
   --disable-static \
   --enable-fts3 \
   --enable-fts4 \
   --enable-fts5 \
   --enable-rtree \
   TCLLIBDIR=/usr/lib/sqlite$pkgver
-=======
-	--disable-static \
-	--enable-fts3 \
-	--enable-fts4 \
-	--enable-fts5 \
-	--enable-rtree \
-	TCLLIBDIR=/usr/lib/sqlite$pkgver \
->>>>>>> 9f1b1f49502cab8d656aae2fe8f38c477f1718d4
 
   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
   make

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -13,7 +13,7 @@ pkgdesc="A C library that implements an SQL database engine"
 arch=('x86_64')
 license=('custom:Public Domain')
 url="https://www.sqlite.org/"
-makedepends=('tcl' 'readline' 'zlib')
+makedepends=('tcl' 'readline' 'zlib' 'clang' 'llvm' 'llvm-libs' 'lld')
 options=('!emptydirs')
 source=(https://www.sqlite.org/2023/sqlite-src-${_srcver}.zip
         https://www.sqlite.org/2023/sqlite-doc-${_docver}.zip
@@ -26,7 +26,8 @@ sha256sums=('73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27'
             '62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf'
             '55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97'
             '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d'
-            'SKIP')
+            'SKIP'
+            '189c37a5f2020d20ef9ebc0b9d4cf2204fe78658bbab235f0313d41447410ddd')
 options=('!lto')
 
 prepare() {
@@ -43,7 +44,8 @@ build() {
   # this uses malloc_usable_size, which is incompatible with fortification level 3
   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
-  
+  export LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
+
   export CPPFLAGS="$CPPFLAGS \
         -DSQLITE_ENABLE_COLUMN_METADATA=1 \
         -DSQLITE_ENABLE_UNLOCK_NOTIFY \
@@ -105,8 +107,6 @@ build() {
 
   cat queries.sql | while read query; do
       sync
-      echo 3 | sudo tee /proc/sys/vm/drop_caches
-
       echo "$query";
       for i in $(seq 1 $TRIES); do
           LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb <<< "${query}"

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -68,7 +68,7 @@ build() {
   export ORIG_CFLAGS="${CFLAGS}"
   #export ORIG_CXXFLAGS="${CXXFLAGS}"
 
-  export CFLAGS+=" -g -fprofile-instr-generate"
+  export CFLAGS+=" -g -fprofile-generate"
   #export CXXFLAGS+=" -g -fprofile-instr-generate"
 
 
@@ -113,17 +113,17 @@ build() {
   # merge the profile data
   llvm-profdata merge -o merged.profdata ${PGO_PROFILE_DIR}/*.profraw
 
-  export CFLAGS="${ORIG_CFLAGS} -fprofile-instr-use=merged.profdata"
+  export CFLAGS="${ORIG_CFLAGS} -fprofile-use=merged.profdata"
   #export CXXFLAGS="${ORIG_CXXFLAGS} -fprofile-instr-use=/merged.profdata"
 
   make clean
   ./configure --prefix=/usr \
-	--disable-static \
-	--enable-fts3 \
-	--enable-fts4 \
-	--enable-fts5 \
-	--enable-rtree \
-	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+  	--disable-static \
+  	--enable-fts3 \
+  	--enable-fts4 \
+  	--enable-fts5 \
+  	--enable-rtree \
+  	TCLLIBDIR=/usr/lib/sqlite$pkgver \
 
   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
   make

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -75,7 +75,6 @@ build() {
 
   # build sqlite
   cd sqlite-src-$_srcver
-  cd sqlite-src-$_srcver
   ./configure --prefix=/usr \
   --disable-static \
   --enable-fts3 \

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Andreas Radke <andyrtr@archlinux.org>
 # Contributor: Tom Newsom <Jeepster@gmx.co.uk>
+# PGO Version: Laio Seman <laio@ieee.org>
 
 pkgbase="sqlite"
 pkgname=('sqlite' 'sqlite-tcl' 'sqlite-analyzer' 'lemon' 'sqlite-doc')

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -1,0 +1,140 @@
+# Maintainer: Andreas Radke <andyrtr@archlinux.org>
+# Contributor: Tom Newsom <Jeepster@gmx.co.uk>
+
+pkgbase="sqlite"
+pkgname=('sqlite')
+_srcver=3440200
+_docver=${_srcver}
+#_docver=3440000
+pkgver=3.44.2
+pkgrel=3
+pkgdesc="A C library that implements an SQL database engine"
+arch=('x86_64')
+license=('custom:Public Domain')
+url="https://www.sqlite.org/"
+makedepends=('tcl' 'readline' 'zlib')
+options=('!emptydirs')
+source=(https://www.sqlite.org/2023/sqlite-src-${_srcver}.zip
+        https://www.sqlite.org/2023/sqlite-doc-${_docver}.zip
+        sqlite-lemon-system-template.patch
+        license.txt)
+# upstream now switched to sha3sums - currently not supported by makepkg
+sha256sums=('73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27'
+            '62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf'
+            '55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97'
+            '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d')
+options=('!lto')
+
+prepare() {
+  cd sqlite-src-$_srcver
+
+  # patch taken from Fedora
+  # https://src.fedoraproject.org/rpms/sqlite/blob/master/f/sqlite.spec
+  patch -Np1 -i ../sqlite-lemon-system-template.patch
+
+  #autoreconf -vfi
+}
+
+build() {
+  # this uses malloc_usable_size, which is incompatible with fortification level 3
+  export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+  export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+  
+
+  export CPPFLAGS="$CPPFLAGS \
+        -DSQLITE_ENABLE_COLUMN_METADATA=1 \
+        -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+        -DSQLITE_ENABLE_DBSTAT_VTAB=1 \
+        -DSQLITE_ENABLE_FTS3_TOKENIZER=1 \
+        -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+        -DSQLITE_SECURE_DELETE \
+        -DSQLITE_ENABLE_STMTVTAB \
+        -DSQLITE_ENABLE_STAT4 \
+        -DSQLITE_MAX_VARIABLE_NUMBER=250000 \
+        -DSQLITE_MAX_EXPR_DEPTH=10000 \
+        -DSQLITE_ENABLE_MATH_FUNCTIONS"
+
+  # define PGO_PROFILE_DIR to use a custom directory for the profile data
+  export PGO_PROFILE_DIR=$PWD/pgo-data
+  mkdir -p ${PGO_PROFILE_DIR}
+
+  #echo "PGO_PROFILE_DIR: ${PGO_PROFILE_DIR}"
+
+  export CC=clang
+  #export CXX=clang++
+
+  export ORIG_CFLAGS="${CFLAGS}"
+  #export ORIG_CXXFLAGS="${CXXFLAGS}"
+
+  export CFLAGS+=" -g -fprofile-instr-generate"
+  #export CXXFLAGS+=" -g -fprofile-instr-generate"
+
+
+  # build sqlite
+  cd sqlite-src-$_srcver
+  ./configure --prefix=/usr \
+    --enable-shared \
+	--enable-fts3 \
+	--enable-fts4 \
+	--enable-fts5 \
+	--enable-rtree \
+	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+
+  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+
+  make
+  
+  export CURRENT_DIR=$PWD
+
+  cd /data/git/ClickBench/sqlite
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw ./run.sh
+
+  cd $CURRENT_DIR
+
+  # merge the profile data
+  llvm-profdata merge -o merged.profdata ${PGO_PROFILE_DIR}/*.profraw
+
+  export CFLAGS="${ORIG_CFLAGS} -fprofile-instr-use=merged.profdata"
+  #export CXXFLAGS="${ORIG_CXXFLAGS} -fprofile-instr-use=/merged.profdata"
+
+  make clean
+  ./configure --prefix=/usr \
+  --enable-shared \
+  --enable-static \
+	--enable-fts3 \
+	--enable-fts4 \
+	--enable-fts5 \
+	--enable-rtree \
+	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+
+  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+  make
+
+  # build additional tools
+  make showdb showjournal showstat4 showwal sqldiff
+}
+
+package_sqlite() {
+  
+
+ pkgdesc="A C library that implements an SQL database engine"
+ depends=('readline' 'zlib' 'glibc')
+ provides=("sqlite3=$pkgver" 'libsqlite3.so')
+ replaces=("sqlite3")
+
+  cd sqlite-src-$_srcver
+  make DESTDIR="${pkgdir}" install
+
+  install -m755 showdb showjournal showstat4 showwal sqldiff "${pkgdir}"/usr/bin/
+
+  # install manpage
+  install -m755 -d "${pkgdir}"/usr/share/man/man1
+  install -m644 sqlite3.1 "${pkgdir}"/usr/share/man/man1/
+
+  # license - no linking required because pkgbase=pkgname
+  install -D -m644 "${srcdir}"/license.txt "${pkgdir}"/usr/share/licenses/${pkgbase}/license.txt
+
+  # split out tcl extension
+  mkdir "$srcdir"/tcl
+  mv "$pkgdir"/usr/lib/sqlite* "$srcdir"/tcl
+}

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -27,6 +27,7 @@ sha256sums=('73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27'
             '55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97'
             '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d'
             'SKIP')
+options=('!lto')
 
 prepare() {
   cd sqlite-src-$_srcver
@@ -42,7 +43,7 @@ build() {
   # this uses malloc_usable_size, which is incompatible with fortification level 3
   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
-
+  
   export CPPFLAGS="$CPPFLAGS \
         -DSQLITE_ENABLE_COLUMN_METADATA=1 \
         -DSQLITE_ENABLE_UNLOCK_NOTIFY \
@@ -60,27 +61,43 @@ build() {
   export PGO_PROFILE_DIR=$PWD/pgo-data
   mkdir -p ${PGO_PROFILE_DIR}
 
-  #echo "PGO_PROFILE_DIR: ${PGO_PROFILE_DIR}"
-
+  export AR=llvm-ar
   export CC=clang
-  #export CXX=clang++
+  export CXX=clang++
+  export NM=llvm-nm
+  export RANLIB=llvm-ranlib
 
   export ORIG_CFLAGS="${CFLAGS}"
-  #export ORIG_CXXFLAGS="${CXXFLAGS}"
+  export ORIG_CXXFLAGS="${CXXFLAGS}"
 
+<<<<<<< HEAD
+  export CFLAGS+=" -fprofile-generate"
+  export CXXFLAGS+=" -fprofile-generate"
+=======
   export CFLAGS+=" -g -fprofile-generate"
   #export CXXFLAGS+=" -g -fprofile-instr-generate"
+>>>>>>> 9f1b1f49502cab8d656aae2fe8f38c477f1718d4
 
 
   # build sqlite
   cd sqlite-src-$_srcver
+  cd sqlite-src-$_srcver
   ./configure --prefix=/usr \
+<<<<<<< HEAD
+  --disable-static \
+  --enable-fts3 \
+  --enable-fts4 \
+  --enable-fts5 \
+  --enable-rtree \
+  TCLLIBDIR=/usr/lib/sqlite$pkgver
+=======
 	--disable-static \
 	--enable-fts3 \
 	--enable-fts4 \
 	--enable-fts5 \
 	--enable-rtree \
 	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+>>>>>>> 9f1b1f49502cab8d656aae2fe8f38c477f1718d4
 
   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
   make
@@ -93,8 +110,10 @@ build() {
   export ROOT_DIR=$PWD
   mv hits.csv ClickBench/sqlite/hits.csv
   cd ClickBench/sqlite
+  rm -rf mydb
   LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb < create.sql
-  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb '.import --csv hits.csv hits'
+  head -n 5000000 hits.csv > sample.csv
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb '.import --csv sample.csv hits'
   wc -c mydb
 
   TRIES=3
@@ -105,33 +124,37 @@ build() {
 
       echo "$query";
       for i in $(seq 1 $TRIES); do
-          LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb <<< "${query}"
+          LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb <<< "${query}"
       done;
   done;
 
-  cd $CURRENT_DIR
+
+  cd $SQLITE_DIR
+
   # merge the profile data
   llvm-profdata merge -o merged.profdata ${PGO_PROFILE_DIR}/*.profraw
 
-  export CFLAGS="${ORIG_CFLAGS} -fprofile-use=merged.profdata"
-  #export CXXFLAGS="${ORIG_CXXFLAGS} -fprofile-instr-use=/merged.profdata"
+  export CFLAGS="${ORIG_CFLAGS} -fprofile-use=merged.profdata -flto=thin"
+  export CXXFLAGS="${ORIG_CXXFLAGS} -fprofile-use=merged.profdata -flto=thin"
 
   make clean
   ./configure --prefix=/usr \
-  	--disable-static \
-  	--enable-fts3 \
-  	--enable-fts4 \
-  	--enable-fts5 \
-  	--enable-rtree \
-  	TCLLIBDIR=/usr/lib/sqlite$pkgver \
+	--disable-static \
+  --enable-fts3 \
+  --enable-fts4 \
+  --enable-fts5 \
+  --enable-rtree \
+  TCLLIBDIR=/usr/lib/sqlite$pkgver \
 
-  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+  sed -i -e 's/ -shared / -flto=thin -Wl,-O1,--as-needed\0/g' libtool
   make
+
   # build additional tools
-  make showdb showjournal showstat4 showwal sqldiff sqlite3_analyzer
+  make showdb showjournal showstat4 showwal sqldiff
 }
 
 package_sqlite() {
+  
 
  pkgdesc="A C library that implements an SQL database engine"
  depends=('readline' 'zlib' 'glibc')
@@ -151,27 +174,8 @@ package_sqlite() {
   install -D -m644 "${srcdir}"/license.txt "${pkgdir}"/usr/share/licenses/${pkgbase}/license.txt
 
   # split out tcl extension
-  mkdir "$srcdir"/tcl
+  mkdir -p "$srcdir"/tcl
   mv "$pkgdir"/usr/lib/sqlite* "$srcdir"/tcl
-}
-
-package_sqlite-tcl() {
-
- pkgdesc="sqlite Tcl Extension Architecture (TEA)"
- depends=('sqlite' 'glibc')
- provides=("sqlite3-tcl=$pkgver")
- replaces=("sqlite3-tcl")
-
-  install -m755 -d "${pkgdir}"/usr/lib
-  mv "$srcdir"/tcl/* "${pkgdir}"/usr/lib
-
-  # install manpage
-  install -m755 -d "${pkgdir}"/usr/share/man/mann
-  install -m644 "${srcdir}"/sqlite-src-$_srcver/autoconf/tea/doc/sqlite3.n "${pkgdir}"/usr/share/man/mann/
-
-  # link license
-  install -m755 -d "${pkgdir}"/usr/share/licenses
-  ln -sf /usr/share/licenses/${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"
 }
 
 package_sqlite-analyzer() {

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -135,7 +135,7 @@ build() {
   make
 
   # build additional tools
-  make showdb showjournal showstat4 showwal sqldiff
+  make showdb showjournal showstat4 showwal sqldiff sqlite3_analyzer
 }
 
 package_sqlite() {

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -163,6 +163,26 @@ package_sqlite() {
   mv "$pkgdir"/usr/lib/sqlite* "$srcdir"/tcl
 }
 
+package_sqlite-tcl() {
+
+ pkgdesc="sqlite Tcl Extension Architecture (TEA)"
+ depends=('sqlite' 'glibc')
+ provides=("sqlite3-tcl=$pkgver")
+ replaces=("sqlite3-tcl")
+
+  install -m755 -d "${pkgdir}"/usr/lib
+  mv "$srcdir"/tcl/* "${pkgdir}"/usr/lib
+
+  # install manpage
+  install -m755 -d "${pkgdir}"/usr/share/man/mann
+  install -m644 "${srcdir}"/sqlite-src-$_srcver/autoconf/tea/doc/sqlite3.n "${pkgdir}"/usr/share/man/mann/
+
+  # link license
+  install -m755 -d "${pkgdir}"/usr/share/licenses
+  ln -sf /usr/share/licenses/${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"
+}
+
+
 package_sqlite-analyzer() {
 
  pkgdesc="An analysis program for sqlite3 database files"

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Tom Newsom <Jeepster@gmx.co.uk>
 
 pkgbase="sqlite"
-pkgname=('sqlite')
+pkgname=('sqlite' 'sqlite-tcl' 'sqlite-analyzer' 'lemon' 'sqlite-doc')
 _srcver=3440200
 _docver=${_srcver}
 #_docver=3440000
@@ -17,13 +17,15 @@ options=('!emptydirs')
 source=(https://www.sqlite.org/2023/sqlite-src-${_srcver}.zip
         https://www.sqlite.org/2023/sqlite-doc-${_docver}.zip
         sqlite-lemon-system-template.patch
-        license.txt)
+        license.txt
+        git+https://github.com/ClickHouse/ClickBench.git
+        https://datasets.clickhouse.com/hits_compatible/hits.csv.gz)
 # upstream now switched to sha3sums - currently not supported by makepkg
 sha256sums=('73187473feb74509357e8fa6cb9fd67153b2d010d00aeb2fddb6ceeb18abaf27'
             '62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf'
             '55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97'
-            '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d')
-options=('!lto')
+            '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d'
+            'SKIP')
 
 prepare() {
   cd sqlite-src-$_srcver
@@ -39,7 +41,6 @@ build() {
   # this uses malloc_usable_size, which is incompatible with fortification level 3
   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
-  
 
   export CPPFLAGS="$CPPFLAGS \
         -DSQLITE_ENABLE_COLUMN_METADATA=1 \
@@ -73,7 +74,7 @@ build() {
   # build sqlite
   cd sqlite-src-$_srcver
   ./configure --prefix=/usr \
-    --enable-shared \
+  --enable-shared \
 	--enable-fts3 \
 	--enable-fts4 \
 	--enable-fts5 \
@@ -81,16 +82,33 @@ build() {
 	TCLLIBDIR=/usr/lib/sqlite$pkgver \
 
   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
-
   make
   
-  export CURRENT_DIR=$PWD
+  export SQLITE_DIR=$PWD
 
-  cd /data/git/ClickBench/sqlite
-  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw ./run.sh
+  # preparing PGO data
+  # using ClickHouse ClickBench scripts
+  cd ..
+  export ROOT_DIR=$PWD
+  mv hits.csv ClickBench/sqlite/hits.csv
+  cd ClickBench/sqlite
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb < create.sql
+  LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb '.import --csv hits.csv hits'
+  wc -c mydb
+
+  TRIES=3
+
+  cat queries.sql | while read query; do
+      sync
+      echo 3 | sudo tee /proc/sys/vm/drop_caches
+
+      echo "$query";
+      for i in $(seq 1 $TRIES); do
+          LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 sqlite3 mydb <<< "${query}"
+      done;
+  done;
 
   cd $CURRENT_DIR
-
   # merge the profile data
   llvm-profdata merge -o merged.profdata ${PGO_PROFILE_DIR}/*.profraw
 
@@ -109,13 +127,11 @@ build() {
 
   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
   make
-
   # build additional tools
-  make showdb showjournal showstat4 showwal sqldiff
+  make showdb showjournal showstat4 showwal sqldiff sqlite3_analyzer
 }
 
 package_sqlite() {
-  
 
  pkgdesc="A C library that implements an SQL database engine"
  depends=('readline' 'zlib' 'glibc')
@@ -137,4 +153,65 @@ package_sqlite() {
   # split out tcl extension
   mkdir "$srcdir"/tcl
   mv "$pkgdir"/usr/lib/sqlite* "$srcdir"/tcl
+}
+
+package_sqlite-tcl() {
+
+ pkgdesc="sqlite Tcl Extension Architecture (TEA)"
+ depends=('sqlite' 'glibc')
+ provides=("sqlite3-tcl=$pkgver")
+ replaces=("sqlite3-tcl")
+
+  install -m755 -d "${pkgdir}"/usr/lib
+  mv "$srcdir"/tcl/* "${pkgdir}"/usr/lib
+
+  # install manpage
+  install -m755 -d "${pkgdir}"/usr/share/man/mann
+  install -m644 "${srcdir}"/sqlite-src-$_srcver/autoconf/tea/doc/sqlite3.n "${pkgdir}"/usr/share/man/mann/
+
+  # link license
+  install -m755 -d "${pkgdir}"/usr/share/licenses
+  ln -sf /usr/share/licenses/${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"
+}
+
+package_sqlite-analyzer() {
+
+ pkgdesc="An analysis program for sqlite3 database files"
+ depends=('sqlite' 'tcl' 'glibc')
+
+  cd sqlite-src-$_srcver
+  install -m755 -d "${pkgdir}"/usr/bin
+  install -m755 sqlite3_analyzer "${pkgdir}"/usr/bin/
+}
+
+package_lemon() {
+
+ # https://www.sqlite.org/lemon.html
+ pkgdesc="A parser generator"
+ depends=('glibc')
+
+  cd sqlite-src-$_srcver
+  # ELF file ('usr/bin/lemon') lacks FULL RELRO, check LDFLAGS. - no fix found so far
+  install -Dm755 lemon ${pkgdir}/usr/bin/lemon
+  install -Dm644 lempar.c ${pkgdir}/usr/share/lemon/lempar.c
+  
+  mkdir -p "${pkgdir}"/usr/share/doc/${pkgname}
+  cp ../sqlite-doc-${_docver}/lemon.html  "${pkgdir}"/usr/share/doc/${pkgname}/
+  install -m755 -d "${pkgdir}"/usr/share/licenses
+  ln -sf /usr/share/licenses/${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"
+
+}
+
+package_sqlite-doc() {
+
+ pkgdesc="most of the static HTML files that comprise this website, including all of the SQL Syntax and the C/C++ interface specs and other miscellaneous documentation"
+ #arch=('any') - not yet supported
+ provides=("sqlite3-doc=$pkgver")
+ replaces=("sqlite3-doc")
+
+  cd sqlite-doc-${_docver}
+  mkdir -p "${pkgdir}"/usr/share/doc/${pkgbase}
+  cp -R *  "${pkgdir}"/usr/share/doc/${pkgbase}/
+  
+  rm "${pkgdir}"/usr/share/doc/${pkgbase}/lemon.html
 }

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -95,6 +95,7 @@ build() {
   mv hits.csv ClickBench/sqlite/hits.csv
   cd ClickBench/sqlite
   rm -rf mydb
+  sed -i '/REGEXP_REPLACE/d' queries.sql
   LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb < create.sql
   head -n 5000000 hits.csv > sample.csv
   LLVM_PROFILE_FILE=${PGO_PROFILE_DIR}/_%m_%p.profraw $SQLITE_DIR/sqlite3 mydb '.import --csv sample.csv hits'

--- a/sqlite3/PKGBUILD
+++ b/sqlite3/PKGBUILD
@@ -75,7 +75,7 @@ build() {
   # build sqlite
   cd sqlite-src-$_srcver
   ./configure --prefix=/usr \
-  --enable-shared \
+	--disable-static \
 	--enable-fts3 \
 	--enable-fts4 \
 	--enable-fts5 \
@@ -118,8 +118,7 @@ build() {
 
   make clean
   ./configure --prefix=/usr \
-  --enable-shared \
-  --enable-static \
+	--disable-static \
 	--enable-fts3 \
 	--enable-fts4 \
 	--enable-fts5 \

--- a/sqlite3/license.txt
+++ b/sqlite3/license.txt
@@ -1,0 +1,33 @@
+SQLite Copyright
+SQLite is in the
+Public Domain 
+
+
+All of the deliverable code in SQLite has been dedicated to the public domain by the authors. All code authors, and representatives of the companies they work for, have signed affidavits dedicating their contributions to the public domain and originals of those signed affidavits are stored in a firesafe at the main offices of Hwaci. Anyone is free to copy, modify, publish, use, compile, sell, or distribute the original SQLite code, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means. 
+
+The previous paragraph applies to the deliverable code in SQLite - those parts of the SQLite library that you actually bundle and ship with a larger application. Portions of the documentation and some code used as part of the build process might fall under other licenses. The details here are unclear. We do not worry about the licensing of the documentation and build code so much because none of these things are part of the core deliverable SQLite library. 
+
+All of the deliverable code in SQLite has been written from scratch. No code has been taken from other projects or from the open internet. Every line of code can be traced back to its original author, and all of those authors have public domain dedications on file. So the SQLite code base is clean and is uncontaminated with licensed code from other projects. 
+Obtaining An Explicit License To Use SQLite
+
+Even though SQLite is in the public domain and does not require a license, some users want to obtain a license anyway. Some reasons for obtaining a license include: 
+You are using SQLite in a jurisdiction that does not recognize the public domain. 
+You are using SQLite in a jurisdiction that does not recognize the right of an author to dedicate their work to the public domain. 
+You want to hold a tangible legal document as evidence that you have the legal right to use and distribute SQLite. 
+Your legal department tells you that you have to purchase a license. 
+
+If you feel like you really have to purchase a license for SQLite, Hwaci, the company that employs the architect and principal developers of SQLite, will sell you one. 
+Contributed Code
+
+In order to keep SQLite completely free and unencumbered by copyright, all new contributors to the SQLite code base are asked to dedicate their contributions to the public domain. If you want to send a patch or enhancement for possible inclusion in the SQLite source tree, please accompany the patch with the following statement: 
+The author or authors of this code dedicate any and all copyright interest in this code to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this code under copyright law. 
+
+We are not able to accept patches or changes to SQLite that are not accompanied by a statement such as the above. In addition, if you make changes or enhancements as an employee, then a simple statement such as the above is insufficient. You must also send by surface mail a copyright release signed by a company officer. A signed original of the copyright release should be mailed to:
+Hwaci
+6200 Maple Cove Lane
+Charlotte, NC 28269
+USA 
+
+A template copyright release is available in PDF or HTML. You can use this release to make future changes.
+
+see http://www.sqlite.org/copyright.html

--- a/sqlite3/sqlite-lemon-system-template.patch
+++ b/sqlite3/sqlite-lemon-system-template.patch
@@ -1,0 +1,13 @@
+diff --git a/tool/lemon.c b/tool/lemon.c
+index 54c8946..ac14a06 100644
+--- a/tool/lemon.c
++++ b/tool/lemon.c
+@@ -3668,6 +3668,8 @@ PRIVATE FILE *tplt_open(struct lemon *lemp)
+     tpltname = buf;
+   }else if( access(templatename,004)==0 ){
+     tpltname = templatename;
++  }else if( access("/usr/share/lemon/lempar.c", R_OK)==0){
++    tpltname = "/usr/share/lemon/lempar.c";
+   }else{
+     toFree = tpltname = pathsearch(lemp->argv0,templatename,0);
+   }


### PR DESCRIPTION
Starting a discussion on how could we provide sqlite3-pgo PKGBUILD.

A good benchmark for databases that can be used for PGOing is:
[ClickBench](https://github.com/ClickHouse/ClickBench)

see: https://github.com/zamazan4ik/awesome-pgo/blob/main/sqlite.md

The database for sqlite3 is 15GB, the default test randomly sample 2.2GB.
We could provide those 2.2GB, which compressed are as follows:

```
.rw-r--r--  291M seman 23 Dec 23:39   mydb.tar.xz
.rw-r--r--  334M seman 23 Dec 20:55   mydb.zst
```

But, what about the license of the database? Can we host it?

Any ideas?

@ptr1337 @vnepogodin 