### PR TITLE
Allow manual entries for systemd boot to be created without being deleted.

### DIFF
--- a/systemd-boot-manager/sdboot-kernel-remove.hook
+++ b/systemd-boot-manager/sdboot-kernel-remove.hook
@@ -1,9 +1,10 @@
 [Trigger]
 Type = Path
 Operation = Remove
-Target = boot/linux*.kver
+Target = usr/lib/modules/*/vmlinuz
+Target = boot/vmlinuz*
 
 [Action]
-Description = Updating systemd-boot entries
+Description = Cleaning up systemd-boot entries
 When = PostTransaction
 Exec = /usr/bin/sdboot-manage remove

--- a/systemd-boot-manager/sdboot-manage.conf
+++ b/systemd-boot-manager/sdboot-manage.conf
@@ -22,14 +22,14 @@ LINUX_OPTIONS="zswap.enabled=0 nowatchdog splash"
 #KERNEL_PATTERN="vmlinuz-"
 
 # setting REMOVE_EXISTING to "yes" will remove all your existing systemd-boot entries before building new entries
-#REMOVE_EXISTING="yes"
+REMOVE_EXISTING="no"
 
 # unless OVERWRITE_EXISTING is set to "yes" existing entries for currently installed kernels will not be touched
 # this setting has no meaning if REMOVE_EXISTING is set to "yes"
-#OVERWRITE_EXISTING="no"
+OVERWRITE_EXISTING="yes"
 
 # when REMOVE_OBSOLETE is set to "yes" entries for kernels no longer available on the system will be removed
-#REMOVE_OBSOLETE="yes"
+REMOVE_OBSOLETE="yes"
 
 # if PRESERVE_FOREIGN is set to "yes", do not delete entries starting with $ENTRY_ROOT
 #PRESERVE_FOREIGN="no"


### PR DESCRIPTION
Also fixed the remove hook because it was coded to check for a file made by a mhwd-kernel (a manjaro app)