### PR TITLE
Bump cachy-update to include latest patch commit & add missing sudo-rs optdepend

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachy-update
 	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
 	pkgver = 3.15.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/CachyOS/cachy-update
 	arch = any
 	license = GPL-3.0-or-later
@@ -31,9 +31,10 @@ pkgbase = cachy-update
 	optdepends = neovim: Default diff program for pacdiff if EDITOR=nvim
 	optdepends = qt6-wayland: Systray applet support on Wayland
 	optdepends = sudo: Privilege elevation
+	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=2f1f47fca0e09fe6ebe544dc52c88376e455ab82
-	sha256sums = 0652b32f84321bd9d48e853084e74896e49ec8cdcc9c200e4e33eb4733732a77
+	source = git+https://github.com/CachyOS/cachy-update#commit=ec237282bb796b89d9b8e57e85168c2f78389f9a
+	sha256sums = 4db225ddc4b8c17889eb52bc69937e98f807c35bf599fccb1eee0085eac7dba8
 
 pkgname = cachy-update

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cachy-update
 pkgver=3.15.0
-pkgrel=2
+pkgrel=3
 pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
 arch=('any')
@@ -21,9 +21,10 @@ optdepends=('paru: AUR Packages support'
             'neovim: Default diff program for pacdiff if EDITOR=nvim'
             'qt6-wayland: Systray applet support on Wayland'
             'sudo: Privilege elevation'
+            'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=2f1f47fca0e09fe6ebe544dc52c88376e455ab82")
-sha256sums=('0652b32f84321bd9d48e853084e74896e49ec8cdcc9c200e4e33eb4733732a77')
+source=("git+https://github.com/CachyOS/cachy-update#commit=ec237282bb796b89d9b8e57e85168c2f78389f9a")
+sha256sums=('4db225ddc4b8c17889eb52bc69937e98f807c35bf599fccb1eee0085eac7dba8')
 
 prepare() {
 	cd "${pkgname}"


### PR DESCRIPTION
- Latest patch commit fixing tooltip's branding: https://github.com/CachyOS/cachy-update/pull/3
- `sudo-rs` support added upstream in: https://github.com/Antiz96/arch-update/pull/408