### PR TITLE
cachyos-hooks: 2025.04.26

### DIFF
--- a/cachyos-hooks/.SRCINFO
+++ b/cachyos-hooks/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-hooks
 	pkgdesc = CachyOS libalpm hooks
-	pkgver = 2025.04.21
+	pkgver = 2025.04.26
 	pkgrel = 1
 	url = https://github.com/cachyos/cachyos-hooks/
 	arch = any
@@ -8,7 +8,7 @@ pkgbase = cachyos-hooks
 	license = GPL-3.0-or-later
 	makedepends = git
 	depends = systemd
-	source = git+https://github.com/CachyOS/cachyos-hooks#tag=2025.04.21
-	sha512sums = d696e9e6f42469f2be6a867f99e8aec6218660816a5926a96c676d02866369f5670b13481cd627a22fa2bf95f6d39810bed624e8a9c7bd68bf4f45d9fb84d5b5
+	source = git+https://github.com/CachyOS/cachyos-hooks#tag=2025.04.26
+	sha512sums = 6580e4253b478d36ae364f45524f85d90cb9661cff5f0d39a022c9325651be005430b9b85db06c8e924abbf2ced5c2881f18f9e0da0d4ff75b351423bc6810f5
 
 pkgname = cachyos-hooks

--- a/cachyos-hooks/PKGBUILD
+++ b/cachyos-hooks/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Michael Bolden <me@sm9.dev>
 
 pkgname=cachyos-hooks
-pkgver=2025.04.21
+pkgver=2025.04.26
 pkgrel=1
 pkgdesc='CachyOS libalpm hooks'
 groups=('cachyos')
@@ -12,7 +12,7 @@ arch=('any')
 license=(GPL-3.0-or-later)
 url="https://github.com/cachyos/${pkgname}/"
 source=("git+https://github.com/CachyOS/cachyos-hooks#tag=$pkgver")
-sha512sums=('d696e9e6f42469f2be6a867f99e8aec6218660816a5926a96c676d02866369f5670b13481cd627a22fa2bf95f6d39810bed624e8a9c7bd68bf4f45d9fb84d5b5')
+sha512sums=('6580e4253b478d36ae364f45524f85d90cb9661cff5f0d39a022c9325651be005430b9b85db06c8e924abbf2ced5c2881f18f9e0da0d4ff75b351423bc6810f5')
 
 package() {
   cd "$pkgname"


### PR DESCRIPTION
I don't know how I didn't notice it before, but it's a hotfix for script name in the hook.