### PR TITLE
lsfg-vk: change compiler to clang && add UI app

### DIFF
--- a/lsfg-vk/.SRCINFO
+++ b/lsfg-vk/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = lsfg-vk
-	pkgdesc = Lossless Scaling Frame Generation on Linux via DXVK/Vulkan
-	pkgver = r199.e67fcd3
-	pkgrel = 2
+	pkgdesc = Lossless Scaling Frame Generation on Linux
+	pkgver = r255.7c0c29c
+	pkgrel = 1
 	url = https://github.com/PancakeTAS/lsfg-vk
 	install = lsfg-vk.install
 	arch = x86_64
@@ -10,20 +10,14 @@ pkgbase = lsfg-vk
 	makedepends = llvm
 	makedepends = vulkan-headers
 	makedepends = cmake
-	makedepends = meson
 	makedepends = ninja
 	makedepends = git
-	makedepends = sed
-	makedepends = sdl2
-	makedepends = glslang
-	makedepends = spirv-headers
-	makedepends = libxrandr
-	makedepends = libxinerama
-	makedepends = libxi
-	makedepends = libxkbcommon
+	makedepends = rust
+	makedepends = cargo
 	depends = vulkan-icd-loader
-	depends = libglvnd
-	source = git+https://github.com/PancakeTAS/lsfg-vk#commit=e67fcd3dd832c9d177ad2be780e5dd0e47810bdf
-	sha256sums = baa1ec98f125d200637f6acae85db3940d7625f66c331eaf4d577859f96e0c41
+	depends = gtk4
+	depends = libadwaita
+	source = git+https://github.com/PancakeTAS/lsfg-vk#commit=7c0c29c1e74c51921b2f5455e3dc2472a6bc99c0
+	sha256sums = 16b30fa19b3e7eda9aa888b0e9f5b460202f978ec54d4820e63b40479493c851
 
 pkgname = lsfg-vk

--- a/lsfg-vk/PKGBUILD
+++ b/lsfg-vk/PKGBUILD
@@ -1,36 +1,31 @@
 # Maintainer: Konstantin Rannev <konstantin.rannev@gmail.com>
 # Contributor: Ash <xash at riseup d0t net>
+# Contributor: PancakeTAS <???>
 
 pkgname=lsfg-vk
-pkgver=r199.e67fcd3
-pkgrel=2
-pkgdesc="Lossless Scaling Frame Generation on Linux via DXVK/Vulkan"
+pkgver=r255.7c0c29c
+pkgrel=1
+pkgdesc="Lossless Scaling Frame Generation on Linux"
 arch=('x86_64')
 url="https://github.com/PancakeTAS/lsfg-vk"
 license=('MIT')
 depends=(
   vulkan-icd-loader
-  libglvnd
+  gtk4
+  libadwaita
 )
 makedepends=(
   clang
   llvm
   vulkan-headers
   cmake
-  meson
   ninja
   git
-  sed
-  sdl2
-  glslang
-  spirv-headers
-  libxrandr
-  libxinerama
-  libxi
-  libxkbcommon
+  rust
+  cargo
 )
-source=('git+https://github.com/PancakeTAS/lsfg-vk#commit=e67fcd3dd832c9d177ad2be780e5dd0e47810bdf')
-sha256sums=('baa1ec98f125d200637f6acae85db3940d7625f66c331eaf4d577859f96e0c41')
+source=('git+https://github.com/PancakeTAS/lsfg-vk#commit=7c0c29c1e74c51921b2f5455e3dc2472a6bc99c0')
+sha256sums=('16b30fa19b3e7eda9aa888b0e9f5b460202f978ec54d4820e63b40479493c851')
 install=lsfg-vk.install
 
 pkgver() {
@@ -43,28 +38,38 @@ pkgver() {
 prepare() {
   cd "$srcdir/$pkgname"
 
+  # --filter=tree:0 minimizes network traffic
   git submodule update --init --filter=tree:0 --recursive
 }
 
 build() {
   cd "$srcdir/$pkgname"
 
-  # Unset certain default makepkg flags that strip out necessary symbols in the linker
-  export LDFLAGS="${LDFLAGS//-Wl,-z,now/} -Wl,-z,lazy"
-  export CFLAGS="${CFLAGS//-flto=auto/}"
-
+  # build library
   cmake -B build -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/usr \
-    -DCMAKE_C_FLAGS="$CFLAGS" \
-    -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS"
-  cmake --build build
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=On
+  ninja -C build
+
+  # build UI
+  cd ui
+  cargo build --release --locked
 }
 
 package() {
   cd "$srcdir/$pkgname"
 
+  # base library and config
   install -Dm644 VkLayer_LS_frame_generation.json "$pkgdir/etc/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json"
   install -Dm644 build/liblsfg-vk.so "$pkgdir/usr/lib/liblsfg-vk.so"
+
+  # UI binary, desktop file and icon
+  install -Dm755 ui/target/release/lsfg-vk-ui "$pkgdir/usr/bin/lsfg-vk-ui"
+  install -Dm644 ui/rsc/gay.pancake.lsfg-vk-ui.desktop "$pkgdir/usr/share/applications/lsfg-vk-ui.desktop"
+  install -Dm644 ui/rsc/icon.png "$pkgdir/usr/share/icons/hicolor/256x256/apps/gay.pancake.lsfg-vk-ui.png"
+
+  # license
   install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
- Change the compiler to `Clang` to comply with upstream's build system
- Remove no longer needed dependencies and add new ones
- Add the new UI functionality
- Change commit to the [v0.9.0 pre-release](https://github.com/PancakeTAS/lsfg-vk/commit/7c0c29c1e74c51921b2f5455e3dc2472a6bc99c0)