### PR TITLE
wine-cachyos: Enable LTO compilation for all native libraries

### DIFF
--- a/wine-cachyos/.SRCINFO
+++ b/wine-cachyos/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wine-cachyos
 	pkgdesc = A compatibility layer for running Windows programs, with extra CachyOS flavor
 	pkgver = 9.0.20240831
-	pkgrel = 1
+	pkgrel = 2
 	epoch = 2
 	url = https://github.com/CachyOS/wine-cachyos
 	install = wine.install
@@ -125,10 +125,12 @@ pkgbase = wine-cachyos
 	source = wine-cachyos::git+https://github.com/CachyOS/wine-cachyos.git#tag=cachyos-wine-9.0-20240831
 	source = 30-win32-aliases.conf
 	source = wine-binfmt.conf
+	source = lto-fixup.patch
 	validpgpkeys = 5AC1A08B03BD7A313E0A955AF5E6E9EEB9461DD7
 	validpgpkeys = DA23579A74D4AD9AF9D3F945CEFAC8EAAF17519D
 	b2sums = 16429f09051c0a47219ab419a1e4de6551f6d997491673c52aeed5c3e7e4a14976ef500f6fd148ee1a9a6a5e0d915f057e534dfb840655cb576d7fc1d5065589
 	b2sums = 45db34fb35a679dc191b4119603eba37b8008326bd4f7d6bd422fbbb2a74b675bdbc9f0cc6995ed0c564cf088b7ecd9fbe2d06d42ff8a4464828f3c4f188075b
 	b2sums = e9de76a32493c601ab32bde28a2c8f8aded12978057159dd9bf35eefbf82f2389a4d5e30170218956101331cf3e7452ae82ad0db6aad623651b0cc2174a61588
+	b2sums = 3f3e4757e5bb02cde801e9c7dd97090b74ff1bd071c3ace6e3115eb8089672c78fe4405bf2d0fb57bb96b2ce38112b2970ff9b4e064ad92b8febeaa8ed1c8e33
 
 pkgname = wine-cachyos

