### PR TITLE
chwd: Cherrypick amd profile update due recent mesa changes

### DIFF
--- a/chwd/.SRCINFO
+++ b/chwd/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = chwd
 	pkgdesc = CachyOS Hardware Detection Tool
 	pkgver = 1.10.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/cachyos/chwd
 	arch = x86_64
 	groups = cachyos
@@ -19,6 +19,8 @@ pkgbase = chwd
 	conflicts = chwd-db
 	replaces = chwd-db
 	source = chwd-1.10.1.tar.gz::https://github.com/cachyos/chwd/archive/1.10.1.tar.gz
+	source = mesa-fix.patch::https://github.com/CachyOS/chwd/commit/0953acc44dc6abf670f11611bdb406ede7c2a656.patch
 	sha256sums = 17a9450f66d62b3f7668230ff00cb9f89d623ee968631a0f30db3c09845b2569
+	sha256sums = 295f31029888e55887ff3c29bf9c2ea81ce993bf76d2383d814237db10ff59fe
 
 pkgname = chwd

--- a/chwd/PKGBUILD
+++ b/chwd/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=chwd
 pkgver=1.10.1
-pkgrel=1
+pkgrel=2
 pkgdesc="CachyOS Hardware Detection Tool"
 arch=(x86_64)
 url="https://github.com/cachyos/chwd"
@@ -14,11 +14,17 @@ provides=('chwd-db')
 replaces=('chwd-db')
 conflicts=('chwd-db')
 groups=('cachyos')
-source=("chwd-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
-sha256sums=('17a9450f66d62b3f7668230ff00cb9f89d623ee968631a0f30db3c09845b2569')
+source=("chwd-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz"
+        "mesa-fix.patch::https://github.com/CachyOS/chwd/commit/0953acc44dc6abf670f11611bdb406ede7c2a656.patch")
+sha256sums=('17a9450f66d62b3f7668230ff00cb9f89d623ee968631a0f30db3c09845b2569'
+            '295f31029888e55887ff3c29bf9c2ea81ce993bf76d2383d814237db10ff59fe')
 
 prepare() {
   cd "$srcdir/$pkgname-$pkgver"
+
+  msg2 "Cherrypick amd profile update due to recent mesa packaging changes"
+  patch -Np1 < ../mesa-fix.patch
+
   cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 
   cd scripts/chwd-kernel


### PR DESCRIPTION
This should also fix chwd failing in ISO installs since it won't fetch the obsolete packages anymore.