### PR TITLE
power-profiles-daemon: 0.23

### DIFF
--- a/power-profiles-daemon/.SRCINFO
+++ b/power-profiles-daemon/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = power-profiles-daemon
 	pkgdesc = Makes power profiles handling available over D-Bus
-	pkgver = 0.22
+	pkgver = 0.23
 	pkgrel = 2
 	url = https://gitlab.freedesktop.org/upower/power-profiles-daemon
 	arch = x86_64
@@ -19,9 +19,7 @@ pkgbase = power-profiles-daemon
 	depends = polkit
 	depends = upower
 	optdepends = python-gobject: for powerprofilesctl
-	source = git+https://gitlab.freedesktop.org/upower/power-profiles-daemon#tag=0.22
-	source = no-dpm-user-override.patch::https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/merge_requests/208.patch
-	sha256sums = 1bc3965288d36554fcfa56d3de7dc1b16e09204205cf0af23bd47007a91530ec
-	sha256sums = 5ee72e38a522b3226ede7176770db9af186376e1a7e13a2edc6b3cba7b2504c7
+	source = git+https://gitlab.freedesktop.org/upower/power-profiles-daemon#tag=0.23
+	sha256sums = ffa0951d6c008239539c2a51150ad454b283c4b4b0e1910920b6afed3d143a3f
 
 pkgname = power-profiles-daemon

--- a/power-profiles-daemon/PKGBUILD
+++ b/power-profiles-daemon/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: tinywrkb <tinywrkb@gmail.com>
 
 pkgname=power-profiles-daemon
-pkgver=0.22
+pkgver=0.23
 pkgrel=2
 pkgdesc='Makes power profiles handling available over D-Bus'
 url='https://gitlab.freedesktop.org/upower/power-profiles-daemon'
@@ -22,16 +22,12 @@ checkdepends=(python-dbusmock
               python-isort
               python-mccabe
               umockdev)
-source=(git+https://gitlab.freedesktop.org/upower/$pkgname#tag=$pkgver
-        no-dpm-user-override.patch::https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/merge_requests/208.patch)
-sha256sums=('1bc3965288d36554fcfa56d3de7dc1b16e09204205cf0af23bd47007a91530ec'
-            '5ee72e38a522b3226ede7176770db9af186376e1a7e13a2edc6b3cba7b2504c7')
+source=(git+https://gitlab.freedesktop.org/upower/$pkgname#tag=$pkgver)
+sha256sums=('ffa0951d6c008239539c2a51150ad454b283c4b4b0e1910920b6afed3d143a3f')
 
-prepare() {
-  cd $pkgname
-  msg2 "Don't override user settings for dpm if set to manual"
-  patch -Np1 < ../no-dpm-user-override.patch
-}
+#prepare() {
+#  cd $pkgname
+#}
 
 build() {
   meson $pkgname build \


### PR DESCRIPTION
Closes #338 

Let's just maintain our own ppd instead of using Arch's. It is pretty low effort and we can cherrypick commits that introduce more fixes or even new features. We can revisit this decision if development slows down.