--- a/wine-cachyos/PKGBUILD
+++ b/wine-cachyos/PKGBUILD
@@ -8,7 +8,7 @@
 pkgname=wine-cachyos
 _srctag=9.0-20240831
 pkgver=${_srctag//-/.}
-pkgrel=1
+pkgrel=2
 epoch=2
 
 _pkgbasever=${pkgver/rc/-rc}
@@ -18,12 +18,13 @@ _winever=$_pkgbasever
 source=(wine-cachyos::git+https://github.com/CachyOS/wine-cachyos.git#tag=cachyos-wine-${_srctag}
         30-win32-aliases.conf
         wine-binfmt.conf)
-source+=(
+source+=('lto-fixup.patch'
 )
 b2sums=('16429f09051c0a47219ab419a1e4de6551f6d997491673c52aeed5c3e7e4a14976ef500f6fd148ee1a9a6a5e0d915f057e534dfb840655cb576d7fc1d5065589'
         '45db34fb35a679dc191b4119603eba37b8008326bd4f7d6bd422fbbb2a74b675bdbc9f0cc6995ed0c564cf088b7ecd9fbe2d06d42ff8a4464828f3c4f188075b'
         'e9de76a32493c601ab32bde28a2c8f8aded12978057159dd9bf35eefbf82f2389a4d5e30170218956101331cf3e7452ae82ad0db6aad623651b0cc2174a61588')
 b2sums+=(
+        '3f3e4757e5bb02cde801e9c7dd97090b74ff1bd071c3ace6e3115eb8089672c78fe4405bf2d0fb57bb96b2ce38112b2970ff9b4e064ad92b8febeaa8ed1c8e33'
 )
 validpgpkeys=(5AC1A08B03BD7A313E0A955AF5E6E9EEB9461DD7
               DA23579A74D4AD9AF9D3F945CEFAC8EAAF17519D)
@@ -113,6 +114,8 @@ prepare() {
   mkdir $pkgname-{32,64}-build
 
   pushd $pkgname
+      patch -Np1 -i "$srcdir"/lto-fixup.patch
+
       git config user.email "wine@cachyos.org"
       git config user.name "wine cachyos"
       git tag wine-9.0 --annotate -m "$pkgver" --force
@@ -124,8 +127,7 @@ prepare() {
 }
 
 build() {
-  # Doesn't compile without remove these flags as of 4.10
-  export CFLAGS="$CFLAGS -ffat-lto-objects"
+  export CFLAGS="$CFLAGS"
 
   local -a split=($CFLAGS)
   local -A flags
@@ -139,17 +141,20 @@ build() {
   WARNING_FLAGS="-Wno-incompatible-pointer-types"
   COMMON_FLAGS="$OPTIMIZE_FLAGS $SANITY_FLAGS $WARNING_FLAGS -s"
 
-  export LDFLAGS="-Wl,-O1,--sort-common,--as-needed"
-  export CROSSLDFLAGS="$LDFLAGS -Wl,--file-alignment,4096"
+  COMMON_LDFLAGS="-Wl,-O1,--sort-common,--as-needed"
+  LTO_FLAGS="-fuse-linker-plugin -fdevirtualize-at-ltrans -flto-partition=one -flto -Wl,-flto"
+
+  export LDFLAGS="$COMMON_LDFLAGS $LTO_FLAGS"
+  export CROSSLDFLAGS="$COMMON_LDFLAGS -Wl,--file-alignment,4096"
 
   cd "$srcdir"
 
   msg2 "Building Wine-64..."
 
-  export CFLAGS="$COMMON_FLAGS -mcmodel=small"
-  export CXXFLAGS="$COMMON_FLAGS -mcmodel=small -std=c++17"
-  export CROSSCFLAGS="$CFLAGS"
-  export CROSSCXXFLAGS="$CXXFLAGS"
+  export CFLAGS="$COMMON_FLAGS -mcmodel=small $LTO_FLAGS"
+  export CXXFLAGS="$COMMON_FLAGS -mcmodel=small -std=c++17 $LTO_FLAGS"
+  export CROSSCFLAGS="$COMMON_FLAGS -mcmodel=small"
+  export CROSSCXXFLAGS="$COMMON_FLAGS -mcmodel=small -std=c++17"
   export PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig"
   cd "$srcdir/$pkgname-64-build"
   ../$pkgname/configure \
@@ -171,10 +176,10 @@ build() {
   msg2 "Building Wine-32..."
 
   # Disable AVX instead of using 02, for 32bit
-  export CFLAGS="$COMMON_FLAGS -mstackrealign -mno-avx"
-  export CXXFLAGS="$COMMON_FLAGS -mstackrealign -mno-avx -std=c++17"
-  export CROSSCFLAGS="$CFLAGS"
-  export CROSSCXXFLAGS="$CXXFLAGS"
+  export CFLAGS="$COMMON_FLAGS -mstackrealign -mno-avx $LTO_FLAGS"
+  export CXXFLAGS="$COMMON_FLAGS -mstackrealign -mno-avx -std=c++17 $LTO_FLAGS"
+  export CROSSCFLAGS="$COMMON_FLAGS -mstackrealign -mno-avx"
+  export CROSSCXXFLAGS="$COMMON_FLAGS -mstackrealign -mno-avx -std=c++17"
   export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/share/pkgconfig"
   cd "$srcdir/$pkgname-32-build"
   ../$pkgname/configure \

--- a/wine-cachyos/lto-fixup.patch
+++ b/wine-cachyos/lto-fixup.patch
@@ -1,0 +1,102 @@
+rebased and updated: https://github.com/openglfreak/wine-tkg-userpatches/blob/df0a89aec388b23a8a82dca6d53e65d25c3a8f86/patches/9999-diffs/lto-fixup.patch
+diff --git a/loader/preloader.c b/loader/preloader.c
+index 11111111111..11111111111 100644
+--- a/loader/preloader.c
++++ b/loader/preloader.c
+@@ -183,7 +183,7 @@ void __bb_init_func(void) { return; }
+ 
+ /* data for setting up the glibc-style thread-local storage in %gs */
+ 
+-static int thread_data[256];
++static int thread_data[256] __attribute__((used));
+ 
+ struct
+ {
+@@ -198,7 +198,7 @@ struct
+     unsigned int  seg_not_present : 1;
+     unsigned int  usable : 1;
+     unsigned int  garbage : 25;
+-} thread_ldt = { -1, (unsigned long)thread_data, 0xfffff, 1, 0, 0, 1, 0, 1, 0 };
++} thread_ldt __attribute__((used)) = { -1, (unsigned long)thread_data, 0xfffff, 1, 0, 0, 1, 0, 1, 0 };
+ 
+ 
+ /*
+@@ -337,7 +337,7 @@ static inline int wld_prctl( int code, long arg )
+ 
+ #elif defined(__x86_64__)
+ 
+-void *thread_data[256];
++void *thread_data[256] __attribute__((used));
+ 
+ /*
+  * The _start function is the entry and exit point of this program
+@@ -426,7 +426,7 @@ SYSCALL_NOERR( wld_getegid, 108 /* SYS_getegid */ );
+ 
+ #elif defined(__aarch64__)
+ 
+-void *thread_data[256];
++void *thread_data[256] __attribute__((used));
+ 
+ /*
+  * The _start function is the entry and exit point of this program
+@@ -1432,7 +1432,7 @@ static void init_r_debug( struct wld_auxv *av )
+  *  Load the binary and then its ELF interpreter.
+  *  Note, we assume that the binary is a dynamically linked ELF shared object.
+  */
+-void* wld_start( void **stack )
++__attribute__((used)) void* wld_start( void **stack )
+ {
+     long i, *pargc;
+     char **argv, **p;
+diff --git a/dlls/ntdll/unix/signal_arm.c b/dlls/ntdll/unix/signal_arm.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/unix/signal_arm.c
++++ b/dlls/ntdll/unix/signal_arm.c
+@@ -1625,7 +1625,7 @@ void signal_init_process(void)
+ /***********************************************************************
+  *           call_init_thunk
+  */
+-void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
++__attribute__((used)) void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
+                       struct syscall_frame *frame, void *syscall_cfa )
+ {
+     struct arm_thread_data *thread_data = (struct arm_thread_data *)&teb->GdiTebBatch;
+diff --git a/dlls/ntdll/unix/signal_arm64.c b/dlls/ntdll/unix/signal_arm64.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/unix/signal_arm64.c
++++ b/dlls/ntdll/unix/signal_arm64.c
+@@ -1643,7 +1643,7 @@ void syscall_dispatcher_return_slowpath(void)
+ /***********************************************************************
+  *           call_init_thunk
+  */
+-void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
++__attribute__((used)) void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
+                       struct syscall_frame *frame, void *syscall_cfa )
+ {
+     struct arm64_thread_data *thread_data = (struct arm64_thread_data *)&teb->GdiTebBatch;
+diff --git a/dlls/ntdll/unix/signal_i386.c b/dlls/ntdll/unix/signal_i386.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/unix/signal_i386.c
++++ b/dlls/ntdll/unix/signal_i386.c
+@@ -2512,7 +2512,7 @@ void signal_init_process(void)
+ /***********************************************************************
+  *           call_init_thunk
+  */
+-void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
++__attribute__((used)) void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
+                       struct syscall_frame *frame, void *syscall_cfa )
+ {
+     struct x86_thread_data *thread_data = (struct x86_thread_data *)&teb->GdiTebBatch;
+diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -2849,7 +2849,7 @@ void set_thread_teb( TEB *teb )
+ /***********************************************************************
+  *           call_init_thunk
+  */
+-void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
++__attribute__((used)) void call_init_thunk( LPTHREAD_START_ROUTINE entry, void *arg, BOOL suspend, TEB *teb,
+                       struct syscall_frame *frame, void *syscall_cfa )
+ {
+     struct amd64_thread_data *thread_data = (struct amd64_thread_data *)&teb->GdiTebBatch;


### PR DESCRIPTION
`lto-fixup.patch` is a rebase of a [patch](https://github.com/openglfreak/wine-tkg-userpatches/blob/df0a89aec388b23a8a82dca6d53e65d25c3a8f86/patches/9999-diffs/lto-fixup.patch) by Torge Matthies, which supersedes [server: Enable link-time optimization](https://github.com/CachyOS/wine-cachyos/commit/cc9ebe323b825db218fb3c257374e81fb5ebc4ed) by allowing all native modules (i.e. modules compiled without mingw) to be compiled with LTO, not just wineserver. 

The relevant compilation flags are added to the PKGBUILD.