### PR TITLE
Disabling native AVX512 SIMD code in svt-av1 until it gets fixed in mainline

### DIFF
--- a/svt-av1-psy/.SRCINFO
+++ b/svt-av1-psy/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = svt-av1-psy
 	pkgdesc = Scalable Video Technology AV1 encoder and decoder, with added perceptual enhancements for psychovisually optimal AV1 encoding
 	pkgver = v2.0.0.rc2.r0.g5cac47c1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/gianni-rosato/svt-av1-psy
 	arch = x86_64
 	license = BSD

--- a/svt-av1-psy/PKGBUILD
+++ b/svt-av1-psy/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=svt-av1-psy
 pkgver=v2.0.0.rc2.r0.g5cac47c1
-pkgrel=1
+pkgrel=2
 pkgdesc='Scalable Video Technology AV1 encoder and decoder, with added perceptual enhancements for psychovisually optimal AV1 encoding'
 arch=(x86_64)
 url=https://github.com/gianni-rosato/svt-av1-psy
@@ -40,7 +40,8 @@ build() {
   cmake -S svt-av1-psy -B build -G Ninja \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=ON \
-    -DENABLE_AVX512=ON
+    -DENABLE_AVX512=OFF \
+    -DNATIVE=OFF
   ninja -C build
 }
 

--- a/svt-av1/.SRCINFO
+++ b/svt-av1/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = svt-av1
 	pkgdesc = Scalable Video Technology AV1 encoder and decoder
 	pkgver = 1.8.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://gitlab.com/AOMediaCodec/SVT-AV1
 	arch = x86_64
 	license = BSD

--- a/svt-av1/PKGBUILD
+++ b/svt-av1/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=svt-av1
 pkgver=1.8.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Scalable Video Technology AV1 encoder and decoder'
 arch=(x86_64)
 url=https://gitlab.com/AOMediaCodec/SVT-AV1
@@ -37,7 +37,7 @@ build() {
   cmake -S SVT-AV1 -B build -G Ninja \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DBUILD_SHARED_LIBS=ON \
-    -DENABLE_AVX512=ON \
+    -DENABLE_AVX512=OFF \
     -DNATIVE=OFF
   ninja -C build
 }


### PR DESCRIPTION
Simple fix for those Zen 4 until I investigate why exactly this happens (I can't reproduce it on Skylake X or Icelake), and then open a PR in the SVT-AV1 repository.