### PR TITLE
feat: Introduce lib32-gamescope-plus

### DIFF
--- a/handheld/cachyos-handheld/.SRCINFO
+++ b/handheld/cachyos-handheld/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-handheld
 	pkgdesc = CachyOS - Handheld!
 	pkgver = 1.0.6
-	pkgrel = 1
+	pkgrel = 2
 	install = cachyos-handheld.install
 	arch = any
 	license = GPL-3.0-later
@@ -19,6 +19,7 @@ pkgbase = cachyos-handheld
 	depends = gamescope-session-steam-git
 	depends = jupiter-hw-support
 	depends = gamescope-plus
+	depends = lib32-gamescope-plus
 	depends = cachyos-vapor
 	depends = cachyos-alacritty-config
 	depends = wine-cachyos

--- a/handheld/cachyos-handheld/PKGBUILD
+++ b/handheld/cachyos-handheld/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cachyos-handheld
 pkgver=1.0.6
-pkgrel=1
+pkgrel=2
 arch=('any')
 license=('GPL-3.0-later')
 pkgdesc='CachyOS - Handheld!'
@@ -19,7 +19,7 @@ validpgpkeys=(
 
 depends=('gamescope-session-git' 'mangohud' 'jq' 'dmidecode' 'glew' 'glfw' 'glxinfo' 'curl' 'tar'
          'scx-scheds' 'qt5-tools' 'gamescope-session-steam-git' 'jupiter-hw-support'
-         'gamescope-plus' 'cachyos-vapor' 'cachyos-alacritty-config'
+         'gamescope-plus' 'lib32-gamescope-plus' 'cachyos-vapor' 'cachyos-alacritty-config'
          # Common dependecies
          wine-cachyos giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls
          lib32-gnutls mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils

--- a/handheld/lib32-gamescope-plus/.SRCINFO
+++ b/handheld/lib32-gamescope-plus/.SRCINFO
@@ -1,0 +1,21 @@
+pkgbase = lib32-gamescope-plus
+	pkgdesc = WSI Layer for use with gamescope (32-bit)
+	pkgver = 3.15.13.plus1
+	pkgrel = 1
+	url = https://github.com/ChimeraOS/gamescope
+	arch = x86_64
+	license = MIT
+	makedepends = cmake
+	makedepends = meson
+	makedepends = ninja
+	makedepends = wayland-protocols
+	makedepends = vulkan-headers
+	makedepends = lib32-glm
+	depends = lib32-wayland
+	depends = lib32-libx11
+	depends = lib32-libxcb
+	depends = lib32-vulkan-icd-loader
+	source = lib32-gamescope-plus-3.15.13.plus1::git+https://github.com/ChimeraOS/gamescope#tag=3.15.13.plus1
+	sha256sums = 2d3deeacc515e45e90c51535c171fe0d36f1d0e3a62127ec54997b213eb08c23
+
+pkgname = lib32-gamescope-plus

--- a/handheld/lib32-gamescope-plus/PKGBUILD
+++ b/handheld/lib32-gamescope-plus/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Eric Naim <dnaim@cachyos.org>
+# Contributor: Matthew Schwartz <matthew.schwartz@linux.dev>
+
+pkgname=lib32-gamescope-plus
+pkgver=3.15.13.plus1
+pkgrel=1
+pkgdesc="WSI Layer for use with gamescope (32-bit)"
+arch=(x86_64)
+url="https://github.com/ChimeraOS/gamescope"
+license=('BSD-2-Clause')
+depends=(
+    'lib32-wayland'
+    'lib32-libx11'
+    'lib32-libxcb'
+    'lib32-vulkan-icd-loader')
+makedepends=(
+    'cmake'
+    'meson'
+    'ninja'
+    'wayland-protocols'
+    'vulkan-headers'
+    'lib32-glm')
+source=("git+${url}#tag=${pkgver}")
+sha256sums=('2d3deeacc515e45e90c51535c171fe0d36f1d0e3a62127ec54997b213eb08c23')
+
+build() {
+    export CC="gcc -m32"
+    export CXX="g++ -m32"
+    export PKG_CONFIG="i686-pc-linux-gnu-pkg-config"
+
+    arch-meson gamescope build \
+        --libdir /usr/lib32 \
+        -Denable_gamescope=false \
+        -Denable_gamescope_wsi_layer=true \
+        -Denable_openvr_support=false \
+        -Dpipewire=disabled
+    meson compile -C build
+}
+
+package() {
+    DESTDIR="$pkgdir" meson install -C build --skip-subprojects
+
+    rm -rf "$pkgdir"/usr/share/gamescope
+    rm -rf "$pkgdir"/usr/include
+    rm -rf "$pkgdir"/usr/lib/libwlroots*
+    rm -rf "$pkgdir"/usr/lib32/libwlroots*
+    rm -rf "$pkgdir"/usr/lib/pkgconfig
+    rm -rf "$pkgdir"/usr/lib32/pkgconfig
+}


### PR DESCRIPTION
This adds the WSI layer for 32-bit gamescope-plus (what's used in handheld edition). If this isn't present, some games[1] can show very bad display corruption

[1] https://discuss.cachyos.org/t/weird-hid-render-corruption-rgb-artifacts-in-gaming-mode-handheld-edition-steam-deck-lcd/6153