### PR TITLE
Update svt-av1-psy to 2.1.0 release

### DIFF
--- a/svt-av1-psy/.SRCINFO
+++ b/svt-av1-psy/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = svt-av1-psy
 	pkgdesc = Scalable Video Technology AV1 encoder and decoder, with added perceptual enhancements for psychovisually optimal AV1 encoding
-	pkgver = v2.0.0.r0.gfe919d9f
-	pkgrel = 2
+	pkgver = v2.1.0.r0.g5471bd78
+	pkgrel = 3
 	url = https://github.com/gianni-rosato/svt-av1-psy
 	arch = x86_64
 	license = BSD
@@ -13,7 +13,7 @@ pkgbase = svt-av1-psy
 	depends = glibc
 	provides = svt-av1
 	conflicts = svt-av1
-	source = git+https://github.com/gianni-rosato/svt-av1-psy.git#tag=fe919d9fb35247fd47a50539da61a0d2f231212a
+	source = git+https://github.com/gianni-rosato/svt-av1-psy.git#tag=5471bd78311d70ab4691af1ae54fd80e25f214f5
 	b2sums = SKIP
 
 pkgname = svt-av1-psy

--- a/svt-av1-psy/PKGBUILD
+++ b/svt-av1-psy/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Zak BlueSwordM <neutronpcxt@gmail.com>
 
 pkgname=svt-av1-psy
-pkgver=v2.0.0.r0.gfe919d9f
-pkgrel=2
+pkgver=v2.1.0.r0.g5471bd78
+pkgrel=3
 pkgdesc='Scalable Video Technology AV1 encoder and decoder, with added perceptual enhancements for psychovisually optimal AV1 encoding'
 arch=(x86_64)
 url=https://github.com/gianni-rosato/svt-av1-psy
@@ -22,7 +22,7 @@ makedepends=(
 )
 provides=('svt-av1')
 conflicts=('svt-av1')
-_tag=fe919d9fb35247fd47a50539da61a0d2f231212a
+_tag=5471bd78311d70ab4691af1ae54fd80e25f214f5
 source=(git+https://github.com/gianni-rosato/svt-av1-psy.git#tag=${_tag})
 b2sums=('SKIP')
 


### PR DESCRIPTION
Simple enough PR. I closed the previous one by mistake :P

It just updates it to the latest version with a few changes on how we name revisions to make it slightly easier for future maintenance.
