### PR TITLE
Fix url for wine-cachyos PKGBUILD

### DIFF
--- a/wine-cachyos/PKGBUILD
+++ b/wine-cachyos/PKGBUILD
@@ -29,7 +29,7 @@ validpgpkeys=(5AC1A08B03BD7A313E0A955AF5E6E9EEB9461DD7
               DA23579A74D4AD9AF9D3F945CEFAC8EAAF17519D)
 
 pkgdesc="A compatibility layer for running Windows programs, with extra CachyOS flavor"
-url="https://github.com/GloriousEggroll/wine-ge-custom"
+url="https://github.com/CachyOS/wine-cachyos"
 arch=(x86_64 x86_64_v3)
 options=(!staticlibs !lto !debug)
 license=(LGPL-2.1-or-later)


### PR DESCRIPTION
Hello, I noticed the URL for wine-cachyos is different than what it actually pulls from, shouldn't it be at least 
https://github.com/CachyOS/wine-cachyos ?