### PR TITLE
Remove SoulHarsh us mirror

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -15,8 +15,6 @@ Server = https://cdn.cachyos.org/repo/$arch/$repo
 Server = https://au.soulharsh007.dev/repo/$arch/$repo
 ## India CDN Mirror much thanks to soulharsh007!
 Server = https://in.soulharsh007.dev/repo/$arch/$repo
-## USA CDN Mirror much thanks to soulharsh007!
-Server = https://us.soulharsh007.dev/repo/$arch/$repo
 ## Germany
 Server = https://aur.cachyos.org/repo/$arch/$repo
 Server = https://mirror.cachyos.org/repo/$arch/$repo


### PR DESCRIPTION
No longer operational as per SoulHarsh

![image](https://github.com/CachyOS/CachyOS-PKGBUILDS/assets/841141/d64960ff-384e-49d2-952c-b989512350f5)