### PR TITLE
cachyos-rate-mirrors: Check CDN77 availability by timeout

### DIFF
--- a/cachyos-rate-mirrors/.SRCINFO
+++ b/cachyos-rate-mirrors/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-rate-mirrors
 	pkgdesc = CachyOS - Rate mirrors service
-	pkgver = 12
+	pkgver = 13
 	pkgrel = 1
 	url = https://github.com/CachyOS
 	arch = any
@@ -10,7 +10,7 @@ pkgbase = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors.service
 	source = cachyos-rate-mirrors.timer
-	sha256sums = a990943d3641495ec6e8dbe51eed80409a7b64c02942dbe1619266434fd16b94
+	sha256sums = 0f05a9fb7cd6d852e6ac3bb510e182a05f3fa9387c11525cf3d8d1f48ed7d3a3
 	sha256sums = 599f7675454b0dd4f305051288c304e185cf9880df86f61588d1be7ffc041409
 	sha256sums = d8f45568d7bd4d4b5b2f8932afe4cc0af1cfb05960be59e13b982f1aadd28058
 

--- a/cachyos-rate-mirrors/PKGBUILD
+++ b/cachyos-rate-mirrors/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Michael Bolden Jnr SM9(); <me@sm9.dev>
 
 pkgname=cachyos-rate-mirrors
-pkgver=12
+pkgver=13
 pkgrel=1
 groups=(cachyos)
 arch=('any')
@@ -16,7 +16,7 @@ source=(
     cachyos-rate-mirrors.timer
 )
 sha256sums=(
-    'a990943d3641495ec6e8dbe51eed80409a7b64c02942dbe1619266434fd16b94'
+    '0f05a9fb7cd6d852e6ac3bb510e182a05f3fa9387c11525cf3d8d1f48ed7d3a3'
     '599f7675454b0dd4f305051288c304e185cf9880df86f61588d1be7ffc041409'
     'd8f45568d7bd4d4b5b2f8932afe4cc0af1cfb05960be59e13b982f1aadd28058'
 )

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -108,7 +108,7 @@ rate_repository_mirrors() {
 # Special check for RU region where CDN77 mirror gets timeouted due to
 # blockings that mirror is applied by default on the ISO
 check_ru_location() {
-    curl -s 'https://geoip.kde.org/v1/ubiquity' | grep -q '<CountryCode>RU<'
+    curl -sL --connect-timeout 5 https://cdn77.com
     return $?
 }
 


### PR DESCRIPTION
It's possible to bypass Russian censorship by using tools such as zapret, which do not change the user's IP address and thus allow access to CDN77, but cachyos-rate-mirrors still will not use it.