### PR TITLE
nvidia-utils: Enable services for sleep and add config

### DIFF
--- a/nvidia/nvidia-utils/.SRCINFO
+++ b/nvidia/nvidia-utils/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nvidia-utils
 	pkgver = 555.42.02
-	pkgrel = 5
+	pkgrel = 6
 	url = http://www.nvidia.com/
 	arch = x86_64
 	license = custom

--- a/nvidia/nvidia-utils/PKGBUILD
+++ b/nvidia/nvidia-utils/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=nvidia-utils
 pkgname=('nvidia-utils' 'opencl-nvidia' 'nvidia-dkms')
 pkgver=555.42.02
-pkgrel=5
+pkgrel=6
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom')
@@ -253,6 +253,9 @@ package_nvidia-utils() {
 
     echo "blacklist nouveau" | install -Dm644 /dev/stdin "${pkgdir}/usr/lib/modprobe.d/${pkgname}.conf"
     echo "nvidia-uvm" | install -Dm644 /dev/stdin "${pkgdir}/usr/lib/modules-load.d/${pkgname}.conf"
+
+    # Fix sleep on NVIDIA and wayland
+    install -Dm644 "${srcdir}/nvidia-sleep.conf" "${pkgdir}/usr/lib/modprobe.d/nvidia-sleep.conf"
 
     create_links
 }

--- a/nvidia/nvidia-utils/nvidia-sleep.conf
+++ b/nvidia/nvidia-utils/nvidia-sleep.conf
@@ -1,0 +1,1 @@
+options nvidia NVreg_PreserveVideoMemoryAllocations=1 NVreg_TemporaryFilePath=/var/tmp

--- a/nvidia/nvidia-utils/nvidia-utils.install
+++ b/nvidia/nvidia-utils/nvidia-utils.install
@@ -1,4 +1,3 @@
-SERVICES=("nvidia-suspend" "nvidia-hibernate" "nvidia-resume")
 
 post_upgrade() {
   echo "If you run into trouble with CUDA not being available, run nvidia-modprobe first."
@@ -10,7 +9,5 @@ post_install() {
   post_upgrade
 
     echo "Enabling services..."
-    for service in "${SERVICES[@]}"; do
-        systemctl enable "$service"
-    done
+    systemctl enable nvidia-resume nvidia-hibernate nvidia-suspend
 }

--- a/nvidia/nvidia-utils/nvidia-utils.install
+++ b/nvidia/nvidia-utils/nvidia-utils.install
@@ -1,3 +1,5 @@
+SERVICES=("nvidia-suspend" "nvidia-hibernate" "nvidia-resume")
+
 post_upgrade() {
   echo "If you run into trouble with CUDA not being available, run nvidia-modprobe first."
   echo "If you use GDM on Wayland, you might have to run systemctl enable --now nvidia-resume.service"
@@ -6,4 +8,9 @@ post_upgrade() {
 
 post_install() {
   post_upgrade
+
+    echo "Enabling services..."
+    for service in "${SERVICES[@]}"; do
+        systemctl enable "$service"
+    done
 }


### PR DESCRIPTION
Enable these services at the initial installation.
Existing users need to enable the services manually.

Also, set NVReg Path, which fixes graphical corruption on wayland. 