### PR TITLE
Reduce PyTorch legacy support

### DIFF
--- a/python-pytorch/PKGBUILD
+++ b/python-pytorch/PKGBUILD
@@ -285,7 +285,7 @@ _prepare() {
   export CUDNN_INCLUDE_DIR=/usr/include
   export TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
   # CUDA arch 8.7 is not supported (needed by Jetson boards, etc.)
-  export TORCH_CUDA_ARCH_LIST="5.2;5.3;6.0;6.1;6.2;7.0;7.2;7.5;8.0;8.6;8.9;9.0;9.0+PTX"  #include latest PTX for future compat
+  export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;8.9;9.0;9.0+PTX"  #include latest PTX for future compat
   export OVERRIDE_TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
   export ROCM_PATH=/opt/rocm
   export HIP_ROOT_DIR=/opt/rocm


### PR DESCRIPTION
To reduce PyTorch storage we could start only on Turing, or even latter.

Fermi†,	Kepler†	Maxwell‡	Pascal	Volta	Turing	Ampere	Ada	Hopper	Blackwell sm_20	sm_30	sm_50	sm_60	sm_70	sm_75	sm_80	sm_89	sm_90	??? sm_35	sm_52	sm_61	sm_72
(Xavier)		sm_86		sm_90a (Thor)	
sm_37	sm_53	sm_62			sm_87 (Orin)