### PR TITLE
gallium-nine & gallium-xa deleted, gallium-mediafoundation added

### DIFF
--- a/mesa/mesa-git/PKGBUILD
+++ b/mesa/mesa-git/PKGBUILD
@@ -465,10 +465,9 @@ build () {
        -D vulkan-drivers=${_vulkan_drivers} \
        -D egl=${_enabled_} \
        -D gallium-extra-hud=true \
-       -D gallium-nine=true \
+       -D gallium-mediafoundation=${_disabled_} \
        -D gallium-va=${_gallium_va} \
        -D gallium-vdpau=${_gallium_vdpau} \
-       -D gallium-xa=${_gallium_xa} \
        -D gbm=${_enabled_} \
        -D gles1=${_disabled_} \
        -D gles2=${_enabled_} \
@@ -525,10 +524,9 @@ build () {
           -D vulkan-drivers=${_vulkan_drivers} \
           -D egl=${_enabled_} \
           -D gallium-extra-hud=true \
-          -D gallium-nine=true \
+	  -D gallium-mediafoundation=${_disabled_} \
           -D gallium-va=${_gallium_va} \
           -D gallium-vdpau=${_gallium_vdpau} \
-          -D gallium-xa=${_gallium_xa} \
           -D gbm=${_enabled_} \
           -D gles1=${_disabled_} \
           -D gles2=${_enabled_} \


### PR DESCRIPTION
Meson will fail without updating these flags

- delete the XA frontend: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34823
- delete gallium-nine: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34887
- mediafoundation: Add new frontend with d3d12 gallium driver support: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34843