### PR TITLE
Do not strip for sign of extensions

### DIFF
--- a/void/PKGBUILD
+++ b/void/PKGBUILD
@@ -9,7 +9,8 @@ pkgdesc="The open-source Cursor alternative"
 url="https://voideditor.com/"
 arch=('x86_64')
 license=("MIT")
-options=(!debug) # probably will be quite big
+options=(!strip # for sign of extension ?
+!debug) # probably big
 _elnum=34 # 35+ will fail
 depends=( electron${_elnum} ripgrep xdg-utils # replacements
   libx11


### PR DESCRIPTION
`Extra/code` stopped stripping.
https://gitlab.archlinux.org/archlinux/packaging/packages/code/-/issues/10