### PR TITLE
cachyos-rate-mirrors: Use the CachyOS CDN as first mirror after ranking

### DIFF
--- a/cachyos-rate-mirrors/.SRCINFO
+++ b/cachyos-rate-mirrors/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-rate-mirrors
 	pkgdesc = CachyOS - Rate mirrors service
-	pkgver = 6
+	pkgver = 8
 	pkgrel = 1
 	url = https://github.com/CachyOS
 	install = cachyos-rate-mirrors.install
@@ -9,6 +9,6 @@ pkgbase = cachyos-rate-mirrors
 	license = GPL-1.0-only
 	depends = rate-mirrors
 	source = cachyos-rate-mirrors
-	sha256sums = 5fbc905319e6bda1a642686b8d9449bfe3294f70be966bf5663591e42674dd91
+	sha256sums = cf30281d71049b74ae0dc11829ba008f4087c1ea85d73e52a933c8be4d679b59
 
 pkgname = cachyos-rate-mirrors

--- a/cachyos-rate-mirrors/PKGBUILD
+++ b/cachyos-rate-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Peter Jung <admin@ptr1337.dev>
 
 pkgname=cachyos-rate-mirrors
-pkgver=7
+pkgver=8
 pkgrel=1
 groups=(cachyos)
 arch=('any')
@@ -12,7 +12,7 @@ pkgdesc='CachyOS - Rate mirrors service'
 install=$pkgname.install
 depends=(rate-mirrors)
 source=($pkgname)
-sha256sums=('30f28a41340afe418d04606f902f0a97bfe96f7b3ee37573db6a671a5c2ea070')
+sha256sums=('cf30281d71049b74ae0dc11829ba008f4087c1ea85d73e52a933c8be4d679b59')
 
 package() {
   install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -146,6 +146,7 @@ ISO_DETECT_DIR="/run/archiso"
 
 if [ ! -d "${ISO_DETECT_DIR}" ]; then
     rate_mirror_ex arch "${MIRRORS_DEFAULT_DIR}/mirrorlist"
+    sed -i '1iServer = https://archlinux.cachyos.org/repo/$repo/os/$arch' /etc/pacman.d/mirrorlist
 fi
 
 rate_mirror_ex_cos cachyos "${MIRRORS_DEFAULT_DIR}/cachyos-mirrorlist"


### PR DESCRIPTION
The CDN provides a updated archlinux mirror, which gets synced pretty frequently.
Also, most users have quite good download speed on these.

There are not too many packages pulled from this repo, therefore lets put it on the top as default after ranking.

We have been using this mirror as default for the installation and there were never real complains or issues with it at all too.