### PR TITLE
Update Proton/Wine to version 9.0-20240918

### DIFF
--- a/proton-cachyos/.SRCINFO
+++ b/proton-cachyos/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = proton-cachyos
 	pkgdesc = Compatibility tool for Steam Play based on Wine and additional components, experimental branch with extra CachyOS flavour
-	pkgver = 9.0.20240905
-	pkgrel = 1
+	pkgver = 9.0.20240918
+	pkgrel = 2
 	epoch = 1
 	url = https://github.com/cachyos/proton-cachyos
 	install = proton-cachyos.install
@@ -132,22 +132,22 @@ pkgbase = proton-cachyos
 	provides = proton
 	noextract = wine-gecko-2.47.4-x86.tar.xz
 	noextract = wine-gecko-2.47.4-x86_64.tar.xz
-	noextract = wine-mono-9.2.0-x86.tar.xz
+	noextract = wine-mono-9.3.0-x86.tar.xz
 	noextract = xalia-0.4.2-net48-mono.zip
 	options = !staticlibs
 	options = !lto
 	options = !debug
 	options = emptydirs
-	source = proton-cachyos::git+https://github.com/CachyOS/proton-cachyos.git#tag=cachyos-9.0-20240905
+	source = proton-cachyos::git+https://github.com/CachyOS/proton-cachyos.git#tag=cachyos-9.0-20240918
 	source = https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86.tar.xz
 	source = https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86_64.tar.xz
-	source = https://github.com/madewokherd/wine-mono/releases/download/wine-mono-9.2.0/wine-mono-9.2.0-x86.tar.xz
+	source = https://github.com/madewokherd/wine-mono/releases/download/wine-mono-9.3.0/wine-mono-9.3.0-x86.tar.xz
 	source = https://github.com/madewokherd/xalia/releases/download/xalia-0.4.2/xalia-0.4.2-net48-mono.zip
 	source = dxvk-reflex.patch
-	sha256sums = a447c19d25c4852cd0d10099de7fad8695451fbf1f1063d8b5a634005945b316
+	sha256sums = 64341a7887ead819142b0d739e4ed1a3d4bb16301a566bd9f03188546f572de2
 	sha256sums = 2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6
 	sha256sums = fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814
-	sha256sums = 59b35dfe525f32c581884b6c7865496e13b3cd200c5ed267c43fb4663e0cd757
+	sha256sums = c23deb9e3217a574f242b78d74cb94c4948a37d1f2715941b803a02e535854a6
 	sha256sums = 50ce2cc85162343e62340b0ca7994ceba94592ab395fb99711e94e108e991f0c
 	sha256sums = 678bba12f4881cd5b6ffb6a503106232619d46d8bbc6d7ec95e719d63fcb1c37
 

--- a/proton-cachyos/PKGBUILD
+++ b/proton-cachyos/PKGBUILD
@@ -2,13 +2,13 @@
 # Maintainer: loathingkernel <loathingkernel _a_ gmail _d_ com>
 
 pkgname=proton-cachyos
