### PR TITLE
nvidia-550xx: Make it conflict with default drivers

### DIFF
--- a/nvidia/nvidia-550xx/nvidia-550xx-dkms/.SRCINFO
+++ b/nvidia/nvidia-550xx/nvidia-550xx-dkms/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nvidia-550xx-dkms
 	pkgver = 550.127.05
-	pkgrel = 1
+	pkgrel = 2
 	url = http://www.nvidia.com/
 	arch = x86_64
 	license = custom
@@ -34,6 +34,7 @@ pkgname = nvidia-550xx-utils
 	provides = nvidia-libgl
 	provides = nvidia-utils=550.127.05
 	conflicts = nvidia-libgl
+	conflicts = nvidia-utils
 	replaces = nvidia-libgl
 
 pkgname = opencl-550xx-nvidia
@@ -41,6 +42,7 @@ pkgname = opencl-550xx-nvidia
 	depends = zlib
 	optdepends = opencl-headers: headers necessary for OpenCL development
 	provides = opencl-driver
+	conflicts = opencl-nvidia
 
 pkgname = nvidia-550xx-dkms
 	pkgdesc = NVIDIA drivers 550 - module sources

--- a/nvidia/nvidia-550xx/nvidia-550xx-dkms/PKGBUILD
+++ b/nvidia/nvidia-550xx/nvidia-550xx-dkms/PKGBUILD
@@ -8,7 +8,7 @@
 pkgbase=nvidia-550xx-dkms
 pkgname=('nvidia-550xx-utils' 'opencl-550xx-nvidia' 'nvidia-550xx-dkms')
 pkgver=550.127.05
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom')
@@ -69,6 +69,7 @@ package_opencl-550xx-nvidia() {
     depends=('zlib')
     optdepends=('opencl-headers: headers necessary for OpenCL development')
     provides=('opencl-driver')
+    conflicts=('opencl-nvidia')
     cd "${_pkg}"
 
     # OpenCL
@@ -102,7 +103,7 @@ package_nvidia-550xx-utils() {
                 'xorg-server: Xorg support'
                 'xorg-server-devel: nvidia-xconfig'
                 'opencl-nvidia: OpenCL support')
-    conflicts=('nvidia-libgl')
+    conflicts=('nvidia-libgl' 'nvidia-utils')
     provides=('vulkan-driver' 'opengl-driver' 'nvidia-libgl' "nvidia-utils=${pkgver}")
     replaces=('nvidia-libgl')
     install="nvidia-utils.install"


### PR DESCRIPTION
This is needed for systems to be able to replace the NVIDIA drivers correctly without invoking a forced removal (-Rdd).