### PR TITLE
cachyos-settings: Do not explicitly enable systemd-resolved after pac…

### DIFF
--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -16,6 +16,4 @@ post_upgrade() {
         fi
 
     done
-    # Enable systemd-resolved only once for the upcoming upgrade
-    systemctl enable systemd-resolved
 }


### PR DESCRIPTION
…kage update

It is sufficient to only enable systemd-resolved during first installs. Force enabling the service every update can be very annoying for users who explicitly do not want to use systemd-resolved for their DNS resolver.