### PR TITLE
openjdk: Build OpenJDK with Clang

### DIFF
--- a/openjdk/java-openjdk/.SRCINFO
+++ b/openjdk/java-openjdk/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = java-openjdk
 	pkgver = 21.u35
-	pkgrel = 9
+	pkgrel = 10
 	url = https://openjdk.java.net/
 	arch = x86_64
 	license = custom
@@ -29,15 +29,20 @@ pkgbase = java-openjdk
 	makedepends = harfbuzz
 	makedepends = gcc-libs
 	makedepends = glibc
+	makedepends = llvm
+	makedepends = clang
+	makedepends = lld
 	options = !lto
 	source = https://github.com/openjdk/jdk21u/archive/jdk-21+35.tar.gz
 	source = freedesktop-java.desktop
 	source = freedesktop-jconsole.desktop
 	source = freedesktop-jshell.desktop
+	source = clang-lto.patch
 	sha256sums = b798ebc2e899a98edf2be99e786bb0fbad144e2270925dffe624fbe052f07ade
 	sha256sums = 72111743ab6ab36854b0c85a504172983715d0798fce10bc4e35689b7d15fd93
 	sha256sums = 8ecdf5c1605bafa58b3f7da615e6d8d3d943e3a2d3831930d6efa7815aacce07
 	sha256sums = 50fc0d677489b73d549df2f08d759d5f057f200adbbab83ea5e87456152ee03e
+	sha256sums = e9f4353eb6aed22d834793ea28637f1bee368f77e02bab9bbe5cc7e47078ef2b
 
 pkgname = jre-openjdk-headless
 	pkgdesc = OpenJDK Java 21 headless runtime environment
@@ -59,7 +64,7 @@ pkgname = jre-openjdk-headless
 	optdepends = java-rhino: for some JavaScript support
 	provides = java-runtime-headless=21
 	provides = java-runtime-headless-openjdk=21
-	provides = jre21-openjdk-headless=21.u35-9
+	provides = jre21-openjdk-headless=21.u35-10
 	conflicts = jdk-openjdk
 	conflicts = jre-openjdk
 	backup = etc/java-openjdk/logging.properties
@@ -102,10 +107,10 @@ pkgname = jre-openjdk
 	optdepends = gtk3: for the Gtk+ 3 look and feel - desktop usage
 	provides = java-runtime=21
 	provides = java-runtime-openjdk=21
-	provides = jre21-openjdk=21.u35-9
+	provides = jre21-openjdk=21.u35-10
 	provides = java-runtime-headless=21
 	provides = java-runtime-headless-openjdk=21
-	provides = jre21-openjdk-headless=21.u35-9
+	provides = jre21-openjdk-headless=21.u35-10
 	conflicts = jdk-openjdk
 	conflicts = jre-openjdk-headless
 	backup = etc/java-openjdk/logging.properties
@@ -162,13 +167,13 @@ pkgname = jdk-openjdk
 	optdepends = gtk3: for the Gtk+ 3 look and feel - desktop usage
 	provides = java-environment=21
 	provides = java-environment-openjdk=21
-	provides = jdk21-openjdk=21.u35-9
+	provides = jdk21-openjdk=21.u35-10
 	provides = java-runtime=21
 	provides = java-runtime-openjdk=21
-	provides = jre21-openjdk=21.u35-9
+	provides = jre21-openjdk=21.u35-10
 	provides = java-runtime-headless=21
 	provides = java-runtime-headless-openjdk=21
-	provides = jre21-openjdk-headless=21.u35-9
+	provides = jre21-openjdk-headless=21.u35-10
 	conflicts = jre-openjdk
 	conflicts = jre-openjdk-headless
 	backup = etc/java-openjdk/logging.properties
@@ -188,10 +193,10 @@ pkgname = jdk-openjdk
 
 pkgname = openjdk-src
 	pkgdesc = OpenJDK Java 21 sources
-	depends = jdk21-openjdk=21.u35-9
-	provides = openjdk21-src=21.u35-9
+	depends = jdk21-openjdk=21.u35-10
+	provides = openjdk21-src=21.u35-10
 
 pkgname = openjdk-doc
 	pkgdesc = OpenJDK Java 21 documentation
-	depends = jdk21-openjdk=21.u35-9
-	provides = openjdk21-doc=21.u35-9
+	depends = jdk21-openjdk=21.u35-10
+	provides = openjdk21-doc=21.u35-10

--- a/openjdk/java-openjdk/PKGBUILD
+++ b/openjdk/java-openjdk/PKGBUILD
@@ -13,7 +13,7 @@ _securityver=0
 _updatever=35
 # pkgver=${_majorver}.${_minorver}.${_securityver}.u${_updatever}
 pkgver=${_majorver}.u${_updatever}
