### PR TITLE
feat: Add zlib-ng

### DIFF
--- a/zlib-ng/lib32-zlib-ng/.SRCINFO
+++ b/zlib-ng/lib32-zlib-ng/.SRCINFO
@@ -1,0 +1,23 @@
+pkgbase = lib32-zlib-ng
+	pkgdesc = zlib replacement with optimizations for next generation systems - 32-bit
+	pkgver = 2.2.1
+	pkgrel = 2
+	url = https://github.com/zlib-ng/zlib-ng
+	arch = x86_64
+	license = custom:zlib
+	makedepends = cmake
+	makedepends = ninja
+	makedepends = lib32-gcc-libs
+	depends = lib32-glibc
+	source = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.1/zlib-ng-2.2.1.tar.gz
+	sha256sums = ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf
+	b2sums = eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552
+
+pkgname = lib32-zlib-ng
+	provides = libz-ng.so
+
+pkgname = lib32-zlib-ng-compat
+	pkgdesc = zlib replacement with optimizations for next generation systems - 32-bit (zlib compat)
+	provides = lib32-zlib
+	provides = libz.so
+	replaces = lib32-zlib

--- a/zlib-ng/lib32-zlib-ng/.nvchecker.toml
+++ b/zlib-ng/lib32-zlib-ng/.nvchecker.toml
@@ -1,0 +1,4 @@
+[zlib-ng]
+source = "git"
+git = "https://github.com/zlib-ng/zlib-ng.git"
+prefix = "v"

