### PR TITLE
cachyos-settings: add is-enabled check around uksmd disable

### DIFF
--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -18,6 +18,8 @@ post_upgrade() {
             systemctl enable "$service"
         fi
     done
-    echo "Disabling uksmd, managed now via systemd 256 MemoryKSM"
-    systemctl disable uksmd
+    if systemctl is-enabled uksmd >/dev/null; then
+        echo "Disabling uksmd, managed now via systemd 256 MemoryKSM"
+        systemctl disable uksmd
+    fi
 }


### PR DESCRIPTION
This prevents an error when it is already disabled or not installed.