-_srctag=9.0-20240905
+_srctag=9.0-20240918
 _commit=
 pkgver=${_srctag//-/.}
 _geckover=2.47.4
-_monover=9.2.0
+_monover=9.3.0
 _xaliaver=0.4.2
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Compatibility tool for Steam Play based on Wine and additional components, experimental branch with extra CachyOS flavour"
 url="https://github.com/cachyos/proton-cachyos"
@@ -255,9 +255,9 @@ package() {
         $(find "$_monodir" -iname "*x86_64.dll" -or -iname "*x86_64.exe")
 }
 
-sha256sums=('a447c19d25c4852cd0d10099de7fad8695451fbf1f1063d8b5a634005945b316'
+sha256sums=('64341a7887ead819142b0d739e4ed1a3d4bb16301a566bd9f03188546f572de2'
             '2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6'
             'fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814'
-            '59b35dfe525f32c581884b6c7865496e13b3cd200c5ed267c43fb4663e0cd757'
+            'c23deb9e3217a574f242b78d74cb94c4948a37d1f2715941b803a02e535854a6'
             '50ce2cc85162343e62340b0ca7994ceba94592ab395fb99711e94e108e991f0c'
             '678bba12f4881cd5b6ffb6a503106232619d46d8bbc6d7ec95e719d63fcb1c37')

--- a/wine-cachyos/.SRCINFO
+++ b/wine-cachyos/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wine-cachyos
 	pkgdesc = A compatibility layer for running Windows programs, with extra CachyOS flavor
-	pkgver = 9.0.20240905
-	pkgrel = 1
+	pkgver = 9.0.20240918
+	pkgrel = 2
 	epoch = 2
 	url = https://github.com/CachyOS/wine-cachyos
 	install = wine.install
@@ -122,12 +122,12 @@ pkgbase = wine-cachyos
 	options = !staticlibs
 	options = !lto
 	options = !debug
-	source = wine-cachyos::git+https://github.com/CachyOS/wine-cachyos.git#tag=cachyos-wine-9.0-20240905
+	source = wine-cachyos::git+https://github.com/CachyOS/wine-cachyos.git#tag=cachyos-wine-9.0-20240918
 	source = 30-win32-aliases.conf
 	source = wine-binfmt.conf
 	validpgpkeys = 5AC1A08B03BD7A313E0A955AF5E6E9EEB9461DD7
 	validpgpkeys = DA23579A74D4AD9AF9D3F945CEFAC8EAAF17519D
-	b2sums = fd2961a3fec818a0fa41f15c6bb5bd2db8bf84e3adc864ad330179d445cac30ae48346eb2be0bab77f8a5c2a3d485844847e4dbd8fb7f4cd66704b91a5010c6a
+	b2sums = 01500958bca788e2b57d56c108c22ad74b791a247dce3644b505936d56f8635b2532665e9e847f3d7d8b2d5f160157127c43e760bdc6063cd9d930c896b3515c
 	b2sums = 45db34fb35a679dc191b4119603eba37b8008326bd4f7d6bd422fbbb2a74b675bdbc9f0cc6995ed0c564cf088b7ecd9fbe2d06d42ff8a4464828f3c4f188075b
 	b2sums = e9de76a32493c601ab32bde28a2c8f8aded12978057159dd9bf35eefbf82f2389a4d5e30170218956101331cf3e7452ae82ad0db6aad623651b0cc2174a61588
 

--- a/wine-cachyos/PKGBUILD
+++ b/wine-cachyos/PKGBUILD
@@ -6,9 +6,9 @@
 # Contributor: Giovanni Scafora <giovanni@archlinux.org>
 
 pkgname=wine-cachyos
-_srctag=9.0-20240905
+_srctag=9.0-20240918
 pkgver=${_srctag//-/.}
-pkgrel=1
+pkgrel=2
 epoch=2
 
 _pkgbasever=${pkgver/rc/-rc}
@@ -20,7 +20,7 @@ source=(wine-cachyos::git+https://github.com/CachyOS/wine-cachyos.git#tag=cachyo
         wine-binfmt.conf)
 source+=(
 )
-b2sums=('fd2961a3fec818a0fa41f15c6bb5bd2db8bf84e3adc864ad330179d445cac30ae48346eb2be0bab77f8a5c2a3d485844847e4dbd8fb7f4cd66704b91a5010c6a'
+b2sums=('01500958bca788e2b57d56c108c22ad74b791a247dce3644b505936d56f8635b2532665e9e847f3d7d8b2d5f160157127c43e760bdc6063cd9d930c896b3515c'
         '45db34fb35a679dc191b4119603eba37b8008326bd4f7d6bd422fbbb2a74b675bdbc9f0cc6995ed0c564cf088b7ecd9fbe2d06d42ff8a4464828f3c4f188075b'
         'e9de76a32493c601ab32bde28a2c8f8aded12978057159dd9bf35eefbf82f2389a4d5e30170218956101331cf3e7452ae82ad0db6aad623651b0cc2174a61588')
 b2sums+=(


### PR DESCRIPTION
- wine-cachyos: version 9.0-20240918
- proton-cachyos: version 9.0-20240918

## Version 9.0-20240918
* Wine
  - rebase-only
* Proton
  - removed: (staging) d3dx11_43-D3DX11CreateTextureFromMemory
  - removed: (staging) d3dx9_36-BumpLuminance
  - removed: (staging) shell32-SHFileOperation_Move
  - removed: (staging) shell32-registry-lookup-app
  - dropped: (in-upstream) include: Add TCP_KEEPCNT and TCP_KEEPINTVL definitions.
  - dropped: (in-upstream) include: ws2_32: Implement TCP_KEEP{ALIVE,CNT,INTVL} options.
  -   added: gdi32,win32u,winex11: Implement D3DKMTEnumAdapters2.
  -   added: win32u: Allow faking HAGS in QueryAdapterInfo.
