### PR TITLE
Move _gallium_xa to legacy following deprecation and frontend deletion

### DIFF
--- a/mesa/mesa-git/customization.cfg
+++ b/mesa/mesa-git/customization.cfg
@@ -52,9 +52,6 @@ _vulkan_drivers="amd,intel,intel_hasvk,swrast"
 # If you wanted to disable osmesa, uncomment the line below
 #_osmesa="false"
 
-# Whether to build Gallium XA tracker - set to "false" to disable.
-#_gallium_xa="false"
-
 # Custom optimization flags - optional.
 #_custom_opt_flags="-march=native -O3 -fno-tree-vectorize"
 
@@ -93,6 +90,10 @@ _mesa_source="https://gitlab.freedesktop.org/mesa/mesa.git"
 # Which DRI drivers to include in the build - default is "i915,i965,r100,r200,nouveau" - this doesn't affect the "main" (default) branch
 # This option was removed altogether with https://gitlab.freedesktop.org/mesa/mesa/-/commit/59625a68ffc592cc5c6c62baf3a03853f234dbf2
 _dri_drivers="i915,i965,r100,r200,nouveau"
+
+# Whether to build Gallium XA tracker - set to "false" to disable.
+# Gallium XA is deprecated and now disabled by default and will be removed in Mesa 25.2 https://gitlab.freedesktop.org/mesa/mesa/-/commit/31cf6b94ad1dfaf4272b22a39d7e2805d03f9375
+#_gallium_xa="false"
 
 #### USER PATCHES ####
 

--- a/mesa/mesa-git/customization.cfg
+++ b/mesa/mesa-git/customization.cfg
@@ -91,10 +91,6 @@ _mesa_source="https://gitlab.freedesktop.org/mesa/mesa.git"
 # This option was removed altogether with https://gitlab.freedesktop.org/mesa/mesa/-/commit/59625a68ffc592cc5c6c62baf3a03853f234dbf2
 _dri_drivers="i915,i965,r100,r200,nouveau"
 
-# Whether to build Gallium XA tracker - set to "false" to disable.
-# Gallium XA is deprecated and now disabled by default and will be removed in Mesa 25.2 https://gitlab.freedesktop.org/mesa/mesa/-/commit/31cf6b94ad1dfaf4272b22a39d7e2805d03f9375
-#_gallium_xa="false"
-
 #### USER PATCHES ####
 
 # Community patches - add patches (separated by a space) of your choice by name from the community-patches dir.


### PR DESCRIPTION
Gallium XA is deprecated and now disabled by default and will be removed in Mesa 25.2 https://gitlab.freedesktop.org/mesa/mesa/-/commit/31cf6b94ad1dfaf4272b22a39d7e2805d03f9375