### PR TITLE
mesa: 24.3.0-1

### DIFF
--- a/mesa/lib32-mesa/.SRCINFO
+++ b/mesa/lib32-mesa/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = lib32-mesa
 	pkgdesc = Open-source OpenGL drivers - 32-bit
-	pkgver = 24.2.7
-	pkgrel = 2
+	pkgver = 24.3.0
+	pkgrel = 1
 	epoch = 1
 	url = https://www.mesa3d.org/
 	arch = x86_64
@@ -50,8 +50,8 @@ pkgbase = lib32-mesa
 	makedepends = wayland-protocols
 	makedepends = xorgproto
 	options = !lto
-	source = https://mesa.freedesktop.org/archive/mesa-24.2.7.tar.xz
-	source = https://mesa.freedesktop.org/archive/mesa-24.2.7.tar.xz.sig
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz.sig
 	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31443.patch
 	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31505.patch
 	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31891.patch
@@ -76,7 +76,7 @@ pkgbase = lib32-mesa
 	validpgpkeys = 57551DE15B968F6341C248F68D8E31AFC32428A6
 	validpgpkeys = A5CC9FEC93F2F837CB044912336909B6B25FADFA
 	validpgpkeys = E3E8F480C52ADD73B278EE78E1ECBE07D7D70895
-	sha256sums = a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd
+	sha256sums = 97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc
 	sha256sums = SKIP
 	sha256sums = 22581baa9db479709b7f1592ebb6c034b7e62bca265b5afc2fbe48f9e5521feb
 	sha256sums = 01172dbf3916960aaddd5023993c43f5f759d5dce56725104b5902f8d901dbd5
@@ -96,7 +96,7 @@ pkgbase = lib32-mesa
 	sha256sums = 3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183
 	sha256sums = 692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56
 	sha256sums = 901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9
-	b2sums = eb1b0285e14e77c3140275b322ff084fca74a1048e6df38f4b14cb03ed7fc436897f7b33d107d1e262d9d4944229fb1e85d02e731c645ead5a7b269dec9334b7
+	b2sums = 43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec
 	b2sums = SKIP
 	b2sums = 7883601fa9e03ecdd808d77c39f8e62c4911c88cc4e12818578c60edead74f8223628133225ba555a3cef13f439e3c05df99cba0a5b344f23e4fe5162c97279f
 	b2sums = 83439bf1339b615dbb13d786b93ab364a8b7f326fc3cec83455d2b8e767162cdfdfbe960a5bbc66065a85881713fbe7bf01d665bebad7068f3f530e4668a61ce
@@ -137,9 +137,9 @@ pkgname = lib32-mesa
 	depends = lib32-zstd
 	depends = mesa
 	optdepends = opengl-man-pages: for the OpenGL API man pages
-	provides = lib32-libva-mesa-driver=1:24.2.7-2
-	provides = lib32-mesa-libgl=1:24.2.7-2
-	provides = lib32-mesa-vdpau=1:24.2.7-2
+	provides = lib32-libva-mesa-driver=1:24.3.0-1
+	provides = lib32-mesa-libgl=1:24.3.0-1
+	provides = lib32-mesa-vdpau=1:24.3.0-1
 	provides = lib32-libva-driver
 	provides = lib32-opengl-driver
 	provides = lib32-vdpau-driver

--- a/mesa/lib32-mesa/PKGBUILD
+++ b/mesa/lib32-mesa/PKGBUILD
@@ -20,8 +20,8 @@ pkgname=(
   lib32-vulkan-swrast
   lib32-vulkan-virtio
 )
-pkgver=24.2.7
-pkgrel=2
+pkgver=24.3.0
+pkgrel=1
 epoch=1
 pkgdesc="Open-source OpenGL drivers - 32-bit"
 url="https://www.mesa3d.org/"
@@ -122,7 +122,7 @@ for _crate in "${!_crates[@]}"; do
   )
 done
 
