### PR TITLE
cachy-browser: 131.0.2-1

### DIFF
--- a/cachy-browser/.SRCINFO
+++ b/cachy-browser/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachy-browser
 	pkgdesc = Community-maintained fork of Firefox, focused on privacy, security and freedom.
-	pkgver = 130.0.1
+	pkgver = 131.0.2
 	pkgrel = 1
 	install = cachy-browser.install
 	arch = x86_64
@@ -9,7 +9,6 @@ pkgbase = cachy-browser
 	makedepends = cbindgen
 	makedepends = diffutils
 	makedepends = imake
-	makedepends = inetutils
 	makedepends = jack
 	makedepends = mesa
 	makedepends = nasm
@@ -64,18 +63,18 @@ pkgbase = cachy-browser
 	options = !emptydirs
 	options = !lto
 	options = !makeflags
-	source = https://archive.mozilla.org/pub/firefox/releases/130.0.1/source/firefox-130.0.1.source.tar.xz
-	source = https://archive.mozilla.org/pub/firefox/releases/130.0.1/source/firefox-130.0.1.source.tar.xz.asc
+	source = https://archive.mozilla.org/pub/firefox/releases/131.0.2/source/firefox-131.0.2.source.tar.xz
+	source = https://archive.mozilla.org/pub/firefox/releases/131.0.2/source/firefox-131.0.2.source.tar.xz.asc
 	source = cachy-browser.desktop
-	source = git+https://github.com/cachyos/cachyos-browser-settings.git#commit=72b43a93b822ad06554d8dbe793b31fffef5aa74
-	source = git+https://github.com/cachyos/cachyos-browser-common.git#commit=5dd46aafa8ad8b4bddc86a4febdab901e447c9a2
+	source = git+https://github.com/cachyos/cachyos-browser-settings.git#commit=541156d4b673e18a565a76904ad1f3b726d1ccee
+	source = git+https://github.com/Stebalien/cachyos-browser-common.git#commit=7794576484c02a24075abe0a3a69bb443719b7ac
 	source = match.patch
 	validpgpkeys = 14F26682D0916CDD81E37B6D61B7B526D98F0353
-	sha256sums = 027225a1e9b074f0072e22c7264cf27b0d2364c675c3ca811aa6c25fb01b9f70
+	sha256sums = 040e834ac94dd5246f9d77a66f7b43c43c62f538d00b5f94597534dc1db77616
 	sha256sums = SKIP
 	sha256sums = de5c0deb9b6a4ebfaa933103cc6a65f1f43c9a456296d356cc54c7ca042d144c
-	sha256sums = 1975dba8663744e5757a7398899fe94dd50ba33adfe122d6cfb69d8480de9c3a
-	sha256sums = f9ef09f06f8400a11974d9ac39b14ea9646b9adcccbceb1466076d1d70986260
+	sha256sums = af74351c70fa0121600889598ec8d10aeab65bde1b8cd0c79fac7c54e2058ae3
+	sha256sums = 7dac91042b2645013cf9d7208656a6e36037c9ff527a0143d4154cb1ba9eb651
 	sha256sums = 1fbb1971a1d0d4c875b1af0f9681601909cfbe4fe0cc2c2f42c523c84c934499
 
 pkgname = cachy-browser

--- a/cachy-browser/PKGBUILD
+++ b/cachy-browser/PKGBUILD
@@ -7,7 +7,7 @@
 pkgname=cachy-browser
 _pkgname=Cachy
 __pkgname=cachy
-pkgver=130.0.1
+pkgver=131.0.2
 pkgrel=1
 pkgdesc="Community-maintained fork of Firefox, focused on privacy, security and freedom."
 arch=(x86_64)
@@ -54,7 +54,6 @@ makedepends=(
   #clang
   diffutils
   imake
-  inetutils
   jack
   #lld
   #llvm
@@ -91,18 +90,18 @@ install=cachy-browser.install
 # TODO(vnepogodin): enable back on next firefox release
 #backup=('usr/lib/cachy-browser/distribution/policies.json')
 
-_settings_commit=72b43a93b822ad06554d8dbe793b31fffef5aa74
-_common_commit=5dd46aafa8ad8b4bddc86a4febdab901e447c9a2
+_settings_commit=541156d4b673e18a565a76904ad1f3b726d1ccee
+_common_commit=7794576484c02a24075abe0a3a69bb443719b7ac
 source=(https://archive.mozilla.org/pub/firefox/releases/$pkgver/source/firefox-$pkgver.source.tar.xz{,.asc}
         $pkgname.desktop
         "git+https://github.com/cachyos/cachyos-browser-settings.git#commit=${_settings_commit}"
-        "git+https://github.com/cachyos/cachyos-browser-common.git#commit=${_common_commit}"
+        "git+https://github.com/Stebalien/cachyos-browser-common.git#commit=${_common_commit}"
         "match.patch")
-sha256sums=('027225a1e9b074f0072e22c7264cf27b0d2364c675c3ca811aa6c25fb01b9f70'
+sha256sums=('040e834ac94dd5246f9d77a66f7b43c43c62f538d00b5f94597534dc1db77616'
             'SKIP'
             'de5c0deb9b6a4ebfaa933103cc6a65f1f43c9a456296d356cc54c7ca042d144c'
-            '1975dba8663744e5757a7398899fe94dd50ba33adfe122d6cfb69d8480de9c3a'
-            'f9ef09f06f8400a11974d9ac39b14ea9646b9adcccbceb1466076d1d70986260'
+            'af74351c70fa0121600889598ec8d10aeab65bde1b8cd0c79fac7c54e2058ae3'
+            '7dac91042b2645013cf9d7208656a6e36037c9ff527a0143d4154cb1ba9eb651'
             '1fbb1971a1d0d4c875b1af0f9681601909cfbe4fe0cc2c2f42c523c84c934499')
 validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
 


### PR DESCRIPTION
- Also remove inetutils from makedepends per https://gitlab.archlinux.org/archlinux/packaging/packages/firefox/-/commit/1060ad6cb929f602230199d8029e243e098ce6e3.
- **WIP**: Update settings https://github.com/CachyOS/CachyOS-Browser-Common/pull/10.