### PR TITLE
mesa: 24.3.1

### DIFF
--- a/mesa/lib32-mesa/.SRCINFO
+++ b/mesa/lib32-mesa/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lib32-mesa
 	pkgdesc = Open-source OpenGL drivers - 32-bit
-	pkgver = 24.3.0
+	pkgver = 24.3.1
 	pkgrel = 2
 	epoch = 1
 	url = https://www.mesa3d.org/
@@ -50,8 +50,8 @@ pkgbase = lib32-mesa
 	makedepends = wayland-protocols
 	makedepends = xorgproto
 	options = !lto
-	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz
-	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz.sig
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.1.tar.xz
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.1.tar.xz.sig
 	source = ucd-trie-0.1.6.tar.gz::https://crates.io/api/v1/crates/ucd-trie/0.1.6/download
 	source = pest_meta-2.7.11.tar.gz::https://crates.io/api/v1/crates/pest_meta/2.7.11/download
 	source = indexmap-2.2.6.tar.gz::https://crates.io/api/v1/crates/indexmap/2.2.6/download
@@ -73,7 +73,7 @@ pkgbase = lib32-mesa
 	validpgpkeys = 57551DE15B968F6341C248F68D8E31AFC32428A6
 	validpgpkeys = A5CC9FEC93F2F837CB044912336909B6B25FADFA
 	validpgpkeys = E3E8F480C52ADD73B278EE78E1ECBE07D7D70895
-	sha256sums = 97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc
+	sha256sums = 9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af
 	sha256sums = SKIP
 	sha256sums = ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9
 	sha256sums = a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f
@@ -90,7 +90,7 @@ pkgbase = lib32-mesa
 	sha256sums = 3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183
 	sha256sums = 692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56
 	sha256sums = 901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9
-	b2sums = 43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec
+	b2sums = d3efc322388e29f651b15b0396fef8a6acc0cf24881165900845e429dd6cb53d51511f174d6a4017f48962b764b9a42f069825196af9f4ca969a4b46e1108a0e
 	b2sums = SKIP
 	b2sums = a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823
 	b2sums = 9c34f1ab14ad5ae124882513e0f14b1d731d06a43203bdc37fa3b202dd3ce93dbe8ebb554d01bab475689fe6ffd3ec0cbc0d5365c9b984cb83fb34ea3e9e732e
@@ -128,9 +128,9 @@ pkgname = lib32-mesa
 	depends = lib32-zstd
 	depends = mesa
 	optdepends = opengl-man-pages: for the OpenGL API man pages
-	provides = lib32-libva-mesa-driver=1:24.3.0-2
-	provides = lib32-mesa-libgl=1:24.3.0-2
-	provides = lib32-mesa-vdpau=1:24.3.0-2
+	provides = lib32-libva-mesa-driver=1:24.3.1-2
+	provides = lib32-mesa-libgl=1:24.3.1-2
+	provides = lib32-mesa-vdpau=1:24.3.1-2
 	provides = lib32-libva-driver
 	provides = lib32-opengl-driver
 	provides = lib32-vdpau-driver

--- a/mesa/lib32-mesa/PKGBUILD
+++ b/mesa/lib32-mesa/PKGBUILD
@@ -20,7 +20,7 @@ pkgname=(
   lib32-vulkan-swrast
   lib32-vulkan-virtio
 )
-pkgver=24.3.0
+pkgver=24.3.1
 pkgrel=2
 epoch=1
 pkgdesc="Open-source OpenGL drivers - 32-bit"
@@ -119,7 +119,7 @@ for _crate in "${!_crates[@]}"; do
   )
 done
 
