### PR TITLE
[Cachy-Browser] Missing default privacy setting

### DIFF
--- a/cachy-browser/PKGBUILD
+++ b/cachy-browser/PKGBUILD
@@ -259,10 +259,7 @@ pref("browser.shell.checkDefaultBrowser", false);
 // done in cachy.cfg
 // pref("extensions.autoDisableScopes", 11);
 
-// Turn off mozilla tracking/ai
-pref("app.normandy.enabled", false, locked);
-pref("app.normandy.api_url", "", locked);
-pref("captivedetect.canonicalURL", "", locked);
+// Turn off chatbox
 pref("browser.ml.enable", false, locked);
 
 END

--- a/cachy-browser/PKGBUILD
+++ b/cachy-browser/PKGBUILD
@@ -258,6 +258,13 @@ pref("browser.shell.checkDefaultBrowser", false);
 // Don't disable extensions in the application directory
 // done in cachy.cfg
 // pref("extensions.autoDisableScopes", 11);
+
+// Turn off mozilla tracking/ai
+pref("app.normandy.enabled", false, locked);
+pref("app.normandy.api_url", "", locked);
+pref("captivedetect.canonicalURL", "", locked);
+pref("browser.ml.enable", false, locked);
+
 END
 
     # cd ${srcdir}/settings


### PR DESCRIPTION
Turn off the chatbot by default to go with other privacy settings

Other settings checked already off by default:

- app.normandy.enabled
- app.normandy.api_url
- captivedetect.canonicalURL
- browser.ml.enable