### PR TITLE
New package: lsfg-vk

### DIFF
--- a/lsfg-vk/.SRCINFO
+++ b/lsfg-vk/.SRCINFO
@@ -1,11 +1,10 @@
 pkgbase = lsfg-vk
 	pkgdesc = Lossless Scaling Frame Generation on Linux via DXVK/Vulkan
-	pkgver = r102.45f4296
+	pkgver = r103.223f4ba
 	pkgrel = 1
 	url = https://github.com/PancakeTAS/lsfg-vk
 	arch = x86_64
 	license = MIT
-	makedepends = base-devel
 	makedepends = clang
 	makedepends = llvm
 	makedepends = vulkan-headers
@@ -14,8 +13,10 @@ pkgbase = lsfg-vk
 	makedepends = ninja
 	makedepends = git
 	makedepends = sed
+	makedepends = sdl2
+	makedepends = glslang
 	depends = vulkan-icd-loader
-	source = git+https://github.com/PancakeTAS/lsfg-vk
+	source = git+https://github.com/PancakeTAS/lsfg-vk#commit=223f4ba32a2b98d722e36dcb7201ce7df20534f9
 	sha256sums = SKIP
 
 pkgname = lsfg-vk

--- a/lsfg-vk/.SRCINFO
+++ b/lsfg-vk/.SRCINFO
@@ -1,0 +1,21 @@
+pkgbase = lsfg-vk
+	pkgdesc = Lossless Scaling Frame Generation on Linux via DXVK/Vulkan
+	pkgver = r102.45f4296
+	pkgrel = 1
+	url = https://github.com/PancakeTAS/lsfg-vk
+	arch = x86_64
+	license = MIT
+	makedepends = base-devel
+	makedepends = clang
+	makedepends = llvm
+	makedepends = vulkan-headers
+	makedepends = cmake
+	makedepends = meson
+	makedepends = ninja
+	makedepends = git
+	makedepends = sed
+	depends = vulkan-icd-loader
+	source = git+https://github.com/PancakeTAS/lsfg-vk
+	sha256sums = SKIP
+
+pkgname = lsfg-vk

--- a/lsfg-vk/PKGBUILD
+++ b/lsfg-vk/PKGBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Konstantin Rannev <konstantin.rannev@gmail.com>
-# Contributer: Ash <xash at riseup d0t net>
+# Contributor: Ash <xash at riseup d0t net>
 
 pkgname=lsfg-vk
-pkgver=r102.45f4296
+pkgver=r103.223f4ba
 pkgrel=1
 pkgdesc="Lossless Scaling Frame Generation on Linux via DXVK/Vulkan"
 arch=('x86_64')
 url="https://github.com/PancakeTAS/lsfg-vk"
 license=('MIT')
 depends=('vulkan-icd-loader')
-makedepends=('base-devel' 'clang' 'llvm' 'vulkan-headers' 'cmake' 'meson' 'ninja' 'git' 'sed')
-source=('git+https://github.com/PancakeTAS/lsfg-vk')
+makedepends=('clang' 'llvm' 'vulkan-headers' 'cmake' 'meson' 'ninja' 'git' 'sed' 'sdl2' 'glslang')
+source=('git+https://github.com/PancakeTAS/lsfg-vk#commit=223f4ba32a2b98d722e36dcb7201ce7df20534f9')
 sha256sums=('SKIP')
 
 pkgver() {

--- a/lsfg-vk/PKGBUILD
+++ b/lsfg-vk/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Konstantin Rannev <konstantin.rannev@gmail.com>
+# Contributer: Ash <xash at riseup d0t net>
+
+pkgname=lsfg-vk
+pkgver=r102.45f4296
+pkgrel=1
+pkgdesc="Lossless Scaling Frame Generation on Linux via DXVK/Vulkan"
+arch=('x86_64')
+url="https://github.com/PancakeTAS/lsfg-vk"
+license=('MIT')
+depends=('vulkan-icd-loader')
+makedepends=('base-devel' 'clang' 'llvm' 'vulkan-headers' 'cmake' 'meson' 'ninja' 'git' 'sed')
+source=('git+https://github.com/PancakeTAS/lsfg-vk')
+sha256sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/${pkgname}"
+
+	# Git, no tags available
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+	cd "$srcdir/${pkgname}"
+
+	cmake -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+    -DCMAKE_CXX_CLANG_TIDY="" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,lazy" # fixes makepkg's default "-z,now" flag which strips out the necessary symbols
+    cmake --build build
+}
+
+package() {
+	cd "$srcdir/${pkgname}"
+
+	DESTDIR="$pkgdir/" cmake --install build --prefix=/usr
+}


### PR DESCRIPTION
This uses the [official installation guide](https://github.com/PancakeTAS/lsfg-vk/wiki/Installation-Guide) with the only difference being the additional cmake flag `-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,lazy"`, which removes makepkg's default `-z,now`, thereby preventing it from stripping out the necessary DXVK symbols.
