### PR TITLE
lsfg-vk: fix version check in lsfg-vk.install && change submodules to be sources

### DIFF
--- a/lsfg-vk/.SRCINFO
+++ b/lsfg-vk/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lsfg-vk
 	pkgdesc = Lossless Scaling Frame Generation on Linux via DXVK/Vulkan
-	pkgver = r140.f998647
+	pkgver = r143.cebe5e2
 	pkgrel = 1
 	url = https://github.com/PancakeTAS/lsfg-vk
 	install = lsfg-vk.install
@@ -19,6 +19,10 @@ pkgbase = lsfg-vk
 	makedepends = spirv-headers
 	depends = vulkan-icd-loader
 	source = git+https://github.com/PancakeTAS/lsfg-vk#commit=cebe5e2e7a5bc671183791e880a5e70301676106
+	source = git+https://github.com/PancakeTAS/dxbc.git#commit=04ca5e9ae5fef6c0c65ea72bbaa7375327f11454
+	source = git+https://github.com/trailofbits/pe-parse#commit=31ac5966503689d5693cd9fb520bd525a8710e17
 	sha256sums = 8781e41b5ed773366d4ccba65b31d58412e3be89403ba74c4ce552fb563b463d
+	sha256sums = afdd34616c8ed06c01966e04f245232346a1ea8dd5adaa7167b7225eedcf083e
+	sha256sums = 0cafae771cb547b6f7e48121896dafa44990d2e7fb1fc50fcde1bba5438cd254
 
 pkgname = lsfg-vk

--- a/lsfg-vk/PKGBUILD
+++ b/lsfg-vk/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Ash <xash at riseup d0t net>
 
 pkgname=lsfg-vk
-pkgver=r140.f998647
+pkgver=r143.cebe5e2
 pkgrel=1
 pkgdesc="Lossless Scaling Frame Generation on Linux via DXVK/Vulkan"
 arch=('x86_64')
@@ -24,8 +24,12 @@ makedepends=(
   glslang
   spirv-headers
 )
-source=('git+https://github.com/PancakeTAS/lsfg-vk#commit=cebe5e2e7a5bc671183791e880a5e70301676106')
-sha256sums=('8781e41b5ed773366d4ccba65b31d58412e3be89403ba74c4ce552fb563b463d')
+source=('git+https://github.com/PancakeTAS/lsfg-vk#commit=cebe5e2e7a5bc671183791e880a5e70301676106'
+		'git+https://github.com/PancakeTAS/dxbc.git#commit=04ca5e9ae5fef6c0c65ea72bbaa7375327f11454'
+		'git+https://github.com/trailofbits/pe-parse#commit=31ac5966503689d5693cd9fb520bd525a8710e17')
+sha256sums=('8781e41b5ed773366d4ccba65b31d58412e3be89403ba74c4ce552fb563b463d'
+            'afdd34616c8ed06c01966e04f245232346a1ea8dd5adaa7167b7225eedcf083e'
+            '0cafae771cb547b6f7e48121896dafa44990d2e7fb1fc50fcde1bba5438cd254')
 install=lsfg-vk.install
 
 pkgver() {
@@ -37,7 +41,13 @@ pkgver() {
 
 prepare() {
   cd "$srcdir/$pkgname"
-  git submodule update --init --recursive
+
+  git submodule init
+  
+  git config submodule.dxbc.url "$srcdir/dxbc"
+  git config submodule.pe-parse.url "$srcdir/pe-parse"
+  
+  git -c protocol.file.allow=always submodule update
 }
 
 build() {

--- a/lsfg-vk/lsfg-vk.install
+++ b/lsfg-vk/lsfg-vk.install
@@ -24,18 +24,23 @@ if [[ -z "$steam_dll" ]]; then
     done
 fi
 
-required_version="3.2.0.0" # latest version
-
 user_manifest="$_data_home/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json"
 user_library="$_home/.local/lib/liblsfg-vk.so"
 
-get_version() {
+incorrect_version() {
     case "$1" in
-        1.6.0.0) echo "1.6" ;;
-        3.0.0.2) echo "2.13" ;;
-        3.0.0.1) echo "3.0" ;;
-        3.1.0.2) echo "3.1" ;;
-        *)       echo "$1" ;;  # fallback to productversion if unmapped
+          1.6.0.0 \
+        | 2.8.2.0 \
+        | 2.9.0.0 \
+        | 2.10.0.0 \
+        | 2.11.0.0 \
+        | 2.12.0.0 \
+        | 2.13.2.0 \
+        | 3.0.0.1 \
+        | 3.1.0.2)
+        return 0 ;; # old versions
+        *)
+        return 1 ;;  # latest version
     esac
 }
 
@@ -62,11 +67,10 @@ check_steam_install() {
         echo "==    LSFG_DLL_PATH=\"/your/path/Lossless.dll\"                                                                                  =="
     else
         version="$(get_product_version "$steam_dll")"
-        if [ "$version" != "$required_version" ]; then
-            short_installed=$(get_version "$version")
+        if incorrect_version "$version"; then
             echo "================================================================================================================================="
             echo "==  WARNING: Lossless Scaling version mismatch!                                                                                =="
-            echo "==    Installed version: $short_installed"
+            echo "==    Installed version: $version"
             echo "==                                                                                                                             =="
             echo "==  Please install the latest build via Steam:                                                                                 =="
             echo "==    Library → Lossless Scaling → Properties → Betas → None                                                                   =="


### PR DESCRIPTION
Git submodules are now listed as sources, as per the [AUR guidelines](https://wiki.archlinux.org/title/VCS_package_guidelines#Git_submodules), and the required LSFG version is no longer hard-coded into the `.install` script.

Also, updated to the [latest commit](https://github.com/PancakeTAS/lsfg-vk/commit/cebe5e2e7a5bc671183791e880a5e70301676106).