### PR TITLE
pacutils: Add PrettyProgressBar Config Option

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -63,6 +63,7 @@ validpgpkeys=(
 
 if $_staging; then
     source+=(78cd453.patch)
+    sha256sums+=('843ad07d4a996ad165f20544c5df5b6deec4496ec30daa38b874bf3fa28afa54')
     #source+=(https://raw.githubusercontent.com/vnepogodin/my-patches/develop/pacman/0001-libalpm-parallel-signature-check.patch)
 fi
 

--- a/pacutils/.SRCINFO
+++ b/pacutils/.SRCINFO
@@ -1,0 +1,19 @@
+pkgbase = pacutils
+	pkgdesc = Helper tools for libalpm
+	pkgver = 0.14.0
+	pkgrel = 2
+	url = https://github.com/andrewgregory/pacutils
+	arch = x86_64
+	license = MIT
+	makedepends = git
+	makedepends = perl
+	depends = glibc
+	depends = libarchive
+	depends = pacman
+	source = git+https://github.com/andrewgregory/pacutils.git#tag=v0.14.0
+	source = Add-PrettyProgressBar-config-option.patch
+	validpgpkeys = 0016846EDD8432261C62CB63DF3891463C352040
+	sha256sums = d506e110803a120740b796254fcc599fff5026bff82263a43dac10d6eb3f0a77
+	sha256sums = 8b1bc6f26b53f584d94cf323e654942a38a87dc99fc97a715df0e7eb1d92ace4
+
+pkgname = pacutils

--- a/pacutils/Add-PrettyProgressBar-config-option.patch
+++ b/pacutils/Add-PrettyProgressBar-config-option.patch
@@ -1,0 +1,73 @@
+From 0979284b4f404401a8f083f9713fc5791d76bd9a Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@cachyos.org>
+Date: Tue, 20 Aug 2024 17:53:00 +0700
+Subject: [PATCH] pacconf: Add PrettyProgressBar config option
+
+Signed-off-by: Eric Naim <dnaim@cachyos.org>
+---
+ lib/pacutils/config.c | 5 +++++
+ lib/pacutils/config.h | 4 ++++
+ src/pacconf.c         | 2 ++
+ 3 files changed, 11 insertions(+)
+
+diff --git a/lib/pacutils/config.c b/lib/pacutils/config.c
+index 9b9397a..bb65e0c 100644
+--- a/lib/pacutils/config.c
++++ b/lib/pacutils/config.c
+@@ -51,6 +51,8 @@ struct _pu_config_setting {
+   {"VerbosePkgLists", PU_CONFIG_OPTION_VERBOSEPKGLISTS},
+   {"ILoveCandy",      PU_CONFIG_OPTION_ILOVECANDY},
+ 
++  {"PrettyProgressBar", PU_CONFIG_OPTION_PRETTYPROGRESSBAR},
++
+   {"DisableDownloadTimeout", PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT},
+   {"ParallelDownloads",      PU_CONFIG_OPTION_PARALLELDOWNLOADS},
+ 
+@@ -880,6 +882,9 @@ int pu_config_reader_next(pu_config_reader_t *reader) {
+         case PU_CONFIG_OPTION_ILOVECANDY:
+           config->ilovecandy = 1;
+           break;
++        case PU_CONFIG_OPTION_PRETTYPROGRESSBAR:
++          config->prettyprogressbar = 1;
++          break;
+         case PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT:
+           config->disabledownloadtimeout = 1;
+           break;
+diff --git a/lib/pacutils/config.h b/lib/pacutils/config.h
+index f842f9d..e3bf813 100644
+--- a/lib/pacutils/config.h
++++ b/lib/pacutils/config.h
+@@ -43,6 +43,8 @@ typedef enum pu_config_option_t {
+   PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT,
+   PU_CONFIG_OPTION_PARALLELDOWNLOADS,
+ 
++  PU_CONFIG_OPTION_PRETTYPROGRESSBAR,
++
+   PU_CONFIG_OPTION_SIGLEVEL,
+   PU_CONFIG_OPTION_LOCAL_SIGLEVEL,
+   PU_CONFIG_OPTION_REMOTE_SIGLEVEL,
+@@ -93,6 +95,8 @@ typedef struct pu_config_t {
+   pu_config_bool_t verbosepkglists;
+   pu_config_bool_t disabledownloadtimeout;
+ 
++  pu_config_bool_t prettyprogressbar;
++
+   int siglevel;
+   int localfilesiglevel;
+   int remotefilesiglevel;
+diff --git a/src/pacconf.c b/src/pacconf.c
+index 7d1e8a7..9fd20fe 100644
+--- a/src/pacconf.c
++++ b/src/pacconf.c
+@@ -311,6 +311,8 @@ void dump_options(void) {
+   show_bool("VerbosePkgLists", config->verbosepkglists);
+   show_bool("ILoveCandy", config->ilovecandy);
+ 
++  show_bool("PrettyProgressBar", config->prettyprogressbar);
++
+   show_int("ParallelDownloads", config->paralleldownloads);
+ 
+   show_cleanmethod("CleanMethod", config->cleanmethod);
+-- 
+2.46.0
+

--- a/pacutils/PKGBUILD
+++ b/pacutils/PKGBUILD
@@ -1,0 +1,64 @@
+# Maintainer: Johannes Löthberg <johannes@kyriasis.com>
+
+
+_staging=false
+pkgname=pacutils
+pkgver=0.14.0
+pkgrel=2
+
+pkgdesc='Helper tools for libalpm'
+url='https://github.com/andrewgregory/pacutils'
+arch=('x86_64')
+license=('MIT')
+
+depends=(
+  'glibc'
+  'libarchive'
+  'pacman'
+)
+makedepends=('git' 'perl')
+
+source=("git+https://github.com/andrewgregory/pacutils.git#tag=v$pkgver")
+sha256sums=('d506e110803a120740b796254fcc599fff5026bff82263a43dac10d6eb3f0a77')
+validpgpkeys=('0016846EDD8432261C62CB63DF3891463C352040')
+
+if $_staging; then
+    source+=(Add-PrettyProgressBar-config-option.patch)
+    sha256sums+=('8b1bc6f26b53f584d94cf323e654942a38a87dc99fc97a715df0e7eb1d92ace4')
+    #source+=(https://raw.githubusercontent.com/vnepogodin/my-patches/develop/pacman/0001-libalpm-parallel-signature-check.patch)
+fi
+
+prepare() {
+  cd pacutils
+
+  local src
+  for src in "${source[@]}"; do
+    src="${src%%::*}"
+    src="${src##*/}"
+    [[ $src = *.patch ]] || continue
+    msg2 "Applying patch $src..."
+    patch -Np1 < "../$src"
+  done
+}
+
+build() {
+  cd pacutils
+
+  export PATH="$PATH:/usr/bin/core_perl/"
+  make CFLAGS="$CFLAGS $LDFLAGS" SYSCONFDIR=/etc LOCALSTATEDIR=/var
+}
+
+check() {
+  cd pacutils
+  export PATH="$PATH:/usr/bin/core_perl/"
+  make check
+}
+
+package() {
+  cd pacutils
+  export PATH="$PATH:/usr/bin/core_perl/"
+  make DESTDIR="$pkgdir" PREFIX=/usr install
+  install -Dm644 COPYING "$pkgdir"/usr/share/licenses/"$pkgname"/COPYING
+}
+
+# vim: set ft=PKGBUILD et sw=2:


### PR DESCRIPTION
The pacman PKGBUILD we provide has a patch that enables a unicode progress bar when built with the
necessary options. When used with upstream pacutils however, pacconf will print out warnings about
"PrettyProgressBar" config option not existing because of the way it parses configs manually.

For QoL reasons, I have made a patch to add that config option to pacconf directly so it doesn't complain
when used with PrettyProgressBar'ed pacman