### PR TITLE
draft(rust): starting rust-pgo draft

### DIFF
--- a/rust/PKGBUILD
+++ b/rust/PKGBUILD
@@ -1,0 +1,151 @@
+# Maintainer: Johannes Löthberg <johannes@kyriasis.com>
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Alexander F Rødseth <xyproto@archlinux.org>
+# Contributor: Daniel Micay <danielmicay@gmail.com>
+# Contributor: userwithuid <userwithuid@gmail.com>
+# PGO Version: Laio O. Seman <laio@ieee.org>
+
+pkgbase=rust
+pkgname=(
+  rust
+)
+epoch=1
+pkgver=1.75.0
+pkgrel=1
+pkgdesc="Systems programming language focused on safety, speed and concurrency"
+url=https://www.rust-lang.org/
+arch=(x86_64)
+license=(
+  Apache
+  MIT
+)
+depends=(
+  curl
+  gcc
+  gcc-libs
+  libssh2
+  llvm-libs
+)
+makedepends=(
+  cmake
+  lib32-gcc-libs
+  libffi
+  lld
+  llvm
+  musl
+  ninja
+  perl
+  python
+  rust
+  wasi-libc
+)
+checkdepends=(
+  gdb
+  procps-ng
+)
+source=(git+https://github.com/rust-lang/rust.git#tag=$pkgver)
+validpgpkeys=(
+  108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
+)
+
+prepare() {
+  cd rust
+
+  cat >config.toml <<END
+profile = 'dist'
+changelog-seen = 2
+
+[llvm]
+thin-lto = true
+ccache = 'ccache'
+static-libstdcpp = true
+ninja = true
+
+[build]
+compiler-docs = false
+submodules = true
+locked-deps = true
+extended = true
+# Build the sanitizer runtimes
+sanitizers = false
+profiler = true
+cargo-native-static = true
+configure-args = ['--enable-full-tools', '--enable-profiler', '--set', 'target.x86_64-unknown-linux-gnu.linker=clang', '--set', 'target.x86_64-unknown-linux-gnu.ar=/home/seman/install/bin/llvm-ar', '--set', 'target.x86_64-unknown-linux-gnu.ranlib=/home/seman/install/llvm-ranlib', '--set', 'llvm.thin-lto=true', '--set', 'llvm.ninja=true', '--set', 'rust.jemalloc', '--set', 'rust.use-lld=true', '--set', 'rust.lto=thin', '--set', 'rust.codegen-units=1', '--set', 'build.print-step-timings', '--enable-verbose-tests', '--set', 'build.metrics', '--enable-verbose-configure', '--enable-ccache', '--disable-manage-submodules', '--enable-locked-deps', '--enable-cargo-native-static', '--set', 'rust.codegen-units-std=1', '--set', 'dist.compression-profile=balanced', '--dist-compression-formats=xz', '--release-channel=nightly', '--enable-llvm-static-stdcpp', '--debuginfo-level-std=0', '--set', 'rust.codegen-backends=llvm']
+
+print-step-timings = true
+metrics = true
+
+[install]
+prefix = "/usr"
+
+[rust]
+codegen-units = 1
+codegen-units-std = 1
+debuginfo-level-std = 0
+channel = 'nightly'
+verbose-tests = true
+codegen-backends = ['llvm']
+lld = true
+use-lld = true
+llvm-tools = true
+remap-debuginfo = false
+jemalloc = true
+lto = 'thin'
+
+[target.x86_64-unknown-linux-gnu]
+ar = '/home/seman/install/bin/llvm-ar'
+ranlib = '/home/seman/install/bin/llvm-ranlib'
+linker = 'clang'
+
+[dist]
+compression-formats = ['xz']
+compression-profile = 'balanced'
+
+END
+}
+
+
+build() {
+    cd rust
+    mkdir -p pgo
+    export CC=clang
+    export CXX=clang++
+    export HOSTS=x86_64-unknown-linux-gnu
+    export PATH=/home/seman/install/bin/:$PATH
+    export CMAKE_BUILD_TYPE=Release
+    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
+
+    python3 ./x.py build --set rust.debug=true opt-dist 
+
+    ./build/$HOSTS/stage0-tools-bin/opt-dist local \
+      --target-triple=$HOSTS --checkout-dir=$PWD --artifact-dir=$PWD/pgo \
+      --skipped-tests=tests/assembly \
+      --skipped-tests=tests/codegen \
+      --skipped-tests=tests/codegen-units \
+      --skipped-tests=tests/incremental \
+      --skipped-tests=tests/mir-opt \
+      --skipped-tests=tests/pretty \
+      --skipped-tests=tests/run-pass-valgrind \
+      --skipped-tests=tests/ui \
+      --llvm-dir=/home/seman/install/ -- python3 \
+      ./x.py dist --host $HOSTS --target $HOSTS \
+      --include-default-paths \
+      build-manifest bootstrap
+}
+
+package_rust() {
+  optdepends=(
+    'gdb: rust-gdb script'
+    'lldb: rust-lldb script'
+  )
+  echo $PWD
+  cd rust/build/dist
+  tar -xf rust-nightly-x86_64-unknown-linux-gnu.tar.xz
+  echo $PWD
+  cd rust-nightly-x86_64-unknown-linux-gnu
+  ./install.sh --prefix=/opt/rust --destdir=$pkgdir
+  #cp -a dest-rust/* "$pkgdir"
+}
+
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Starting rust-opt draft, for now the LLVM is hardcoded to my docker dir.

Working with LLVM17, mostly what Kobzol was using. We need to test if LLVM16 is sufficient for building.