### PR TITLE
sqlite: Fix PGO builds!

### DIFF
--- a/sqlite/.SRCINFO
+++ b/sqlite/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = sqlite
 	pkgdesc = A C library that implements an SQL database engine
-	pkgver = 3.49.0
+	pkgver = 3.49.1
 	pkgrel = 2
 	url = https://www.sqlite.org/
 	arch = x86_64
@@ -13,25 +13,27 @@ pkgbase = sqlite
 	makedepends = llvm-libs
 	makedepends = lld
 	options = !lto
-	source = https://www.sqlite.org/2025/sqlite-src-3490000.zip
-	source = https://www.sqlite.org/2025/sqlite-doc-3490000.zip
+	source = https://www.sqlite.org/2025/sqlite-src-3490100.zip
+	source = https://www.sqlite.org/2025/sqlite-doc-3490100.zip
 	source = sqlite-lemon-system-template.patch
 	source = license.txt
 	source = git+https://github.com/ClickHouse/ClickBench.git
 	source = https://datasets.clickhouse.com/hits_compatible/hits.csv.gz
-	sha256sums = bec0262d5b165b133d6f3bdb4339c0610f4ac3d50dee53e8ad148ece54a129d0
-	sha256sums = 1c785395005f55c31c9d3f0a6f45be101fb38de7d7aa6a133dc0ab24fc748557
+	source = remove-header-in-command.patch
+	sha256sums = 4404d93cbce818b1b98ca7259d0ba9b45db76f2fdd9373e56f2d29b519f4d43b
+	sha256sums = 4581e3340d9d0d8ce03f10fb8ab1cea03cf49fed8198478c1abf5d383521f037
 	sha256sums = 55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97
 	sha256sums = 4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d
 	sha256sums = SKIP
 	sha256sums = 189c37a5f2020d20ef9ebc0b9d4cf2204fe78658bbab235f0313d41447410ddd
+	sha256sums = 9f1c2889a51e1b858fb6acc857504a2299a30fcc4917f8788af18d0e65a6746a
 
 pkgname = sqlite
 	pkgdesc = A C library that implements an SQL database engine
 	depends = readline
 	depends = zlib
 	depends = glibc
-	provides = sqlite3=3.49.0
+	provides = sqlite3=3.49.1
 	provides = libsqlite3.so
 	replaces = sqlite3
 
@@ -40,7 +42,7 @@ pkgname = sqlite-tcl
 	depends = sqlite
 	depends = tcl
 	depends = glibc
-	provides = sqlite3-tcl=3.49.0
+	provides = sqlite3-tcl=3.49.1
 	replaces = sqlite3-tcl
 
 pkgname = sqlite-analyzer
@@ -55,5 +57,5 @@ pkgname = lemon
 
 pkgname = sqlite-doc
 	pkgdesc = most of the static HTML files that comprise this website, including all of the SQL Syntax and the C/C++ interface specs and other miscellaneous documentation
-	provides = sqlite3-doc=3.49.0
+	provides = sqlite3-doc=3.49.1
 	replaces = sqlite3-doc

--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -4,10 +4,10 @@
 
 pkgbase="sqlite"
 pkgname=('sqlite' 'sqlite-tcl' 'sqlite-analyzer' 'lemon' 'sqlite-doc')
-_srcver=3490000
+_srcver=3490100
 _docver=${_srcver}
 #_docver=3440000
-pkgver=3.49.0
+pkgver=3.49.1
 pkgrel=2
 pkgdesc="A C library that implements an SQL database engine"
 arch=('x86_64')
