### PR TITLE
wine/proton: use -O2 instead of -O3

### DIFF
--- a/proton-cachyos/.SRCINFO
+++ b/proton-cachyos/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = proton-cachyos
 	pkgdesc = A compatibility tool for Steam Play based on Wine and additional components, experimental branch with extra CachyOS flavour
 	pkgver = 10.0.20250623
-	pkgrel = 1
+	pkgrel = 3
 	epoch = 1
 	url = https://github.com/CachyOS/proton-cachyos
 	install = proton-cachyos.install

--- a/proton-cachyos/PKGBUILD
+++ b/proton-cachyos/PKGBUILD
@@ -8,7 +8,7 @@ pkgver=${_srctag//-/.}
 _geckover=2.47.4
 _monover=10.0.0
 _xaliaver=0.4.6
-pkgrel=1
+pkgrel=3
 epoch=1
 
 source=(
@@ -195,9 +195,9 @@ build() {
     local march="${flags["-march"]:-nocona}"
     local mtune="core-avx2"
 
-    CFLAGS="-O3 -march=$march -mtune=$mtune -pipe -fno-semantic-interposition"
-    CXXFLAGS="-O3 -march=$march -mtune=$mtune -pipe -fno-semantic-interposition"
-    RUSTFLAGS="-C opt-level=3 -C target-cpu=$march"
+    CFLAGS="-O2 -march=$march -mtune=$mtune -pipe -fno-semantic-interposition"
+    CXXFLAGS="-O2 -march=$march -mtune=$mtune -pipe -fno-semantic-interposition"
+    RUSTFLAGS="-C opt-level=2 -C target-cpu=$march"
     LDFLAGS="-Wl,-O1,--sort-common,--as-needed"
 
     export CFLAGS CXXFLAGS RUSTFLAGS LDFLAGS

--- a/wine-cachyos-opt/.SRCINFO
+++ b/wine-cachyos-opt/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wine-cachyos-opt
 	pkgdesc = A compatibility layer for running Windows programs, with extra CachyOS flavour (installs under /opt)
 	pkgver = 10.0.20250623
-	pkgrel = 1
+	pkgrel = 3
 	epoch = 2
 	url = https://github.com/CachyOS/wine-cachyos
 	install = wine.install

--- a/wine-cachyos-opt/PKGBUILD
+++ b/wine-cachyos-opt/PKGBUILD
@@ -11,7 +11,7 @@ pkgver=${_srctag//-/.}
 _geckover=2.47.4
 _monover=10.0.0
 _xaliaver=0.4.6
-pkgrel=1
+pkgrel=3
 epoch=2
 
 _pkgbasever=${pkgver/rc/-rc}
@@ -141,8 +141,8 @@ build() {
   local mtune="core-avx2"
 
   # From Proton
-  OPTIMIZE_FLAGS="-O3 -march=$march -mtune=$mtune -mfpmath=sse -pipe"
-  OPTIMIZE_FLAGS+=" -mprefer-avx128 -fno-semantic-interposition"
+  OPTIMIZE_FLAGS="-O2 -march=$march -mtune=$mtune -mfpmath=sse -pipe"
+  OPTIMIZE_FLAGS+=" -mprefer-avx128"
   SANITY_FLAGS="-fwrapv -fno-strict-aliasing"
   DEBUG_FLAGS="-ffunction-sections -fdata-sections -fno-omit-frame-pointer"
   WARNING_FLAGS="-Wno-incompatible-pointer-types"

--- a/wine-cachyos/.SRCINFO
+++ b/wine-cachyos/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wine-cachyos
 	pkgdesc = A compatibility layer for running Windows programs, with extra CachyOS flavour
 	pkgver = 10.0.20250623
-	pkgrel = 1
+	pkgrel = 3
 	epoch = 2
 	url = https://github.com/CachyOS/wine-cachyos
 	install = wine.install

--- a/wine-cachyos/PKGBUILD
+++ b/wine-cachyos/PKGBUILD
@@ -11,7 +11,7 @@ pkgver=${_srctag//-/.}
 _geckover=2.47.4
 _monover=10.0.0
 _xaliaver=0.4.6
-pkgrel=1
+pkgrel=3
 epoch=2
 
 _pkgbasever=${pkgver/rc/-rc}
@@ -143,8 +143,8 @@ build() {
   local mtune="core-avx2"
 
   # From Proton
-  OPTIMIZE_FLAGS="-O3 -march=$march -mtune=$mtune -mfpmath=sse -pipe"
-  OPTIMIZE_FLAGS+=" -mprefer-avx128 -fno-semantic-interposition"
+  OPTIMIZE_FLAGS="-O2 -march=$march -mtune=$mtune -mfpmath=sse -pipe"
+  OPTIMIZE_FLAGS+=" -mprefer-avx128"
   SANITY_FLAGS="-fwrapv -fno-strict-aliasing"
   DEBUG_FLAGS="-ffunction-sections -fdata-sections -fno-omit-frame-pointer"
   WARNING_FLAGS="-Wno-incompatible-pointer-types"


### PR DESCRIPTION
Fixes crash when opening `explorer.exe`, I am still building `proton-cachyos` to test, but validated it works on `wine-cachyos`. Will update when done
