### PR TITLE
[kde-settings] Move depend package to optional

### DIFF
--- a/cachyos-kde-settings/PKGBUILD
+++ b/cachyos-kde-settings/PKGBUILD
@@ -15,7 +15,9 @@ depends=('ttf-fantasque-nerd'
     'noto-fonts'
     'ttf-fira-sans'
     'capitaine-cursors'
-    'cachyos-alacritty-config'
+)
+optdepends=(
+  'cachyos-alacritty-config'
 )
 install=$pkgname.install
 provides=('cachyos-desktop-settings')


### PR DESCRIPTION
Konsole is installed by default and Alacritty itself is optional in the installer.  No need to store config files for a program that likely isn't installed.  Make Alacritty depend the config not the DE config.