--- a/zlib-ng/lib32-zlib-ng/PKGBUILD
+++ b/zlib-ng/lib32-zlib-ng/PKGBUILD
@@ -1,6 +1,8 @@
-# Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
-# Contributor: Chocobo1 <chocobo1 AT archlinux DOT net>
-# Contributor: Jacek Szafarkiewicz <szafar at linux dot pl>
+### CachyOS PKGBUILD Maintainers:
+# Maintainer: Eric Naim <dnaim@cachyos.org>
+# Maintainer: Peter Jung <admin@ptr1337.dev>
+
+
 pkgbase=lib32-zlib-ng
 pkgname=(
   $pkgbase

--- a/zlib-ng/lib32-zlib-ng/PKGBUILD
+++ b/zlib-ng/lib32-zlib-ng/PKGBUILD
@@ -1,0 +1,95 @@
+# Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
+# Contributor: Chocobo1 <chocobo1 AT archlinux DOT net>
+# Contributor: Jacek Szafarkiewicz <szafar at linux dot pl>
+pkgbase=lib32-zlib-ng
+pkgname=(
+  $pkgbase
+  $pkgbase-compat
+)
+pkgver=2.2.1
+pkgrel=2
+pkgdesc='zlib replacement with optimizations for next generation systems - 32-bit'
+url='https://github.com/zlib-ng/zlib-ng'
+arch=('x86_64')
+license=('custom:zlib')
+depends=(
+  lib32-glibc
+)
+makedepends=(
+  cmake
+  ninja
+  lib32-gcc-libs
+)
+source=("${url}/archive/refs/tags/$pkgver/zlib-ng-${pkgver}.tar.gz")
+sha256sums=('ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf')
+b2sums=('eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552')
+
+
+build() {
+  cd "zlib-ng-${pkgver}"
+
+
+  ## Build for 32-bit
+  export CFLAGS+=" -m32"
+  export CXXFLAGS+=" -m32"
+  export LDFLAGS+=" -m32"
+  export PKG_CONFIG_PATH='/usr/lib32/pkgconfig'
+
+	# WITH_UNALIGNED - unaligned access invokes undefined behaviour,
+	#   see https://github.com/gentoo/gentoo/pull/17167 for more info.
+  local _options=(
+    -G Ninja
+    -DCMAKE_BUILD_TYPE=None
+    -DCMAKE_INSTALL_PREFIX=/usr
+    -DCMAKE_INSTALL_LIBDIR=lib32
+    -Wno-dev
+    -DWITH_GTEST=OFF
+    -DWITH_UNALIGNED=OFF
+  )
+
+  msg2 "Building zlib-ng"
+  cmake -B build \
+    "${_options[@]}"
+  cmake --build build
+
+  msg2 "Building zlib-ng-compat"
+  cmake -B build-compat \
+    "${_options[@]}" \
+    -DZLIB_COMPAT=ON
+  cmake --build build-compat
+}
+
+check() {
+  cd "zlib-ng-${pkgver}"
+  msg2 "Checking zlib-ng"
+  ctest --output-on-failure --test-dir build
+  msg2 "Checking zlib-ng-compat"
+  ctest --output-on-failure --test-dir build-compat
+}
+
+package_lib32-zlib-ng() {
+  provides=('libz-ng.so')
+
+
+  cd "zlib-ng-${pkgver}"
+  DESTDIR="${pkgdir}" cmake --install build
+  install -Dm 644 LICENSE.md -t "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -Dm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+
+  rm -rf "$pkgdir"/usr/include
+}
+
+package_lib32-zlib-ng-compat() {
+  pkgdesc+=" (zlib compat)"
+  provides=('lib32-zlib' 'libz.so')
+  replaces=('lib32-zlib')
+
+  cd "zlib-ng-${pkgver}"
+  DESTDIR="${pkgdir}" cmake --install build-compat
+  install -Dm 644 LICENSE.md -t "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -Dm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+
+  rm -rf "$pkgdir"/usr/include
+}
+
+# vim: ts=2 sw=2 et:

--- a/zlib-ng/lib32-zlib-ng/PKGBUILD
+++ b/zlib-ng/lib32-zlib-ng/PKGBUILD
@@ -32,8 +32,8 @@ build() {
 
 
   ## Build for 32-bit
-  export CFLAGS+=" -m32"
-  export CXXFLAGS+=" -m32"
+  export CFLAGS+=" -m32 -fno-semantic-interposition"
+  export CXXFLAGS+=" -m32 -fno-semantic-interposition"
   export LDFLAGS+=" -m32"
   export PKG_CONFIG_PATH='/usr/lib32/pkgconfig'
 

--- a/zlib-ng/zlib-ng/.SRCINFO
+++ b/zlib-ng/zlib-ng/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = zlib-ng
+	pkgdesc = zlib replacement with optimizations for next generation systems
+	pkgver = 2.2.1
+	pkgrel = 2
+	url = https://github.com/zlib-ng/zlib-ng
+	arch = x86_64
+	license = custom:zlib
+	makedepends = cmake
+	makedepends = ninja
+	depends = glibc
+	source = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.1/zlib-ng-2.2.1.tar.gz
+	sha256sums = ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf
+	b2sums = eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552
+
+pkgname = zlib-ng
+	provides = libz-ng.so
+
+pkgname = zlib-ng-compat
+	pkgdesc = zlib replacement with optimizations for next generation systems (zlib compat)
+	provides = zlib
+	provides = libz.so
+	replaces = zlib

--- a/zlib-ng/zlib-ng/.nvchecker.toml
+++ b/zlib-ng/zlib-ng/.nvchecker.toml
@@ -1,0 +1,4 @@
+[zlib-ng]
+source = "git"
+git = "https://github.com/zlib-ng/zlib-ng.git"
+prefix = "v"

--- a/zlib-ng/zlib-ng/PKGBUILD
+++ b/zlib-ng/zlib-ng/PKGBUILD
@@ -1,6 +1,12 @@
+### Arch Linux PKGBUILD Maintainers:
 # Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
 # Contributor: Chocobo1 <chocobo1 AT archlinux DOT net>
 # Contributor: Jacek Szafarkiewicz <szafar at linux dot pl>
+### CachyOS PKGBUILD Maintainers:
+# Maintainer: Eric Naim <dnaim@cachyos.org>
+# Maintainer: Peter Jung <admin@ptr1337.dev>
+
+
 pkgbase=zlib-ng
 pkgname=(
   $pkgbase

--- a/zlib-ng/zlib-ng/PKGBUILD
+++ b/zlib-ng/zlib-ng/PKGBUILD
@@ -1,0 +1,82 @@
+# Maintainer: Levente Polyak <anthraxx[at]archlinux[dot]org>
+# Contributor: Chocobo1 <chocobo1 AT archlinux DOT net>
+# Contributor: Jacek Szafarkiewicz <szafar at linux dot pl>
+pkgbase=zlib-ng
+pkgname=(
+  $pkgbase
+  $pkgbase-compat
+)
+pkgver=2.2.1
+pkgrel=2
+pkgdesc='zlib replacement with optimizations for next generation systems'
+url='https://github.com/zlib-ng/zlib-ng'
+arch=('x86_64')
+license=('custom:zlib')
+depends=(
+  glibc
+)
+makedepends=(
+  cmake
+  ninja
+)
+source=("${url}/archive/refs/tags/$pkgver/zlib-ng-${pkgver}.tar.gz")
+sha256sums=('ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf')
+b2sums=('eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552')
+
+
+build() {
+  cd "zlib-ng-${pkgver}"
+
+	# WITH_UNALIGNED - unaligned access invokes undefined behaviour,
+	#   see https://github.com/gentoo/gentoo/pull/17167 for more info.
+  local _options=(
+    -G Ninja
+    -DCMAKE_BUILD_TYPE=None
+    -DCMAKE_INSTALL_PREFIX=/usr
+    -DCMAKE_INSTALL_LIBDIR=lib
+    -Wno-dev
+    -DWITH_GTEST=OFF
+    -DWITH_UNALIGNED=OFF
+  )
+
+  msg2 "Building zlib-ng"
+  cmake -B build \
+    "${_options[@]}"
+  cmake --build build
+
+  msg2 "Building zlib-ng-compat"
+  cmake -B build-compat \
+    "${_options[@]}" \
+    -DZLIB_COMPAT=ON
+  cmake --build build-compat
+}
+
+check() {
+  cd "zlib-ng-${pkgver}"
+  msg2 "Checking zlib-ng"
+  ctest --output-on-failure --test-dir build
+  msg2 "Checking zlib-ng-compat"
+  ctest --output-on-failure --test-dir build-compat
+}
+
+package_zlib-ng() {
+  provides=('libz-ng.so')
+
+  cd "zlib-ng-${pkgver}"
+  DESTDIR="${pkgdir}" cmake --install build
+  install -Dm 644 LICENSE.md -t "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -Dm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+}
+
+package_zlib-ng-compat() {
+  pkgdesc+=" (zlib compat)"
+  provides=('zlib' 'libz.so')
+  replaces=('zlib')
+
+  cd "zlib-ng-${pkgver}"
+  DESTDIR="${pkgdir}" cmake --install build-compat
+  install -Dm 644 LICENSE.md -t "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -Dm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+}
+
+# vim: ts=2 sw=2 et:

--- a/zlib-ng/zlib-ng/PKGBUILD
+++ b/zlib-ng/zlib-ng/PKGBUILD
@@ -33,6 +33,9 @@ b2sums=('eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78
 build() {
   cd "zlib-ng-${pkgver}"
 
+  export CFLAGS+=" -fno-semantic-interposition"
+  export CXXLAGS+=" -fno-semantic-interposition"
+
 	# WITH_UNALIGNED - unaligned access invokes undefined behaviour,
 	#   see https://github.com/gentoo/gentoo/pull/17167 for more info.
   local _options=(

--- a/zlib-ng/zlib-ng/PKGBUILD
+++ b/zlib-ng/zlib-ng/PKGBUILD
@@ -34,7 +34,7 @@ build() {
   cd "zlib-ng-${pkgver}"
 
   export CFLAGS+=" -fno-semantic-interposition"
-  export CXXLAGS+=" -fno-semantic-interposition"
+  export CXXFLAGS+=" -fno-semantic-interposition"
 
 	# WITH_UNALIGNED - unaligned access invokes undefined behaviour,
 	#   see https://github.com/gentoo/gentoo/pull/17167 for more info.


### PR DESCRIPTION
We aim to replace zlib with zlib-ng to make use of the optimizations from the next generation implementation

Some benchmarks to highlight the benefits of this replacement:
- [zlib-ng - 2.0.0 Benchmark Discussions](https://github.com/zlib-ng/zlib-ng/discussions/871)
- [AWS - Comparisons between zlib-cloudflare, zlib-ng and other zlib forks](https://aws.amazon.com/blogs/opensource/improving-zlib-cloudflare-and-comparing-performance-with-other-zlib-forks/)
- [Megastorm's Systems zlib-ng vs zlib](https://www.megastormsystems.com/news/benchmarks-results-of-zlib-and-zlib-ng-running-on-some-amd-and-intel-cpus)



Closes #330 