### PR TITLE
chore: update comment to reflect actual cron interval to 4 instead of 6

### DIFF
--- a/.github/workflows/check-pkg-ver.yml
+++ b/.github/workflows/check-pkg-ver.yml
@@ -2,7 +2,7 @@ name: Check Package Versions
 
 on:
   schedule:
-    - cron: '0 */4 * * *'  # Run every 6 hours
+    - cron: '0 */4 * * *'  # Run every 4 hours
   workflow_dispatch:     # Also allows manual trigger
 
 jobs:


### PR DESCRIPTION
This PR changes the comment in the GitHub Actions workflow `check-pkg-ver.yml` to reflect the correct amount of hours defined by the cron schedule.

No core functionality changed, purely clarification fix.