### PR TITLE
scx-scheds: 1.0.12-2

### DIFF
--- a/scx-scheds/scx-scheds-git/.SRCINFO
+++ b/scx-scheds/scx-scheds-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scx-scheds-git
 	pkgdesc = sched_ext schedulers and tools
-	pkgver = 1.0.8.r434.gfe0ec464
+	pkgver = 1.0.12.r6.g760382191813
 	pkgrel = 1
 	url = https://github.com/sched-ext/scx
 	arch = x86_64
@@ -17,8 +17,10 @@ pkgbase = scx-scheds-git
 	depends = jq
 	depends = libbpf
 	depends = libelf
+	depends = libseccomp
+	depends = protobuf
 	depends = zlib
-	provides = scx-scheds=1.0.8.r434.gfe0ec464
+	provides = scx-scheds=1.0.12.r6.g760382191813
 	conflicts = scx-scheds
 	options = !lto
 	backup = etc/default/scx

--- a/scx-scheds/scx-scheds-git/PKGBUILD
+++ b/scx-scheds/scx-scheds-git/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=scx-scheds-git
 _gitname=scx
-pkgver=1.0.8.r434.gfe0ec464
+pkgver=1.0.12.r6.g760382191813
 pkgrel=1
 pkgdesc='sched_ext schedulers and tools'
 url='https://github.com/sched-ext/scx'
@@ -15,6 +15,8 @@ depends=(
   jq
   libbpf
   libelf
+  libseccomp
+  protobuf
   zlib
 )
 makedepends=(

--- a/scx-scheds/scx-scheds/.SRCINFO
+++ b/scx-scheds/scx-scheds/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scx-scheds
 	pkgdesc = sched_ext schedulers and tools
-	pkgver = 1.0.11
+	pkgver = 1.0.12
 	pkgrel = 2
 	url = https://github.com/sched-ext/scx
 	arch = x86_64
@@ -17,12 +17,14 @@ pkgbase = scx-scheds
 	depends = jq
 	depends = libbpf
 	depends = libelf
+	depends = libseccomp
+	depends = protobuf
 	depends = zlib
 	options = !lto
 	backup = etc/default/scx
-	source = git+https://github.com/sched-ext/scx?signed#tag=v1.0.11
+	source = git+https://github.com/sched-ext/scx?signed#tag=v1.0.12
 	validpgpkeys = 697C63013E65270255EBC2608744DC1EB26B5A9A
 	validpgpkeys = F5504C7B7B8107B40EF9E97AA1148BB3207BCC33
-	sha256sums = 3111fe5c616cfd72d4eeeceec3dd1e3ce985b22d7ea780224f5ee448b9ae6322
+	sha256sums = dbf54d82cc1b2130d13f283888e9f4d473dd33d052b5e1d3af763e5711fe0c23
 
 pkgname = scx-scheds

--- a/scx-scheds/scx-scheds/PKGBUILD
+++ b/scx-scheds/scx-scheds/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=scx-scheds
 _gitname=scx
-pkgver=1.0.11
+pkgver=1.0.12
 pkgrel=2
 pkgdesc='sched_ext schedulers and tools'
 url='https://github.com/sched-ext/scx'
@@ -16,6 +16,8 @@ depends=(
   jq
   libbpf
   libelf
+  libseccomp
+  protobuf
   zlib
 )
 makedepends=(
@@ -29,7 +31,7 @@ makedepends=(
 )
 options=(!lto)
 source=("git+https://github.com/sched-ext/scx?signed#tag=v$pkgver")
-sha256sums=('3111fe5c616cfd72d4eeeceec3dd1e3ce985b22d7ea780224f5ee448b9ae6322')
+sha256sums=('dbf54d82cc1b2130d13f283888e9f4d473dd33d052b5e1d3af763e5711fe0c23')
 validpgpkeys=(
   697C63013E65270255EBC2608744DC1EB26B5A9A  # Tejun Heo <tj@kernel.org>
   F5504C7B7B8107B40EF9E97AA1148BB3207BCC33  # David Vernet


### PR DESCRIPTION
Add libseccomp as a dependency for scx_rustland and protobuf as a build
dependency for scxtop