### PR TITLE
cachyos-settings: Remove old optional dependencies

### DIFF
--- a/cachyos-settings/.SRCINFO
+++ b/cachyos-settings/.SRCINFO
@@ -13,10 +13,8 @@ pkgbase = cachyos-settings
 	depends = cachyos-ananicy-rules
 	depends = inxi
 	depends = systemd>=256
-	optdepends = ruby: for tunecfs2
 	optdepends = libluv: for topmem
 	optdepends = lua-luv: for topmem
-	optdepends = irqbalance
 	optdepends = power-profiles-daemon: For game-performance
 	source = git+https://github.com/cachyos/CachyOS-Settings?signed#tag=1.1.2
 	validpgpkeys = E8B9AA39F054E30E8290D492C3C4820857F654FE

--- a/cachyos-settings/PKGBUILD
+++ b/cachyos-settings/PKGBUILD
@@ -23,10 +23,8 @@ depends=(
   inxi
   "systemd>=256"
 )
-optdepends=('ruby: for tunecfs2'
-            'libluv: for topmem'
+optdepends=('libluv: for topmem'
             'lua-luv: for topmem'
-            'irqbalance'
             'power-profiles-daemon: For game-performance')
 
 package() {


### PR DESCRIPTION
tunecfs2 and irqbalance has been dropped from cachyos-settings for quite a while now.