### PR TITLE
reenabled and fixed switzerland mirror

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -48,5 +48,4 @@ Server = https://mirror.limda.net/cachy/repo/$arch/$repo
 ## Finland Mirror much thanks to doridian!
 Server = https://cachyos.doridian.net/repo/$arch/$repo
 ## Switzerland Mirror much thanks to Fabian!
-# Currently outdated, disable mirror for now
-# Server = https://mirror.hb9hil.org/cachyos/$arch/$repo
+Server = https://mirror.hb9hil.org/cachyos/repo/$arch/$repo


### PR DESCRIPTION
I fixed the timer issues and added the correct server path
On this mirror there is also a copy of archlinux. So as  proof of stability you also can check https://archlinux.org/mirrors/hb9hil.org/