### PR TITLE
feat(galileo-mura): add oneshot service to arm on boot

### DIFF
--- a/handheld/galileo-mura/.SRCINFO
+++ b/handheld/galileo-mura/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = galileo-mura
 	pkgdesc = Utilities for setting and reading mura correction on Galileo
 	pkgver = 0.9
-	pkgrel = 1
+	pkgrel = 2
 	url = https://gitlab.com/evlaV/galileo-mura-extractor
 	arch = x86_64
 	license = MIT
@@ -12,6 +12,8 @@ pkgbase = galileo-mura
 	depends = tar
 	depends = sed
 	source = git+https://gitlab.com/evlaV/galileo-mura-extractor.git#tag=v0.9
+	source = galileo-mura.service
 	sha256sums = d9704ec6605e0cd13e6f3e04c1fe00a377a19d8873dce94b59ba52beb24789e0
+	sha256sums = 13350ed52e47a6413c86619060b2978435a7429184af4f41626669c30a6a1df3
 
 pkgname = galileo-mura

--- a/handheld/galileo-mura/PKGBUILD
+++ b/handheld/galileo-mura/PKGBUILD
@@ -3,15 +3,17 @@
 
 pkgname=galileo-mura
 pkgver=0.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Utilities for setting and reading mura correction on Galileo"
 arch=(x86_64)
 url="https://gitlab.com/evlaV/galileo-mura-extractor"
 license=('MIT')
 depends=('bash' 'glibc' 'tar' 'sed')
 makedepends=(meson ninja)
-source=("git+https://gitlab.com/evlaV/galileo-mura-extractor.git#tag=v${pkgver}")
-sha256sums=('d9704ec6605e0cd13e6f3e04c1fe00a377a19d8873dce94b59ba52beb24789e0')
+source=("git+https://gitlab.com/evlaV/galileo-mura-extractor.git#tag=v${pkgver}"
+        galileo-mura.service)
+sha256sums=('d9704ec6605e0cd13e6f3e04c1fe00a377a19d8873dce94b59ba52beb24789e0'
+            '13350ed52e47a6413c86619060b2978435a7429184af4f41626669c30a6a1df3')
 
 build() {
     cd "galileo-mura-extractor"
@@ -25,4 +27,6 @@ package() {
 
     DESTDIR="$pkgdir" meson install -C build --skip-subprojects
     install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/galileo-mura/
+
+    install -Dm 644 $srcdir/galileo-mura.service -t "${pkgdir}"/usr/lib/systemd/user/
 }

--- a/handheld/galileo-mura/galileo-mura.service
+++ b/handheld/galileo-mura/galileo-mura.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=galileo mura setup
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/galileo-mura-setup


### PR DESCRIPTION
Modern versions of SteamOS use a systemd oneshot service so that Mura compensation is armed on boot. Previously it was done with `gamescope-session` but ChimeraOS's session doesn't appear to do this. This PR purports to replicate the behavior of SteamOS