-pkgrel=9
+pkgrel=10
 # _git_tag=jdk-${_majorver}.${_minorver}.${_securityver}+${_updatever}
 _git_tag=jdk-${_majorver}+${_updatever}
 arch=('x86_64')
@@ -22,7 +22,7 @@ license=('custom')
 makedepends=('java-environment>=17' 'cpio' 'unzip' 'zip' 'libelf' 'libcups' 'libx11'
              'libxrender' 'libxtst' 'libxt' 'libxext' 'libxrandr' 'alsa-lib' 'pandoc'
              'graphviz' 'freetype2' 'libjpeg-turbo' 'giflib' 'libpng' 'lcms2'
-             'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc')
+             'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc' 'llvm' 'clang' 'lld')
 # To use LTO we should pass --with-jvm-features=link-time-opt flag instead of
 # options=(lto) to avoid some build errors.
 # See: https://bugs.gentoo.org/833097
@@ -31,11 +31,13 @@ options=(!lto)
 source=(https://github.com/openjdk/jdk${_majorver}u/archive/${_git_tag}.tar.gz
         freedesktop-java.desktop
         freedesktop-jconsole.desktop
-        freedesktop-jshell.desktop)
+        freedesktop-jshell.desktop
+        clang-lto.patch)
 sha256sums=('b798ebc2e899a98edf2be99e786bb0fbad144e2270925dffe624fbe052f07ade'
             '72111743ab6ab36854b0c85a504172983715d0798fce10bc4e35689b7d15fd93'
             '8ecdf5c1605bafa58b3f7da615e6d8d3d943e3a2d3831930d6efa7815aacce07'
-            '50fc0d677489b73d549df2f08d759d5f057f200adbbab83ea5e87456152ee03e')
+            '50fc0d677489b73d549df2f08d759d5f057f200adbbab83ea5e87456152ee03e'
+            'e9f4353eb6aed22d834793ea28637f1bee368f77e02bab9bbe5cc7e47078ef2b')
 
 _jvmdir=/usr/lib/jvm/java-${_majorver}-openjdk
 _jdkdir=jdk${_majorver}u-${_git_tag//+/-}
@@ -49,6 +51,11 @@ _nonheadless=(lib/libawt_xawt.so
 _commondeps=('java-runtime-common>=3' 'ca-certificates-utils' 'nss' 'libjpeg-turbo' 'libjpeg.so'
            'lcms2' 'liblcms2.so' 'libnet' 'freetype2' 'libfreetype.so' 'harfbuzz' 'libharfbuzz.so'
            'glibc' 'gcc-libs')
+
+prepare() {
+  cd "${_jdkdir}"
+  patch -Np1 -i "${srcdir}/clang-lto.patch"
+}
 
 build() {
   cd "${_jdkdir}"
@@ -100,6 +107,7 @@ build() {
     --with-zlib=system \
     --with-harfbuzz=system \
     --with-jvm-features=zgc,shenandoahgc,link-time-opt \
+    --with-toolchain-type=clang \
     --with-native-debug-symbols=internal \
     --enable-unlimited-crypto \
     --disable-warnings-as-errors \

--- a/openjdk/java-openjdk/clang-lto.patch
+++ b/openjdk/java-openjdk/clang-lto.patch
@@ -1,0 +1,26 @@
+From 25973e884728233a86eade92a74ac4c347d8b48f Mon Sep 17 00:00:00 2001
+From: Vasiliy Stelmachenok <ventureo@yandex.ru>
+Date: Fri, 5 Jan 2024 18:44:25 +0300
+Subject: [PATCH] Make it possible to build with LTO via Clang
+
+---
+ make/hotspot/lib/JvmFeatures.gmk | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/make/hotspot/lib/JvmFeatures.gmk b/make/hotspot/lib/JvmFeatures.gmk
+index 8eb57d765..f5eeddf48 100644
+--- a/make/hotspot/lib/JvmFeatures.gmk
++++ b/make/hotspot/lib/JvmFeatures.gmk
+@@ -175,6 +175,9 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
+   else ifeq ($(call isCompiler, microsoft), true)
+     JVM_CFLAGS_FEATURES += -GL
+     JVM_LDFLAGS_FEATURES += -LTCG:INCREMENTAL
++  else ifeq ($(call isCompiler, clang), true)
++    JVM_CFLAGS_FEATURES += -flto=auto
++    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto
+   endif
+ else
+   ifeq ($(call isCompiler, gcc), true)
+-- 
+2.43.0
+

--- a/openjdk/java17-openjdk/.SRCINFO
+++ b/openjdk/java17-openjdk/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = java17-openjdk
 	pkgver = 17.0.9.u8
-	pkgrel = 3
+	pkgrel = 4
 	url = https://openjdk.java.net/
 	arch = x86_64
 	license = custom
@@ -29,6 +29,9 @@ pkgbase = java17-openjdk
 	makedepends = harfbuzz
 	makedepends = gcc-libs
 	makedepends = glibc
+	makedepends = llvm
+	makedepends = clang
+	makedepends = lld
 	options = !lto
 	source = https://github.com/openjdk/jdk17u/archive/jdk-17.0.9+8.tar.gz
 	source = freedesktop-java.desktop
@@ -59,7 +62,7 @@ pkgname = jre17-openjdk-headless
 	optdepends = java-rhino: for some JavaScript support
 	provides = java-runtime-headless=17
 	provides = java-runtime-headless-openjdk=17
-	provides = jre17-openjdk-headless=17.0.9.u8-3
+	provides = jre17-openjdk-headless=17.0.9.u8-4
 	backup = etc/java17-openjdk/logging.properties
 	backup = etc/java17-openjdk/management/jmxremote.access
 	backup = etc/java17-openjdk/management/jmxremote.password.template
@@ -78,7 +81,7 @@ pkgname = jre17-openjdk-headless
 pkgname = jre17-openjdk
 	pkgdesc = OpenJDK Java 17 full runtime environment
 	install = install_jre-openjdk.sh
-	depends = jre17-openjdk-headless=17.0.9.u8-3
+	depends = jre17-openjdk-headless=17.0.9.u8-4
 	depends = giflib
 	depends = libgif.so
 	depends = glibc
@@ -89,12 +92,12 @@ pkgname = jre17-openjdk
 	optdepends = gtk3: for the Gtk+ 3 look and feel - desktop usage
 	provides = java-runtime=17
 	provides = java-runtime-openjdk=17
-	provides = jre17-openjdk=17.0.9.u8-3
+	provides = jre17-openjdk=17.0.9.u8-4
 
 pkgname = jdk17-openjdk
 	pkgdesc = OpenJDK Java 17 development kit
 	install = install_jdk-openjdk.sh
-	depends = jre17-openjdk=17.0.9.u8-3
+	depends = jre17-openjdk=17.0.9.u8-4
 	depends = java-environment-common=3
 	depends = hicolor-icon-theme
 	depends = libelf
@@ -102,14 +105,14 @@ pkgname = jdk17-openjdk
 	depends = gcc-libs
 	provides = java-environment=17
 	provides = java-environment-openjdk=17
-	provides = jdk17-openjdk=17.0.9.u8-3
+	provides = jdk17-openjdk=17.0.9.u8-4
 
 pkgname = openjdk17-src
 	pkgdesc = OpenJDK Java 17 sources
-	depends = jdk17-openjdk=17.0.9.u8-3
-	provides = openjdk17-src=17.0.9.u8-3
+	depends = jdk17-openjdk=17.0.9.u8-4
+	provides = openjdk17-src=17.0.9.u8-4
 
 pkgname = openjdk17-doc
 	pkgdesc = OpenJDK Java 17 documentation
-	depends = jdk17-openjdk=17.0.9.u8-3
-	provides = openjdk17-doc=17.0.9.u8-3
+	depends = jdk17-openjdk=17.0.9.u8-4
+	provides = openjdk17-doc=17.0.9.u8-4

--- a/openjdk/java17-openjdk/PKGBUILD
+++ b/openjdk/java17-openjdk/PKGBUILD
@@ -12,7 +12,7 @@ _securityver=9
 _updatever=8
 pkgver=${_majorver}.${_minorver}.${_securityver}.u${_updatever}
 #pkgver=${_majorver}.u${_updatever}
-pkgrel=3
+pkgrel=4
 _git_tag=jdk-${_majorver}.${_minorver}.${_securityver}+${_updatever}
 #_git_tag=jdk-${_majorver}+${_updatever}
 arch=('x86_64')
@@ -21,7 +21,7 @@ license=('custom')
 makedepends=('java-environment=17' 'cpio' 'unzip' 'zip' 'libelf' 'libcups' 'libx11'
              'libxrender' 'libxtst' 'libxt' 'libxext' 'libxrandr' 'alsa-lib' 'pandoc'
              'graphviz' 'freetype2' 'libjpeg-turbo' 'giflib' 'libpng' 'lcms2'
-             'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc')
+             'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc' 'llvm' 'clang' 'lld')
 # To use LTO we should pass --with-jvm-features=link-time-opt flag instead of
 # options=(lto) to avoid some build errors.
 # See: https://bugs.gentoo.org/833097
@@ -95,6 +95,7 @@ build() {
     --with-zlib=system \
     --with-harfbuzz=system \
     --with-jvm-features=zgc,link-time-opt \
+    --with-toolchain-type=clang \
     --with-native-debug-symbols=internal \
     --enable-unlimited-crypto \
     --disable-warnings-as-errors \


### PR DESCRIPTION
Builds fine on my rig. Note that JDK 21 requires a special patch to bypass LTO restrictions. This is not required for JDK 17.