### PR TITLE
Fix file permissions of Pacman mirrorlist files in case of more restrictive umask

### DIFF
--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -156,3 +156,9 @@ cp -f --backup=simple --suffix="-backup" "${MIRRORS_DEFAULT_DIR}/cachyos-mirrorl
 
 sed -i 's|/$arch/|/$arch_v3/|g' "${MIRRORS_DEFAULT_DIR}/cachyos-v3-mirrorlist"
 sed -i 's|/$arch/|/$arch_v4/|g' "${MIRRORS_DEFAULT_DIR}/cachyos-v4-mirrorlist"
+
+# In the case of a more restrictive umask setting ( 0077 for example ), give read-permissions back to 'Group/Other'.
+# This fixes a case where the third party package wrapper Aura ( https://github.com/fosskers/aura ) tries to parse
+# /etc/pacman.conf and can't read the "include"ded mirror files. By default, Aura intentionally runs without root
+# permissions for most non-modify operations.
+chmod go+r ${MIRRORS_DEFAULT_DIR}/*mirrorlist*

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -161,4 +161,4 @@ sed -i 's|/$arch/|/$arch_v4/|g' "${MIRRORS_DEFAULT_DIR}/cachyos-v4-mirrorlist"
 # This fixes a case where the third party package wrapper Aura ( https://github.com/fosskers/aura ) tries to parse
 # /etc/pacman.conf and can't read the "include"ded mirror files. By default, Aura intentionally runs without root
 # permissions for most non-modify operations.
-chmod go+r ${MIRRORS_DEFAULT_DIR}/*mirrorlist*
+chmod go+r "${MIRRORS_DEFAULT_DIR}"/*mirrorlist*


### PR DESCRIPTION
Fix read permissions for Group/Other in case of more restrictive umask settings after a 'cachyos-rate-mirrors' run. Required to make third party package managers like Aura work properly.