### PR TITLE
cachy-browser: 135.0.1-1

### DIFF
--- a/cachy-browser/.SRCINFO
+++ b/cachy-browser/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachy-browser
 	pkgdesc = Community-maintained fork of Firefox, focused on privacy, security and freedom.
-	pkgver = 135.0
+	pkgver = 135.0.1
 	pkgrel = 1
 	install = cachy-browser.install
 	arch = x86_64
@@ -63,14 +63,14 @@ pkgbase = cachy-browser
 	options = !emptydirs
 	options = !lto
 	options = !makeflags
-	source = https://archive.mozilla.org/pub/firefox/releases/135.0/source/firefox-135.0.source.tar.xz
-	source = https://archive.mozilla.org/pub/firefox/releases/135.0/source/firefox-135.0.source.tar.xz.asc
+	source = https://archive.mozilla.org/pub/firefox/releases/135.0.1/source/firefox-135.0.1.source.tar.xz
+	source = https://archive.mozilla.org/pub/firefox/releases/135.0.1/source/firefox-135.0.1.source.tar.xz.asc
 	source = cachy-browser.desktop
 	source = git+https://github.com/cachyos/cachyos-browser-settings.git#commit=14cae4340660147e877d95acfe4dfc2222ceaf2a
 	source = git+https://github.com/cachyos/cachyos-browser-common.git#commit=abd148ecb5c53a571965afc74b4ea589d735d98b
 	source = match.patch
 	validpgpkeys = 14F26682D0916CDD81E37B6D61B7B526D98F0353
-	sha256sums = 827e12a962ef47511089af4498f65ebf42fa57ca31db790bfd7e9a820d16b960
+	sha256sums = 74fbdfddce3be390f3f03194a4e398b30d0a69754e1542a59d7f2b38bac37906
 	sha256sums = SKIP
 	sha256sums = de5c0deb9b6a4ebfaa933103cc6a65f1f43c9a456296d356cc54c7ca042d144c
 	sha256sums = f9c8cc2327d7ad18279f057bfee57c642c1552128be14868f812cfcb2c1ec5f3

--- a/cachy-browser/PKGBUILD
+++ b/cachy-browser/PKGBUILD
@@ -7,7 +7,7 @@
 pkgname=cachy-browser
 _pkgname=Cachy
 __pkgname=cachy
-pkgver=135.0
+pkgver=135.0.1
 pkgrel=1
 pkgdesc="Community-maintained fork of Firefox, focused on privacy, security and freedom."
 arch=(x86_64)
@@ -91,7 +91,7 @@ source=(
   "git+https://github.com/cachyos/cachyos-browser-common.git#commit=${_common_commit}"
   "match.patch"
 )
-sha256sums=('827e12a962ef47511089af4498f65ebf42fa57ca31db790bfd7e9a820d16b960'
+sha256sums=('74fbdfddce3be390f3f03194a4e398b30d0a69754e1542a59d7f2b38bac37906'
             'SKIP'
             'de5c0deb9b6a4ebfaa933103cc6a65f1f43c9a456296d356cc54c7ca042d144c'
             'f9c8cc2327d7ad18279f057bfee57c642c1552128be14868f812cfcb2c1ec5f3'


### PR DESCRIPTION
I can't test because my machine isn't powerful enough to build, but I checked gentoo's ebuild this time and didn't see any updates to the patchset so this _should_ be fine.

Old gentoo ebuild: https://gitweb.gentoo.org/repo/gentoo.git/tree/www-client/firefox/firefox-135.0.ebuild?id=c2ea9974fabd95a3fa202aeb821198ee2379f336#n6

New ebuild: https://gitweb.gentoo.org/repo/gentoo.git/tree/www-client/firefox/firefox-135.0.1.ebuild?id=c2ea9974fabd95a3fa202aeb821198ee2379f336#n6