@@ -217,7 +217,7 @@ package_lemon() {
   # ELF file ('usr/bin/lemon') lacks FULL RELRO, check LDFLAGS. - no fix found so far
   install -Dm755 lemon ${pkgdir}/usr/bin/lemon
   install -Dm644 lempar.c ${pkgdir}/usr/share/lemon/lempar.c
-  
+
   mkdir -p "${pkgdir}"/usr/share/doc/${pkgname}
   cp ../sqlite-doc-${_docver}/lemon.html  "${pkgdir}"/usr/share/doc/${pkgname}/
   # license
@@ -237,6 +237,6 @@ package_sqlite-doc() {
 
   # license
   install -D -m644 "${srcdir}"/license.txt "${pkgdir}"/usr/share/licenses/${pkgname}/license.txt
-  
+
   rm "${pkgdir}"/usr/share/doc/${pkgbase}/lemon.html
 }

--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -20,14 +20,16 @@ source=(https://www.sqlite.org/2025/sqlite-src-${_srcver}.zip
         sqlite-lemon-system-template.patch
         license.txt
         git+https://github.com/ClickHouse/ClickBench.git
-        https://datasets.clickhouse.com/hits_compatible/hits.csv.gz)
+        https://datasets.clickhouse.com/hits_compatible/hits.csv.gz
+        remove-header-in-command.patch)
 # upstream now switched to sha3sums - currently not supported by makepkg
-sha256sums=('bec0262d5b165b133d6f3bdb4339c0610f4ac3d50dee53e8ad148ece54a129d0'
-            '1c785395005f55c31c9d3f0a6f45be101fb38de7d7aa6a133dc0ab24fc748557'
+sha256sums=('4404d93cbce818b1b98ca7259d0ba9b45db76f2fdd9373e56f2d29b519f4d43b'
+            '4581e3340d9d0d8ce03f10fb8ab1cea03cf49fed8198478c1abf5d383521f037'
             '55746d93b0df4b349c4aa4f09535746dac3530f9fd6de241c9f38e2c92e8ee97'
             '4e57d9ac979f1c9872e69799c2597eeef4c6ce7224f3ede0bf9dc8d217b1e65d'
             'SKIP'
-            '189c37a5f2020d20ef9ebc0b9d4cf2204fe78658bbab235f0313d41447410ddd')
+            '189c37a5f2020d20ef9ebc0b9d4cf2204fe78658bbab235f0313d41447410ddd'
+            '9f1c2889a51e1b858fb6acc857504a2299a30fcc4917f8788af18d0e65a6746a')
 options=('!lto')
 
 prepare() {
@@ -36,6 +38,9 @@ prepare() {
   # patch taken from Fedora
   # https://src.fedoraproject.org/rpms/sqlite/blob/master/f/sqlite.spec
   patch -Np1 -i ../sqlite-lemon-system-template.patch
+
+  # Fix PGO build due
+  patch -Np1 -i ../remove-header-in-command.patch
 
   #autoreconf -vfi
 }

--- a/sqlite/remove-header-in-command.patch
+++ b/sqlite/remove-header-in-command.patch
@@ -1,0 +1,32 @@
+From ad5339cfc277fc704147cea0e85541ec7254cbfb Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@cachyos.org>
+Date: Thu, 27 Mar 2025 23:28:38 +0800
+Subject: [PATCH] build: Remove superfluous header in compile command
+
+PGO build fails because the compiler is trying to generate a header
+based on the given header file. In fact, the header file shouldn't need
+to be passed to the command, as it is already listed in the target's
+dependency and all source files that include it should find it just
+fine.
+
+Signed-off-by: Eric Naim <dnaim@cachyos.org>
+---
+ main.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/main.mk b/main.mk
+index 2803e623a2..b57190b7c0 100644
+--- a/main.mk
++++ b/main.mk
+@@ -1875,7 +1875,7 @@ xbin: sqltclsh$(T.exe) sqlite3_analyzer$(T.exe)
+ 
+ sqlite3_expert$(T.exe): $(TOP)/ext/expert/sqlite3expert.h $(TOP)/ext/expert/sqlite3expert.c \
+                        $(TOP)/ext/expert/expert.c sqlite3.c
+-	$(T.link) $(TOP)/ext/expert/sqlite3expert.h $(TOP)/ext/expert/sqlite3expert.c \
++	$(T.link) $(TOP)/ext/expert/sqlite3expert.c \
+ 		$(TOP)/ext/expert/expert.c sqlite3.c -o sqlite3_expert $(LDFLAGS.libsqlite3)
+ xbin: sqlite3_expert$(T.exe)
+ 
+-- 
+2.49.0
+


### PR DESCRIPTION
Builds were failing due to the compiler generating both the binary and the
header. By removing the passed header to the compiler, the build
continues and succeeds gracefully.

Closes: #528 