### PR TITLE
go: Introduce package for GOAMD=v3/v4

### DIFF
--- a/go/.SRCINFO
+++ b/go/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = go
+	pkgdesc = Core compiler tools for the Go programming language
+	pkgver = 1.23.0
+	pkgrel = 2
+	epoch = 2
+	url = https://golang.org/
+	arch = x86_64
+	license = BSD-3-Clause
+	makedepends = git
+	makedepends = go
+	provides = go-pie
+	replaces = go-pie
+	options = !strip
+	options = staticlibs
+	source = https://go.dev/dl/go1.23.0.src.tar.gz
+	sha256sums = 42b7a8e80d805daa03022ed3fde4321d4c3bf2c990a144165d01eeecd6f699c6
+
+pkgname = go

--- a/go/.nvchecker.toml
+++ b/go/.nvchecker.toml
@@ -1,0 +1,6 @@
+[go]
+source = "github"
+github = "golang/go"
+prefix = "go"
+use_max_tag = true
+exclude_regex = ".*(release|weekly|rc|alpha|beta).*"

--- a/go/PKGBUILD
+++ b/go/PKGBUILD
@@ -1,0 +1,92 @@
+# Maintainer: Morten Linderud <foxboron@archlinux.org>
+# Contributor: Daniel Martí <mvdan@mvdan.cc>
+# Contributor: Bartłomiej Piotrowski <bpiotrowski@archlinux.org>
+# Contributor: Alexander F. Rødseth <xyproto@archlinux.org>
+# Contributor: Pierre Neidhardt <ambrevar@gmail.com>
+# Contributor: Vesa Kaihlavirta <vegai@iki.fi>
+# Contributor: Rémy Oudompheng <remy@archlinux.org>
+# Contributor: Andres Perera <andres87p gmail>
+# Contributor: Matthew Bauer <mjbauer95@gmail.com>
+# Contributor: Christian Himpel <chressie@gmail.com>
+# Contributor: Mike Rosset <mike.rosset@gmail.com>
+# Contributor: Daniel YC Lin <dlin.tw@gmail.com>
+# Contributor: John Luebs <jkluebs@gmail.com>
+
+## ENABLE x86-64-v3 optimization
+_optimize_v3=${_optimize_v3-}
+
+_optimize_v4=${_optimize_v4-}
+
+pkgname=go
+epoch=2
+pkgver=1.23.0
+pkgrel=2
+pkgdesc='Core compiler tools for the Go programming language'
+arch=(x86_64)
+url='https://golang.org/'
+license=(BSD-3-Clause)
+makedepends=(git go)
+replaces=(go-pie)
+provides=(go-pie)
+options=(!strip staticlibs)
+source=(https://go.dev/dl/go${pkgver}.src.tar.gz)
+sha256sums=('42b7a8e80d805daa03022ed3fde4321d4c3bf2c990a144165d01eeecd6f699c6')
+
+build() {
+  ## Enable Optimization, depending on the optimize.
+  ## Might we can simply use grep in the future for autodetection
+  if [ -n "$_optimize_v3" ]; then
+      export GOAMD64=v3
+  elif [ -n "$_optimize_v4" ]; then
+      export GOAMD64=v4
+  else
+      export GOAMD64=v1
+  fi
+
+  
+  export GOROOT_FINAL=/usr/lib/go
+  export GOROOT_BOOTSTRAP=/usr/lib/go
+
+  cd "$pkgname/src"
+  ./make.bash -v
+}
+
+check() {
+  export GO_TEST_TIMEOUT_SCALE=3
+
+  cd $pkgname/src
+  ./run.bash --no-rebuild -v -v -v -k
+}
+
+package() {
+  cd "$pkgname"
+
+  install -d "$pkgdir/usr/bin" "$pkgdir/usr/lib/go" "$pkgdir/usr/share/doc/go" \
+    "$pkgdir/usr/lib/go/pkg/linux_amd64_"{dynlink,race}
+
+  cp -a bin pkg src lib misc api test "$pkgdir/usr/lib/go"
+  # We can't strip all binaries and libraries,
+  # as that also strips some testdata directories and breaks the tests.
+  # Just strip the packaged binaries as a compromise.
+  strip $STRIP_BINARIES "$pkgdir/usr/lib/go"{/bin/*,/pkg/tool/*/*}
+
+  cp -r doc/* "$pkgdir/usr/share/doc/go"
+
+  ln -sf /usr/lib/go/bin/go "$pkgdir/usr/bin/go"
+  ln -sf /usr/lib/go/bin/gofmt "$pkgdir/usr/bin/gofmt"
+  ln -sf /usr/share/doc/go "$pkgdir/usr/lib/go/doc"
+
+  install -Dm644 VERSION "$pkgdir/usr/lib/go/VERSION"
+
+  rm -rf "$pkgdir/usr/lib/go/pkg/bootstrap" "$pkgdir/usr/lib/go/pkg/tool/*/api"
+
+  # TODO: Figure out if really needed
+  rm -rf "$pkgdir"/usr/lib/go/pkg/obj/go-build
+
+  # https://github.com/golang/go/issues/57179
+  install -Dm644 go.env "$pkgdir/usr/lib/go/go.env"
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+# vim: ts=2 sw=2 et


### PR DESCRIPTION
This adds the go package, for using GOAMD=v3/v4 optimization for the cachyos-v3, cachyos-v4 and cachyos-znver4 repository.