### PR TITLE
Bump cachy-update to v3.15.2

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachy-update
 	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
-	pkgver = 3.15.0
-	pkgrel = 3
+	pkgver = 3.15.2
+	pkgrel = 1
 	url = https://github.com/CachyOS/cachy-update
 	arch = any
 	license = GPL-3.0-or-later
@@ -34,7 +34,7 @@ pkgbase = cachy-update
 	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=ec237282bb796b89d9b8e57e85168c2f78389f9a
+	source = git+https://github.com/CachyOS/cachy-update#commit=c4706af0f001c4cfe30e9c9496ddd0767961ca05
 	sha256sums = 4db225ddc4b8c17889eb52bc69937e98f807c35bf599fccb1eee0085eac7dba8
 
 pkgname = cachy-update

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Robin Candau <antiz@archlinux.org>
 
 pkgname=cachy-update
-pkgver=3.15.0
-pkgrel=3
+pkgver=3.15.2
+pkgrel=1
 pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
 arch=('any')
@@ -23,7 +23,7 @@ optdepends=('paru: AUR Packages support'
             'sudo: Privilege elevation'
             'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=ec237282bb796b89d9b8e57e85168c2f78389f9a")
+source=("git+https://github.com/CachyOS/cachy-update#commit=c4706af0f001c4cfe30e9c9496ddd0767961ca05")
 sha256sums=('4db225ddc4b8c17889eb52bc69937e98f807c35bf599fccb1eee0085eac7dba8')
 
 prepare() {


### PR DESCRIPTION
- https://github.com/Antiz96/arch-update/releases/tag/v3.15.1
- https://github.com/Antiz96/arch-update/releases/tag/v3.15.2

Includes a fix that should prevent eventual race conditions resulting in 2 trays being started (see [here](https://www.reddit.com/r/cachyos/comments/1myvi1c/comment/najqza0/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1)), as well as a workaround to fix the news checking feature (which was faulty due to the current [service outages](https://archlinux.org/news/recent-services-outages/) that Arch Linux is currently suffering from).

Closes https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/824