-b2sums=('43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec'
+b2sums=('d3efc322388e29f651b15b0396fef8a6acc0cf24881165900845e429dd6cb53d51511f174d6a4017f48962b764b9a42f069825196af9f4ca969a4b46e1108a0e'
         'SKIP'
         'a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823'
         '9c34f1ab14ad5ae124882513e0f14b1d731d06a43203bdc37fa3b202dd3ce93dbe8ebb554d01bab475689fe6ffd3ec0cbc0d5365c9b984cb83fb34ea3e9e732e'
@@ -138,7 +138,7 @@ b2sums=('43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f519
         '8bc6f68ed286bea617a2cfaf3949bb699d3a0466faeca735314a51596ce950e4ee57eda88154bd562c1728cfaff4cdb5bc1ba701b9d47a9c50d4c4f011bee975')
 
 # https://docs.mesa3d.org/relnotes.html
-sha256sums=('97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc'
+sha256sums=('9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af'
             'SKIP'
             'ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9'
             'a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f'

--- a/mesa/mesa/.SRCINFO
+++ b/mesa/mesa/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = mesa
 	pkgdesc = Open-source OpenGL drivers
-	pkgver = 24.3.0
+	pkgver = 24.3.1
 	pkgrel = 2
 	epoch = 1
 	url = https://www.mesa3d.org/
@@ -55,8 +55,8 @@ pkgbase = mesa
 	makedepends = python-sphinx
 	makedepends = python-sphinx-hawkmoth
 	options = !lto
-	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz
-	source = https://mesa.freedesktop.org/archive/mesa-24.3.0.tar.xz.sig
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.1.tar.xz
+	source = https://mesa.freedesktop.org/archive/mesa-24.3.1.tar.xz.sig
 	source = ucd-trie-0.1.6.tar.gz::https://crates.io/api/v1/crates/ucd-trie/0.1.6/download
 	source = pest_meta-2.7.11.tar.gz::https://crates.io/api/v1/crates/pest_meta/2.7.11/download
 	source = indexmap-2.2.6.tar.gz::https://crates.io/api/v1/crates/indexmap/2.2.6/download
@@ -78,7 +78,7 @@ pkgbase = mesa
 	validpgpkeys = 57551DE15B968F6341C248F68D8E31AFC32428A6
 	validpgpkeys = A5CC9FEC93F2F837CB044912336909B6B25FADFA
 	validpgpkeys = E3E8F480C52ADD73B278EE78E1ECBE07D7D70895
-	sha256sums = 97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc
+	sha256sums = 9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af
 	sha256sums = SKIP
 	sha256sums = ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9
 	sha256sums = a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f
@@ -95,7 +95,7 @@ pkgbase = mesa
 	sha256sums = 3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183
 	sha256sums = 692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56
 	sha256sums = 901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9
-	b2sums = 43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec
+	b2sums = d3efc322388e29f651b15b0396fef8a6acc0cf24881165900845e429dd6cb53d51511f174d6a4017f48962b764b9a42f069825196af9f4ca969a4b46e1108a0e
 	b2sums = SKIP
 	b2sums = a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823
 	b2sums = 9c34f1ab14ad5ae124882513e0f14b1d731d06a43203bdc37fa3b202dd3ce93dbe8ebb554d01bab475689fe6ffd3ec0cbc0d5365c9b984cb83fb34ea3e9e732e
@@ -132,9 +132,9 @@ pkgname = mesa
 	depends = zlib
 	depends = zstd
 	optdepends = opengl-man-pages: for the OpenGL API man pages
-	provides = libva-mesa-driver=1:24.3.0-2
-	provides = mesa-libgl=1:24.3.0-2
-	provides = mesa-vdpau=1:24.3.0-2
+	provides = libva-mesa-driver=1:24.3.1-2
+	provides = mesa-libgl=1:24.3.1-2
+	provides = mesa-vdpau=1:24.3.1-2
 	provides = libva-driver
 	provides = opengl-driver
 	provides = vdpau-driver

--- a/mesa/mesa/PKGBUILD
+++ b/mesa/mesa/PKGBUILD
@@ -21,7 +21,7 @@ pkgname=(
   vulkan-virtio
   mesa-docs
 )
-pkgver=24.3.0
+pkgver=24.3.1
 pkgrel=2
 epoch=1
 pkgdesc="Open-source OpenGL drivers"
@@ -131,7 +131,7 @@ for _crate in "${!_crates[@]}"; do
   )
 done
 
-b2sums=('43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f5194a56a33463eb0b0de8f7f32e4fd2b0dc06cc2f83b27d01bca611f26ec'
+b2sums=('d3efc322388e29f651b15b0396fef8a6acc0cf24881165900845e429dd6cb53d51511f174d6a4017f48962b764b9a42f069825196af9f4ca969a4b46e1108a0e'
         'SKIP'
         'a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823'
         '9c34f1ab14ad5ae124882513e0f14b1d731d06a43203bdc37fa3b202dd3ce93dbe8ebb554d01bab475689fe6ffd3ec0cbc0d5365c9b984cb83fb34ea3e9e732e'
@@ -150,7 +150,7 @@ b2sums=('43977028609e1be35849e5b72d5cdfbe2052ce959ec43dd649fbf2f3d0f262fbbc3f519
         '8bc6f68ed286bea617a2cfaf3949bb699d3a0466faeca735314a51596ce950e4ee57eda88154bd562c1728cfaff4cdb5bc1ba701b9d47a9c50d4c4f011bee975')
 
 # https://docs.mesa3d.org/relnotes.html
-sha256sums=('97813fe65028ef21b4d4e54164563059e8408d8fee3489a2323468d198bf2efc'
+sha256sums=('9c795900449ce5bc7c526ba0ab3532a22c3c951cab7e0dd9de5fcac41b0843af'
             'SKIP'
             'ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9'
             'a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f'


### PR DESCRIPTION
Removed the b2sums array. Refer to commit log for rationale. It's controversial so let me know if you don't want this.