### PR TITLE
egl-wayland: Update !131 Backport

### DIFF
--- a/nvidia/egl-wayland/.SRCINFO
+++ b/nvidia/egl-wayland/.SRCINFO
@@ -1,8 +1,8 @@
 pkgbase = egl-wayland
 	pkgdesc = EGLStream-based Wayland external platform
 	pkgver = 1.1.15
-	pkgrel = 2
-	epoch = 3
+	pkgrel = 3
+	epoch = 4
 	url = https://github.com/NVIDIA/egl-wayland
 	arch = x86_64
 	license = MIT
@@ -17,9 +17,9 @@ pkgbase = egl-wayland
 	provides = libnvidia-egl-wayland.so
 	source = git+https://github.com/NVIDIA/egl-wayland#commit=5a5b17e9f0f18709e08a6ee08adfd27b56f2e601
 	source = 10_nvidia_wayland.json
-	source = fix-egl-wayland.patch::https://github.com/NVIDIA/egl-wayland/pull/131/commits/90c5bdbb8d0552c31830eab9f187a1381f73fdd4.patch
+	source = fix-qt6webengine.patch::https://github.com/NVIDIA/egl-wayland/commit/f30cb0e4c9a215e933dc8250f5dad4e96d4f2136.patch
 	b2sums = 0ced3f4b32516f315d7d39894efc1416dbd703537d8722dbe261c8274beab86c2f029534be769d65f2ab5ed2d9df0da7bc8e1e8bfb360074c834ad1e68667a67
 	b2sums = b10206c742e8966d1192b9b0604137e6b296d2be74a437841c63844c0716343578b11565a34fb4c534d5908c0b5775305581b68039a6ff9ed7421c9d385a2b7a
-	b2sums = 49c52603b10f58f60cc14eb9970575841e2095d120713df23285af28f55012f2ce4d3c90b9fca8d38679be9d3a1a213669a043bc97d8bf4b0ae78caa316ef13d
+	b2sums = 85cddfcf9e75f3c805cfe78dafd8341484beb222873caec9eaa2dd3fec85552562eaff5867102d1c54f1e0e0326630e08eb10534de4d1e38c491587a6e6337e4
 
 pkgname = egl-wayland

--- a/nvidia/egl-wayland/PKGBUILD
+++ b/nvidia/egl-wayland/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=egl-wayland
 pkgver=1.1.15
-pkgrel=2
-epoch=3
+pkgrel=3
+epoch=4
 pkgdesc="EGLStream-based Wayland external platform"
 url="https://github.com/NVIDIA/egl-wayland"
 arch=(x86_64)
@@ -24,15 +24,15 @@ provides=(libnvidia-egl-wayland.so)
 source=(
   "git+$url#commit=5a5b17e9f0f18709e08a6ee08adfd27b56f2e601"
   10_nvidia_wayland.json
-  "fix-egl-wayland.patch::https://github.com/NVIDIA/egl-wayland/pull/131/commits/90c5bdbb8d0552c31830eab9f187a1381f73fdd4.patch"
+  "fix-qt6webengine.patch::$url/commit/f30cb0e4c9a215e933dc8250f5dad4e96d4f2136.patch"
 )
 b2sums=('0ced3f4b32516f315d7d39894efc1416dbd703537d8722dbe261c8274beab86c2f029534be769d65f2ab5ed2d9df0da7bc8e1e8bfb360074c834ad1e68667a67'
         'b10206c742e8966d1192b9b0604137e6b296d2be74a437841c63844c0716343578b11565a34fb4c534d5908c0b5775305581b68039a6ff9ed7421c9d385a2b7a'
-        '49c52603b10f58f60cc14eb9970575841e2095d120713df23285af28f55012f2ce4d3c90b9fca8d38679be9d3a1a213669a043bc97d8bf4b0ae78caa316ef13d')
+        '85cddfcf9e75f3c805cfe78dafd8341484beb222873caec9eaa2dd3fec85552562eaff5867102d1c54f1e0e0326630e08eb10534de4d1e38c491587a6e6337e4')
 
 prepare() {
   cd $pkgname
-  patch -Np1 < ../fix-egl-wayland.patch
+  patch -Np1 < ../fix-qt6webengine.patch
 }
 
 build() {


### PR DESCRIPTION
The patch was updated to use a common surface initializer helper function. It seems to have fixed most issues with previous versions, especially some of the niche ones that a user had.

I updated the patch file name based on https://github.com/NVIDIA/egl-wayland/commit/f30cb0e4c9a215e933dc8250f5dad4e96d4f2136 commit message.
> This fixes crashes with qt6webengine.