### PR TITLE
New package: firefox-pure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/ventureoo"]
+	path = external/ventureoo
+	url = https://github.com/ventureoo/PKGBUILDs.git

--- a/firefox-pure
+++ b/firefox-pure
@@ -1,0 +1,1 @@
+external/ventureoo/firefox-pure

--- a/firefox-settings
+++ b/firefox-settings
@@ -1,0 +1,1 @@
+external/ventureoo/firefox-settings

--- a/tinywl
+++ b/tinywl
@@ -1,0 +1,1 @@
+external/ventureoo/tinywl


### PR DESCRIPTION
A Cachy-browser successor, follows native libs/v3 with pgo and tweaks from Cachy-browser have been moved over.  Ublock is installed by default.  Chose to use submodule to keep the git info from ventureoo's repo.