### PR TITLE
cachyos-hooks: 2025.05.14

### DIFF
--- a/cachyos-hooks/.SRCINFO
+++ b/cachyos-hooks/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-hooks
 	pkgdesc = CachyOS libalpm hooks
-	pkgver = 2025.05.07
+	pkgver = 2025.05.14
 	pkgrel = 1
 	url = https://github.com/cachyos/cachyos-hooks/
 	arch = any
@@ -8,7 +8,7 @@ pkgbase = cachyos-hooks
 	license = GPL-3.0-or-later
 	makedepends = git
 	depends = systemd
-	source = git+https://github.com/CachyOS/cachyos-hooks#tag=2025.05.07
-	sha512sums = 379e0b136799aa291a6f1a80708a5673a8cf7420da05bfc36b79b2ae0cb8bdc0fd6f3d5b4a54e6da802882050490271ca61e7cff1899cb26b2b9a60dd17e1a8b
+	source = git+https://github.com/CachyOS/cachyos-hooks#tag=2025.05.14
+	sha512sums = 690de6643f9c6ca7780eabf98df21527fa99cb41bd65a2c2f90a43f747b23691f48a93bcfbc575bb9c3cb7b92c4de94469c1a2d373a020d4570fd7ea443eafd2
 
 pkgname = cachyos-hooks

--- a/cachyos-hooks/PKGBUILD
+++ b/cachyos-hooks/PKGBUILD
@@ -1,8 +1,9 @@
 # Maintainer: Piotr Górski <lucjan.lucjanov@gmail.com>
+# Maintainer: Vasiliy Stelmachenok <ventureo@cachyos.org>
 # Contributor: Michael Bolden <me@sm9.dev>
 
 pkgname=cachyos-hooks
-pkgver=2025.05.07
+pkgver=2025.05.14
 pkgrel=1
 pkgdesc='CachyOS libalpm hooks'
 groups=('cachyos')
@@ -12,17 +13,18 @@ arch=('any')
 license=(GPL-3.0-or-later)
 url="https://github.com/cachyos/${pkgname}/"
 source=("git+https://github.com/CachyOS/cachyos-hooks#tag=$pkgver")
-sha512sums=('379e0b136799aa291a6f1a80708a5673a8cf7420da05bfc36b79b2ae0cb8bdc0fd6f3d5b4a54e6da802882050490271ca61e7cff1899cb26b2b9a60dd17e1a8b')
+sha512sums=('690de6643f9c6ca7780eabf98df21527fa99cb41bd65a2c2f90a43f747b23691f48a93bcfbc575bb9c3cb7b92c4de94469c1a2d373a020d4570fd7ea443eafd2')
 
 package() {
   cd "$pkgname"
 
+  install -Dm644 cachyos-branding.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-branding.hook"
+  install -Dm644 cachyos-nvidia.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-nvidia.hook"
+  install -Dm644 cachyos-plymouth-initramfs.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-plymouth-initramfs.hook"
+  install -Dm644 cachyos-reboot-required.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-reboot-required.hook"
   install -Dm644 lsb-release.hook "$pkgdir/usr/share/libalpm/hooks/lsb-release.hook"
   install -Dm644 os-release.hook "$pkgdir/usr/share/libalpm/hooks/os-release.hook"
-  install -Dm644 cachyos-hooks.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-hooks.hook"
-  install -Dm644 cachyos-reboot-required.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-reboot-required.hook"
-  install -Dm644 cachyos-nvidia.hook "$pkgdir/usr/share/libalpm/hooks/cachyos-nvidia.hook"
-  install -Dm755 cachyos-nvidia-hook "$pkgdir/usr/bin/cachyos-nvidia-hook"
-  install -Dm755 cachyos-reboot-required "$pkgdir/usr/bin/cachyos-reboot-required"
-  install -Dm755 cachyos-hooks-runner "$pkgdir/usr/bin/cachyos-hooks-runner"
+  install -Dm755 cachyos-branding "$pkgdir/usr/share/libalpm/scripts/cachyos-branding"
+  install -Dm755 cachyos-reboot-required "$pkgdir/usr/share/libalpm/scripts/cachyos-reboot-required"
+  install -Dm755 update-initramfs "$pkgdir/usr/bin/update-initramfs"
 }


### PR DESCRIPTION
- Adds hook to replace plymouth script for updating initrd with our own to fix issues when using limine-mkinitcpio-hook.
- Adds me as a maintainer if no one minds.
- Brings initramfs updates in generic `update-initramfs` script
- Fixes duplicate reboot notifications on system update
- Minor refactoring

Extra testing is always welcome.