### PR TITLE
zlib-ng: 2.2.2 && Add depends=(zlib-ng{,-compat}) for 32bit package

### DIFF
--- a/zlib-ng/lib32-zlib-ng/.SRCINFO
+++ b/zlib-ng/lib32-zlib-ng/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = lib32-zlib-ng
 	pkgdesc = zlib replacement with optimizations for next generation systems - 32-bit
-	pkgver = 2.2.1
-	pkgrel = 4
+	pkgver = 2.2.2
+	pkgrel = 2
 	url = https://github.com/zlib-ng/zlib-ng
 	arch = x86_64
 	license = custom:zlib
@@ -9,9 +9,9 @@ pkgbase = lib32-zlib-ng
 	makedepends = ninja
 	makedepends = lib32-gcc-libs
 	depends = lib32-glibc
-	source = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.1/zlib-ng-2.2.1.tar.gz
-	sha256sums = ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf
-	b2sums = eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552
+	source = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.2/zlib-ng-2.2.2.tar.gz
+	sha256sums = fcb41dd59a3f17002aeb1bb21f04696c9b721404890bb945c5ab39d2cb69654c
+	b2sums = 970260f44fcce467933bf0038afa0f6e18cc007012c7d9be0b259d407e981fa1a353ce4c7aae38e5158ba65c79c5b54777f1cc436654016c5a21d20630061890
 
 pkgname = lib32-zlib-ng
 	provides = libz-ng.so

--- a/zlib-ng/lib32-zlib-ng/.SRCINFO
+++ b/zlib-ng/lib32-zlib-ng/.SRCINFO
@@ -14,10 +14,12 @@ pkgbase = lib32-zlib-ng
 	b2sums = 970260f44fcce467933bf0038afa0f6e18cc007012c7d9be0b259d407e981fa1a353ce4c7aae38e5158ba65c79c5b54777f1cc436654016c5a21d20630061890
 
 pkgname = lib32-zlib-ng
+	depends = zlib-ng=2.2.2
 	provides = libz-ng.so
 
 pkgname = lib32-zlib-ng-compat
 	pkgdesc = zlib replacement with optimizations for next generation systems - 32-bit (zlib compat)
+	depends = zlib-ng-compat=2.2.2
 	provides = lib32-zlib
 	provides = libz.so
 	conflicts = lib32-zlib

--- a/zlib-ng/lib32-zlib-ng/PKGBUILD
+++ b/zlib-ng/lib32-zlib-ng/PKGBUILD
@@ -71,6 +71,7 @@ check() {
 
 package_lib32-zlib-ng() {
   provides=('libz-ng.so')
+  depends=(zlib-ng=$pkgver)
 
 
   cd "zlib-ng-${pkgver}"
@@ -84,6 +85,7 @@ package_lib32-zlib-ng() {
 package_lib32-zlib-ng-compat() {
   pkgdesc+=" (zlib compat)"
   provides=('lib32-zlib' 'libz.so')
+  depends=(zlib-ng-compat=$pkgver)
   conflicts=('lib32-zlib')
   replaces=('lib32-zlib')
   options=('staticlibs')

--- a/zlib-ng/lib32-zlib-ng/PKGBUILD
+++ b/zlib-ng/lib32-zlib-ng/PKGBUILD
@@ -8,8 +8,8 @@ pkgname=(
   $pkgbase
   $pkgbase-compat
 )
-pkgver=2.2.1
-pkgrel=4
+pkgver=2.2.2
+pkgrel=2
 pkgdesc='zlib replacement with optimizations for next generation systems - 32-bit'
 url='https://github.com/zlib-ng/zlib-ng'
 arch=('x86_64')
@@ -23,8 +23,8 @@ makedepends=(
   lib32-gcc-libs
 )
 source=("${url}/archive/refs/tags/$pkgver/zlib-ng-${pkgver}.tar.gz")
-sha256sums=('ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf')
-b2sums=('eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552')
+sha256sums=('fcb41dd59a3f17002aeb1bb21f04696c9b721404890bb945c5ab39d2cb69654c')
+b2sums=('970260f44fcce467933bf0038afa0f6e18cc007012c7d9be0b259d407e981fa1a353ce4c7aae38e5158ba65c79c5b54777f1cc436654016c5a21d20630061890')
 
 
 build() {

--- a/zlib-ng/zlib-ng/.SRCINFO
+++ b/zlib-ng/zlib-ng/.SRCINFO
@@ -1,16 +1,16 @@
 pkgbase = zlib-ng
 	pkgdesc = zlib replacement with optimizations for next generation systems
-	pkgver = 2.2.1
-	pkgrel = 4
+	pkgver = 2.2.2
+	pkgrel = 2
 	url = https://github.com/zlib-ng/zlib-ng
 	arch = x86_64
 	license = custom:zlib
 	makedepends = cmake
 	makedepends = ninja
 	depends = glibc
-	source = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.1/zlib-ng-2.2.1.tar.gz
-	sha256sums = ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf
-	b2sums = eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552
+	source = https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.2/zlib-ng-2.2.2.tar.gz
+	sha256sums = fcb41dd59a3f17002aeb1bb21f04696c9b721404890bb945c5ab39d2cb69654c
+	b2sums = 970260f44fcce467933bf0038afa0f6e18cc007012c7d9be0b259d407e981fa1a353ce4c7aae38e5158ba65c79c5b54777f1cc436654016c5a21d20630061890
 
 pkgname = zlib-ng
 	provides = libz-ng.so

--- a/zlib-ng/zlib-ng/PKGBUILD
+++ b/zlib-ng/zlib-ng/PKGBUILD
@@ -12,8 +12,8 @@ pkgname=(
   $pkgbase
   $pkgbase-compat
 )
-pkgver=2.2.1
-pkgrel=4
+pkgver=2.2.2
+pkgrel=2
 pkgdesc='zlib replacement with optimizations for next generation systems'
 url='https://github.com/zlib-ng/zlib-ng'
 arch=('x86_64')
@@ -26,8 +26,8 @@ makedepends=(
   ninja
 )
 source=("${url}/archive/refs/tags/$pkgver/zlib-ng-${pkgver}.tar.gz")
-sha256sums=('ec6a76169d4214e2e8b737e0850ba4acb806c69eeace6240ed4481b9f5c57cdf')
-b2sums=('eacd6e01b8792d1646054b32274c486021fa3c4341a5ce4e19d7afcccf0fc8645a20e78aedad2b353d662b2b82641780c55ff8e4e255c3fe9ffb67fce2001552')
+sha256sums=('fcb41dd59a3f17002aeb1bb21f04696c9b721404890bb945c5ab39d2cb69654c')
+b2sums=('970260f44fcce467933bf0038afa0f6e18cc007012c7d9be0b259d407e981fa1a353ce4c7aae38e5158ba65c79c5b54777f1cc436654016c5a21d20630061890')
 
 
 build() {


### PR DESCRIPTION
Closes #346 