-sha256sums=('a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd'
+sha256sums=('97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc'
             'SKIP'
             '22581baa9db479709b7f1592ebb6c034b7e62bca265b5afc2fbe48f9e5521feb'
             '01172dbf3916960aaddd5023993c43f5f759d5dce56725104b5902f8d901dbd5'
@@ -142,7 +142,7 @@ sha256sums=('a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd'
             '3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183'
             '692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56'
             '901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9')
-b2sums=('eb1b0285e14e77c3140275b322ff084fca74a1048e6df38f4b14cb03ed7fc436897f7b33d107d1e262d9d4944229fb1e85d02e731c645ead5a7b269dec9334b7'
+b2sums=('43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec'
         'SKIP'
         '7883601fa9e03ecdd808d77c39f8e62c4911c88cc4e12818578c60edead74f8223628133225ba555a3cef13f439e3c05df99cba0a5b344f23e4fe5162c97279f'
         '83439bf1339b615dbb13d786b93ab364a8b7f326fc3cec83455d2b8e767162cdfdfbe960a5bbc66065a85881713fbe7bf01d665bebad7068f3f530e4668a61ce'
@@ -168,13 +168,6 @@ b2sums=('eb1b0285e14e77c3140275b322ff084fca74a1048e6df38f4b14cb03ed7fc436897f7b3
 prepare() {
   cd mesa-$pkgver
 
-  msg2 "RADV: Improve RT performance"
-  patch -Np1 < ../31443.patch
-  msg2 "RADV: Fix DEQP crash (#11953)"
-  patch -Np1 < ../31505.patch
-  msg2 "RADV: Fix massive performance issue with FSR2"
-  patch -Np1 < ../31891.patch
-
   # Include package release in version string so Chromium invalidates
   # its GPU cache; otherwise it can cause pages to render incorrectly.
   # https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/2020604
@@ -189,7 +182,6 @@ build() {
     -D gallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,llvmpipe,softpipe,iris,crocus,i915,zink
     -D gallium-extra-hud=true
     -D gallium-nine=true
-    -D gallium-omx=disabled
     -D gallium-opencl=icd
     -D gallium-rusticl=true
     -D gles1=disabled

--- a/mesa/mesa/.SRCINFO
+++ b/mesa/mesa/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = mesa
 	pkgdesc = Open-source OpenGL drivers
-	pkgver = 24.2.7
-	pkgrel = 2
+	pkgver = 24.3.0
+	pkgrel = 1
 	epoch = 1
 	url = https://www.mesa3d.org/
 	arch = x86_64
@@ -55,11 +55,8 @@ pkgbase = mesa
 	makedepends = python-sphinx
 	makedepends = python-sphinx-hawkmoth
 	options = !lto
-	source = https://mesa.freedesktop.org/archive/mesa-24.2.7.tar.xz
-	source = https://mesa.freedesktop.org/archive/mesa-24.2.7.tar.xz.sig
-	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31443.patch
-	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31505.patch
-	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31891.patch
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz.sig
 	source = ucd-trie-0.1.6.tar.gz::https://crates.io/api/v1/crates/ucd-trie/0.1.6/download
 	source = pest_meta-2.7.11.tar.gz::https://crates.io/api/v1/crates/pest_meta/2.7.11/download
 	source = indexmap-2.2.6.tar.gz::https://crates.io/api/v1/crates/indexmap/2.2.6/download
@@ -81,11 +78,8 @@ pkgbase = mesa
 	validpgpkeys = 57551DE15B968F6341C248F68D8E31AFC32428A6
 	validpgpkeys = A5CC9FEC93F2F837CB044912336909B6B25FADFA
 	validpgpkeys = E3E8F480C52ADD73B278EE78E1ECBE07D7D70895
-	sha256sums = a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd
+	sha256sums = 97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc
 	sha256sums = SKIP
-	sha256sums = 22581baa9db479709b7f1592ebb6c034b7e62bca265b5afc2fbe48f9e5521feb
-	sha256sums = 01172dbf3916960aaddd5023993c43f5f759d5dce56725104b5902f8d901dbd5
-	sha256sums = 91726198267482d255fef507a38a2265e3e304d8139df5f664dd82d940b20e14
 	sha256sums = ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9
 	sha256sums = a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f
 	sha256sums = 168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26
@@ -101,11 +95,8 @@ pkgbase = mesa
 	sha256sums = 3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183
 	sha256sums = 692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56
 	sha256sums = 901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9
-	b2sums = eb1b0285e14e77c3140275b322ff084fca74a1048e6df38f4b14cb03ed7fc436897f7b33d107d1e262d9d4944229fb1e85d02e731c645ead5a7b269dec9334b7
+	b2sums = 43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec
 	b2sums = SKIP
-	b2sums = 7883601fa9e03ecdd808d77c39f8e62c4911c88cc4e12818578c60edead74f8223628133225ba555a3cef13f439e3c05df99cba0a5b344f23e4fe5162c97279f
-	b2sums = 83439bf1339b615dbb13d786b93ab364a8b7f326fc3cec83455d2b8e767162cdfdfbe960a5bbc66065a85881713fbe7bf01d665bebad7068f3f530e4668a61ce
-	b2sums = fc6418d4bc839f2e4c9144300ac208fbcd637f571c82748cd2f6c4fd19618e2bab3f422c41c0dd540b1057b85fd28b4164c049b9db7e6a37db9d32635b62d18f
 	b2sums = a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823
 	b2sums = 9c34f1ab14ad5ae124882513e0f14b1d731d06a43203bdc37fa3b202dd3ce93dbe8ebb554d01bab475689fe6ffd3ec0cbc0d5365c9b984cb83fb34ea3e9e732e
 	b2sums = fac5cf6339dc3c0a40b100035a5c874cc7b2efeafeb31c51488d25156e392dc9db86a497e76eead351d2126f69d060422faa9c55d73407a0de9f5be18d234123
@@ -142,9 +133,9 @@ pkgname = mesa
 	depends = zstd
 	depends = libomxil-bellagio
 	optdepends = opengl-man-pages: for the OpenGL API man pages
-	provides = libva-mesa-driver=1:24.2.7-2
-	provides = mesa-libgl=1:24.2.7-2
-	provides = mesa-vdpau=1:24.2.7-2
+	provides = libva-mesa-driver=1:24.3.0-1
+	provides = mesa-libgl=1:24.3.0-1
+	provides = mesa-vdpau=1:24.3.0-1
 	provides = libva-driver
 	provides = opengl-driver
 	provides = vdpau-driver

--- a/mesa/mesa/PKGBUILD
+++ b/mesa/mesa/PKGBUILD
@@ -21,8 +21,8 @@ pkgname=(
   vulkan-virtio
   mesa-docs
 )
-pkgver=24.2.7
-pkgrel=2
+pkgver=24.3.0
+pkgrel=1
 epoch=1
 pkgdesc="Open-source OpenGL drivers"
 url="https://www.mesa3d.org/"
@@ -97,9 +97,6 @@ options=(
 )
 source=(
   "https://mesa.freedesktop.org/archive/mesa-$pkgver.tar.xz"{,.sig}
-  "https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31443.patch"
-  "https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31505.patch"
-  "https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/31891.patch"
 )
 validpgpkeys=(
   946D09B5E4C9845E63075FF1D961C596A7203456 # Andres Gomez <tanty@igalia.com>
@@ -136,11 +133,8 @@ for _crate in "${!_crates[@]}"; do
   )
 done
 
-sha256sums=('a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd'
+sha256sums=('97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc'
             'SKIP'
-            '22581baa9db479709b7f1592ebb6c034b7e62bca265b5afc2fbe48f9e5521feb'
-            '01172dbf3916960aaddd5023993c43f5f759d5dce56725104b5902f8d901dbd5'
-            '91726198267482d255fef507a38a2265e3e304d8139df5f664dd82d940b20e14'
             'ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9'
             'a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f'
             '168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26'
@@ -156,11 +150,8 @@ sha256sums=('a0ce37228679647268a83b3652d859dcf23d6f6430d751489d4464f6de6459fd'
             '3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183'
             '692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56'
             '901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9')
-b2sums=('eb1b0285e14e77c3140275b322ff084fca74a1048e6df38f4b14cb03ed7fc436897f7b33d107d1e262d9d4944229fb1e85d02e731c645ead5a7b269dec9334b7'
+b2sums=('43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec'
         'SKIP'
-        '7883601fa9e03ecdd808d77c39f8e62c4911c88cc4e12818578c60edead74f8223628133225ba555a3cef13f439e3c05df99cba0a5b344f23e4fe5162c97279f'
-        '83439bf1339b615dbb13d786b93ab364a8b7f326fc3cec83455d2b8e767162cdfdfbe960a5bbc66065a85881713fbe7bf01d665bebad7068f3f530e4668a61ce'
-        'fc6418d4bc839f2e4c9144300ac208fbcd637f571c82748cd2f6c4fd19618e2bab3f422c41c0dd540b1057b85fd28b4164c049b9db7e6a37db9d32635b62d18f'
         'a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823'
         '9c34f1ab14ad5ae124882513e0f14b1d731d06a43203bdc37fa3b202dd3ce93dbe8ebb554d01bab475689fe6ffd3ec0cbc0d5365c9b984cb83fb34ea3e9e732e'
         'fac5cf6339dc3c0a40b100035a5c874cc7b2efeafeb31c51488d25156e392dc9db86a497e76eead351d2126f69d060422faa9c55d73407a0de9f5be18d234123'
@@ -182,13 +173,6 @@ b2sums=('eb1b0285e14e77c3140275b322ff084fca74a1048e6df38f4b14cb03ed7fc436897f7b3
 prepare() {
   cd mesa-$pkgver
 
-  msg2 "RADV: Improve RT performance"
-  patch -Np1 < ../31443.patch
-  msg2 "RADV: Fix DEQP crash (#11953)"
-  patch -Np1 < ../31505.patch
-  msg2 "RADV: Fix massive performance issue with FSR2"
-  patch -Np1 < ../31891.patch
-
   # Include package release in version string so Chromium invalidates
   # its GPU cache; otherwise it can cause pages to render incorrectly.
   # https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/2020604
@@ -202,7 +186,6 @@ build() {
     -D gallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,llvmpipe,softpipe,iris,crocus,i915,zink,d3d12
     -D gallium-extra-hud=true
     -D gallium-nine=true
-    -D gallium-omx=bellagio
     -D gallium-opencl=icd
     -D gallium-rusticl=true
     -D gles1=disabled


### PR DESCRIPTION
Updated for mesa 24.3.0 and needs some testing.
We maybe want to also wait for archlinux to update their PKGBUILD and then sync it. Compilation was successful and the size got around 10mb lowers each - maybe because the gallium-omx driver was removed.