### PR TITLE
Add new package cachyos-kdump-tools

### DIFF
--- a/cachyos-kdump-tools/PKGBUILD
+++ b/cachyos-kdump-tools/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Vasiliy Stelmachenok <ventureo@yandex.ru>
+pkgname=cachyos-kdump-tools
+pkgver=1.0.2
+pkgrel=1
+pkgdesc="Utility for easy creation of kernel dumps after panics"
+url="https://github.com/CachyOS/cachyos-kdump-tools"
+license=(GPL-3.0-or-later)
+arch=('any')
+depends=('kexec-tools' 'makedumpfile' 'mkinitcpio' 'systemd')
+optdepends=(
+    'linux-cachyos-dbg: For analyzing dumps'
+    'crash: For analyzing dumps'
+)
+source=("git+https://github.com/CachyOS/$pkgname#tag=$pkgver")
+sha256sums=('0ef026374f879110cb790c3872061342a01a11e2f4e4a1e6daca0766f12a48fd')
+install="${pkgname}.install"
+
+package() {
+    cd "$pkgname"
+    install -Dm644 10-kdump.conf "${pkgdir}/etc/mkinitcpio.conf.d/10-kdump.conf"
+    install -Dm644 disable-hardened-kexec.conf "${pkgdir}/usr/lib/sysctl.d/disable-hardened-kexec.conf"
+    install -Dm644 kdump.service "${pkgdir}/usr/lib/systemd/system/kdump.service"
+    install -Dm755 kdump-initcpio-install "${pkgdir}/usr/lib/initcpio/install/kdump"
+    install -Dm755 kdump-initcpio-hook "${pkgdir}/usr/lib/initcpio/hooks/kdump"
+    install -Dm755 kdump "${pkgdir}/usr/bin/kdump"
+    install -Dm755 trigger-kernel-panic "${pkgdir}/usr/bin/trigger-kernel-panic"
+}

--- a/cachyos-kdump-tools/cachyos-kdump-tools.install
+++ b/cachyos-kdump-tools/cachyos-kdump-tools.install
@@ -1,0 +1,11 @@
+post_install() {
+	cat << EOF
+
+Please configure crashkernel=128M using command kdump setup or by manually
+specifying it in your bootloader settings, then you can enable the service to
+automaticlly create dumps on kernel panics:
+
+sudo systemctl enable --now kdump
+
+EOF
+}


### PR DESCRIPTION
Since we offer quite a few upstream patches and often send feedback there, it's useful to make our tools for debugging extreme kernel cases like kernel panics. This package is needed to make debugging kernel issues much easier for us and our users. With this package the user only needs 3 steps to get a normal kernel panic dump:

1) Set `crashkernel=128M` manually or use command `kdump setup`, which will reserve memory for a "fallback kernel" (it's also called a capture kernel) that will only be loaded when a kernel panic occurs, so that a memory dump of the main kernel and dmesg logs can be recorded.
2) Enable the kdump service to automatically load a fallback kernel.
3) Wait for panic to happen or create it artificially for testing purposes using the `trigger-kernel-panic` script. When panic happens, a fallback kernel is booted and a kdump hook is triggered inside the initramfs image, which is responsible for writing dump and dmesg logs. Once the dump is written to disk in the `/var/crash` directory, filesystem is synchronized and root is safely unmounted, followed by an automatic system reboot.

After receiving kernel dump, user can send it to us or analyze it themselves using crash and unstripped vmlinux file (which is installed by the `linux-cachyos-dbg` package):
```
sudo crash /usr/src/debug/linux-cachyos/vmlinux /var/crash/crashdump-2024-07-09-15:23:24
```