### PR TITLE
Add limine-hook

### DIFF
--- a/limine-hook/.SRCINFO
+++ b/limine-hook/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = limine-hook
+	pkgdesc = Pacman hooks to update kernel entries in limine
+	pkgver = 20250407
+	pkgrel = 1
+	url = https://github.com/CachyOS/CachyOS-PKGBUILDS
+	arch = any
+	license = GPL-3.0-or-later
+	depends = limine-entry-tool
+	source = limine-kernel-hook
+	source = 10-limine-add-kernel.hook
+	source = 10-limine-remove-kernel.hook
+	sha256sums = b6bf6d2608d5cfd30da6d0305b429c3bbe641f27940cebc1f5acd19c01ea2eb0
+	sha256sums = c551d174a3dc9576bceb70d037fdc50238cff6fc514b9d7f4ff62ae45245f04b
+	sha256sums = 4125d03a16061816031537deabd02041c0320cbb103b3e31f42fe0616ee7e63e
+
+pkgname = limine-hook

--- a/limine-hook/10-limine-add-kernel.hook
+++ b/limine-hook/10-limine-add-kernel.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = usr/lib/modules/*/vmlinuz
+
+[Action]
+Description = Updating limine entries for new kernels...
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/limine-kernel-hook update

--- a/limine-hook/10-limine-remove-kernel.hook
+++ b/limine-hook/10-limine-remove-kernel.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Remove
+Type = Path
+Target = usr/lib/modules/*/vmlinuz
+
+[Action]
+Description = Removing limine entries for older kernels...
+When = PreTransaction
+Exec = /usr/share/libalpm/scripts/limine-kernel-hook remove
+NeedsTargets

--- a/limine-hook/PKGBUILD
+++ b/limine-hook/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Vasiliy Stelmachenok <ventureo@cachyos.org>
+pkgname="limine-hook"
+pkgver=20250407
+pkgrel=1
+pkgdesc='Pacman hooks to update kernel entries in limine'
+license=(GPL-3.0-or-later)
+arch=('any')
+url="https://github.com/CachyOS/CachyOS-PKGBUILDS"
+depends=('limine-entry-tool')
+source=(
+    "limine-kernel-hook"
+    "10-limine-add-kernel.hook"
+    "10-limine-remove-kernel.hook"
+)
+sha256sums=(
+    'b6bf6d2608d5cfd30da6d0305b429c3bbe641f27940cebc1f5acd19c01ea2eb0'
+    'c551d174a3dc9576bceb70d037fdc50238cff6fc514b9d7f4ff62ae45245f04b'
+    '4125d03a16061816031537deabd02041c0320cbb103b3e31f42fe0616ee7e63e'
+)
+
+pkgver() {
+    date +%Y%m%d
+}
+
+package() {
+    install -Dm755 limine-kernel-hook "$pkgdir/usr/share/libalpm/scripts/limine-kernel-hook"
+    install -Dm644 10-limine-add-kernel.hook -t "$pkgdir/usr/share/libalpm/hooks/"
+    install -Dm644 10-limine-remove-kernel.hook -t "$pkgdir/usr/share/libalpm/hooks/"
+}

--- a/limine-hook/limine-kernel-hook
+++ b/limine-hook/limine-kernel-hook
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+update_kernel_list() {
+    local kernel initramfs vmlinuz
+
+    for pkgbase in /usr/lib/modules/*/pkgbase; do
+        kernel="$(cat "$pkgbase")"
+        initramfs="/boot/initramfs-${kernel}.img"
+        vmlinuz="/boot/vmlinuz-${kernel}"
+
+        limine-entry-tool --remove "${kernel}" --quiet
+        [[ ! -e "$initramfs" ]] && continue
+        [[ ! -e "$vmlinuz" ]] && continue
+        limine-entry-tool --add "${kernel}" "$initramfs" "$vmlinuz" --quiet
+    done
+}
+
+clean_kernel_list() {
+    local kernel
+    while IFS= read -r target; do
+        kernel="$(cat /"$(dirname "$target")"/pkgbase)"
+        limine-entry-tool --remove "${kernel}" --quiet
+    done < <(tee /dev/null)
+}
+
+case "$1" in
+    update)
+        update_kernel_list
+        ;;
+    remove)
+        clean_kernel_list
+        ;;
+    *)
+        echo "Invalid argument" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This adds limine-hook to automatically add boot entries after removing/installing kernels, like grub-hook. Works for UEFI users only. Note that limine-entry-tool does copy initramfs and vmlinuz to a different directory in ``/boot``, so you need to keep an eye on the free space of ESP partition.