### PR TITLE
Bump cachy-update to v3.15.3

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachy-update
 	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
-	pkgver = 3.15.0
-	pkgrel = 3
+	pkgver = 3.15.3
+	pkgrel = 1
 	url = https://github.com/CachyOS/cachy-update
 	arch = any
 	license = GPL-3.0-or-later
@@ -34,7 +34,7 @@ pkgbase = cachy-update
 	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=ec237282bb796b89d9b8e57e85168c2f78389f9a
-	sha256sums = 4db225ddc4b8c17889eb52bc69937e98f807c35bf599fccb1eee0085eac7dba8
+	source = git+https://github.com/CachyOS/cachy-update#commit=bd4648f84d12bdf6994b9b30ebc6e8d5ae2823b7
+	sha256sums = afedd9f278f42aad70eae06c07eca8330fd924453c66a5e71de68671e9de3507
 
 pkgname = cachy-update

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Robin Candau <antiz@archlinux.org>
 
 pkgname=cachy-update
-pkgver=3.15.0
-pkgrel=3
+pkgver=3.15.3
+pkgrel=1
 pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
 arch=('any')
@@ -23,8 +23,8 @@ optdepends=('paru: AUR Packages support'
             'sudo: Privilege elevation'
             'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=ec237282bb796b89d9b8e57e85168c2f78389f9a")
-sha256sums=('4db225ddc4b8c17889eb52bc69937e98f807c35bf599fccb1eee0085eac7dba8')
+source=("git+https://github.com/CachyOS/cachy-update#commit=bd4648f84d12bdf6994b9b30ebc6e8d5ae2823b7")
+sha256sums=('afedd9f278f42aad70eae06c07eca8330fd924453c66a5e71de68671e9de3507')
 
 prepare() {
 	cd "${pkgname}"


### PR DESCRIPTION
- https://github.com/Antiz96/arch-update/releases/tag/v3.15.1
- https://github.com/Antiz96/arch-update/releases/tag/v3.15.2
- https://github.com/Antiz96/arch-update/releases/tag/v3.15.3

Includes a fix that should prevent eventual race conditions resulting in 2 trays being started (see [here](https://www.reddit.com/r/cachyos/comments/1myvi1c/comment/najqza0/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1)), as well as a workaround to fix the news checking feature (which was faulty due to the current [service outages](https://archlinux.org/news/recent-services-outages/) that Arch Linux is currently suffering from).

Closes https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/824