### PR TITLE
cachy-update: update to v3.15.0

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachy-update
 	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
-	pkgver = 3.14.1
+	pkgver = 3.15.0
 	pkgrel = 1
 	url = https://github.com/CachyOS/cachy-update
 	arch = any
@@ -33,7 +33,7 @@ pkgbase = cachy-update
 	optdepends = sudo: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=f95d552db6c0597dfd9d223a862feb3ec2a21827
-	sha256sums = c66b01ebb7cc19e7bfaebecd998ac60aec4c9cabfb7ed36b5278d7bcd9df8345
+	source = git+https://github.com/CachyOS/cachy-update#commit=0ae4e47b9dda45410943a5bb61b359c678194f07
+	sha256sums = f37570528d5715c796092268d3919f12635f4f386dff9c5c5f85b17cf885121b
 
 pkgname = cachy-update

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Robin Candau <antiz@archlinux.org>
 
 pkgname=cachy-update
-pkgver=3.14.1
+pkgver=3.15.0
 pkgrel=1
 pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
@@ -22,8 +22,8 @@ optdepends=('paru: AUR Packages support'
             'qt6-wayland: Systray applet support on Wayland'
             'sudo: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=f95d552db6c0597dfd9d223a862feb3ec2a21827")
-sha256sums=('c66b01ebb7cc19e7bfaebecd998ac60aec4c9cabfb7ed36b5278d7bcd9df8345')
+source=("git+https://github.com/CachyOS/cachy-update#commit=0ae4e47b9dda45410943a5bb61b359c678194f07")
+sha256sums=('f37570528d5715c796092268d3919f12635f4f386dff9c5c5f85b17cf885121b')
 
 prepare() {
 	cd "${pkgname}"


### PR DESCRIPTION
- https://github.com/CachyOS/cachy-update/commit/0ae4e47b9dda45410943a5bb61b359c678194f07
- https://github.com/Antiz96/arch-update/releases/tag/v3.15.0