### PR TITLE
cachyos-ananicy-rules: Use HEAD instead of specific commits

### DIFF
--- a/cachyos-ananicy-rules/.SRCINFO
+++ b/cachyos-ananicy-rules/.SRCINFO
@@ -8,7 +8,7 @@ pkgbase = cachyos-ananicy-rules
 	provides = ananicy-rules-git
 	conflicts = ananicy-rules-git
 	replaces = ananicy-rules-git
-	source = cachyos-ananicy-rules::git+https://github.com/CachyOS/ananicy-rules.git#commit=44a13936cccb3a5d09cbd3c641338fca515e0394
-	sha256sums = 80f024c817f72debaf69e6b1019f0dbd88a3ff3a4f79059f62be74b9d15182a8
+	source = cachyos-ananicy-rules::git+https://github.com/CachyOS/ananicy-rules.git
+	sha256sums = SKIP
 
 pkgname = cachyos-ananicy-rules

--- a/cachyos-ananicy-rules/PKGBUILD
+++ b/cachyos-ananicy-rules/PKGBUILD
@@ -10,9 +10,8 @@ groups=(cachyos)
 arch=('any')
 license=(GPL-1.0-only)
 pkgdesc='CachyOS - ananicy-rules'
-_commit=44a13936cccb3a5d09cbd3c641338fca515e0394
-source=("${pkgname}::git+https://github.com/CachyOS/${_gitname}.git#commit=${_commit}")
-sha256sums=('80f024c817f72debaf69e6b1019f0dbd88a3ff3a4f79059f62be74b9d15182a8')
+source=("${pkgname}::git+https://github.com/CachyOS/${_gitname}.git")
+sha256sums=('SKIP')
 replaces=(ananicy-rules-git)
 provides=(ananicy-rules-git)
 conflicts=(ananicy-rules-git)


### PR DESCRIPTION
This avoids the need of bumping the commit everytime there's an update and updating the PKGBUILD for it. We can also integrate this to https://github.com/CachyOS/PKGBUILDS-git/ for less maintenance burden.

Merge with https://github.com/CachyOS/PKGBUILDS-git/pull/1