### PR TITLE
change(python): flags for perf

### DIFF
--- a/python-312/PKGBUILD
+++ b/python-312/PKGBUILD
@@ -47,7 +47,7 @@ build() {
     # Print the set value for confirmation
     echo "ax_cv_c_float_words_bigendian set to $ax_cv_c_float_words_bigendian"
 
-    CFLAGS="${CFLAGS} -fno-semantic-interposition"
+    CFLAGS="${CFLAGS} -fno-semantic-interposition -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
     ./configure --prefix=/usr \
         --enable-shared \
         --with-computed-gotos \


### PR DESCRIPTION
New Python 3.12 has improved supported for perf, for that to works as expected we need to add -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer.