### PR TITLE
ci: update validate pkgbuilds

### DIFF
--- a/.github/scripts/validate-pkgbuilds.js
+++ b/.github/scripts/validate-pkgbuilds.js
@@ -123,9 +123,14 @@ if (processedPkgbuilds.length > 0) {
     .sort((a, b) => a.pkgName.localeCompare(b.pkgName))
     .forEach((pkg) => {
       console.log(`PKGBUILD: ${pkg.pkgName}`);
-      pkg.details.forEach((detail) => {
-        console.log(`  [${detail.type}] ${detail.code}`);
-      });
+      pkg.details
+        .sort(
+          (a, b) =>
+            a.type.localeCompare(b.type) || a.code.localeCompare(b.code),
+        )
+        .forEach((detail) => {
+          console.log(`  [${detail.type}] ${detail.code}`);
+        });
       if (pkg.commandError) {
         console.log(
           "  [CRITICAL] Additionally, An error occurred while processing this PKGBUILD",

--- a/.github/scripts/validate-pkgbuilds.js
+++ b/.github/scripts/validate-pkgbuilds.js
@@ -54,8 +54,8 @@ if (isPullRequest) {
   console.log("PR detected - scanning only changed PKGBUILDs...");
   pkgbuildFiles = await getChangedPkgbuilds();
   console.log(`Found ${pkgbuildFiles.length} changed PKGBUILD(s)`);
-} else if (isMainBranch || process.env.GITHUB_EVENT_NAME === "push") {
-  console.log("Main branch or push detected - scanning all PKGBUILDs...");
+} else if (isMainBranch) {
+  console.log("Main branch - scanning all PKGBUILDs...");
   pkgbuildFiles = await getAllPkgbuilds();
 } else {
   console.log("Manual trigger - scanning all PKGBUILDs...");

--- a/.github/scripts/validate-pkgbuilds.js
+++ b/.github/scripts/validate-pkgbuilds.js
@@ -117,17 +117,19 @@ if (processedPkgbuilds.length > 0) {
     `\n${processedPkgbuilds.length} PKGBUILDs out of ${pkgbuildFiles.length} have issues and ${erroredCount} have errors. Summary of issues:\n`,
   );
 
-  processedPkgbuilds.forEach((pkg) => {
-    console.log(`PKGBUILD: ${pkg.pkgName}`);
-    pkg.details.forEach((detail) => {
-      console.log(`  [${detail.type}] ${detail.code}`);
+  processedPkgbuilds
+    .sort((a, b) => a.pkgName.localeCompare(b.pkgName))
+    .forEach((pkg) => {
+      console.log(`PKGBUILD: ${pkg.pkgName}`);
+      pkg.details.forEach((detail) => {
+        console.log(`  [${detail.type}] ${detail.code}`);
+      });
+      if (pkg.commandError) {
+        console.log(
+          "  [CRITICAL] Additionally, An error occurred while processing this PKGBUILD",
+        );
+      }
     });
-    if (pkg.commandError) {
-      console.log(
-        "  [CRITICAL] Additionally, An error occurred while processing this PKGBUILD",
-      );
-    }
-  });
 
   console.log(
     `\n${processedPkgbuilds.length} PKGBUILDs out of ${pkgbuildFiles.length} have issues and ${erroredCount} have errors.`,

--- a/.github/scripts/validate-pkgbuilds.js
+++ b/.github/scripts/validate-pkgbuilds.js
@@ -4,12 +4,68 @@ import { $ } from "bun";
 
 const pkgbuildsDir = join(import.meta.dir, "..", "..");
 
-const pkgbuildFiles = readdirSync(pkgbuildsDir, {
-  recursive: true,
-  withFileTypes: true,
-})
-  .filter((x) => x.isFile() && x.name === "PKGBUILD")
-  .map((x) => x.parentPath);
+async function getChangedPkgbuilds() {
+  const { stdout } =
+    await $`git diff --name-only origin/${process.env.GITHUB_BASE_REF || "master"}...HEAD`
+      .nothrow()
+      .quiet();
+
+  const changedFiles = stdout
+    .toString("utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+
+  const changedPkgbuildDirs = new Set();
+
+  for (const file of changedFiles) {
+    const parts = file.split("/");
+    for (let i = 0; i < parts.length; i++) {
+      const dirPath = parts.slice(0, i + 1).join("/");
+      try {
+        const pkgbuildPath = join(pkgbuildsDir, dirPath, "PKGBUILD");
+        await $`test -f ${pkgbuildPath}`.quiet();
+        changedPkgbuildDirs.add(dirPath);
+        break;
+      } catch {
+        // Continue searching parent directories
+      }
+    }
+  }
+
+  return Array.from(changedPkgbuildDirs);
+}
+
+async function getAllPkgbuilds() {
+  return readdirSync(pkgbuildsDir, {
+    recursive: true,
+    withFileTypes: true,
+  })
+    .filter((x) => x.isFile() && x.name === "PKGBUILD")
+    .map((x) => x.parentPath);
+}
+
+const isMainBranch = process.env.GITHUB_REF === "refs/heads/master";
+const isPullRequest = process.env.GITHUB_EVENT_NAME === "pull_request";
+
+let pkgbuildFiles;
+
+if (isPullRequest) {
+  console.log("PR detected - scanning only changed PKGBUILDs...");
+  pkgbuildFiles = await getChangedPkgbuilds();
+  console.log(`Found ${pkgbuildFiles.length} changed PKGBUILD(s)`);
+} else if (isMainBranch || process.env.GITHUB_EVENT_NAME === "push") {
+  console.log("Main branch or push detected - scanning all PKGBUILDs...");
+  pkgbuildFiles = await getAllPkgbuilds();
+} else {
+  console.log("Manual trigger - scanning all PKGBUILDs...");
+  pkgbuildFiles = await getAllPkgbuilds();
+}
+
+if (pkgbuildFiles.length === 0) {
+  console.log("No PKGBUILDs to validate.");
+  process.exit(0);
+}
 
 const processedPkgbuilds = await Promise.all(
   pkgbuildFiles.map(async (path) => {
@@ -49,16 +105,16 @@ const processedPkgbuilds = await Promise.all(
       hasErrors,
       pkgName,
     };
-  })
+  }),
 ).then((res) => res.filter((x) => x && x.details.length > 0));
 
 if (processedPkgbuilds.length > 0) {
   const { length: erroredCount } = processedPkgbuilds.filter(
-    (x) => x.hasErrors || x.commandError
+    (x) => x.hasErrors || x.commandError,
   );
 
   console.log(
-    `\n${processedPkgbuilds.length} PKGBUILDs out of ${pkgbuildFiles.length} have issues and ${erroredCount} have errors. Summary of issues:\n`
+    `\n${processedPkgbuilds.length} PKGBUILDs out of ${pkgbuildFiles.length} have issues and ${erroredCount} have errors. Summary of issues:\n`,
   );
 
   processedPkgbuilds.forEach((pkg) => {
@@ -68,16 +124,18 @@ if (processedPkgbuilds.length > 0) {
     });
     if (pkg.commandError) {
       console.log(
-        "  [CRITICAL] Additionally, An error occurred while processing this PKGBUILD"
+        "  [CRITICAL] Additionally, An error occurred while processing this PKGBUILD",
       );
     }
   });
 
   console.log(
-    `\n${processedPkgbuilds.length} PKGBUILDs out of ${pkgbuildFiles.length} have issues and ${erroredCount} have errors.`
+    `\n${processedPkgbuilds.length} PKGBUILDs out of ${pkgbuildFiles.length} have issues and ${erroredCount} have errors.`,
   );
 
   if (erroredCount) {
     process.exit(1);
   }
+} else {
+  console.log("All PKGBUILDs are valid!");
 }

--- a/.github/workflows/validate-pkgbuilds.yml
+++ b/.github/workflows/validate-pkgbuilds.yml
@@ -4,17 +4,21 @@ jobs:
     container: cachyos/cachyos:latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      # https://github.com/actions/checkout/issues/363
+      - name: Fix Git safe directory issue
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install dependencies
         run: pacman -Syu --noconfirm namcap bun-bin
-
       - name: Validate PKGBUILDs
         run: bun .github/scripts/validate-pkgbuilds.js
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF: ${{ github.ref }}
-          GITHUB_BASE_REF: ${{ github.base_ref }}
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_REF: origin/${{ github.head_ref }}
 
 name: Validate PKGBUILDs
 
@@ -23,6 +27,8 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - "**/PKGBUILD"
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/validate-pkgbuilds.yml
+++ b/.github/workflows/validate-pkgbuilds.yml
@@ -20,13 +20,15 @@ name: Validate PKGBUILDs
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
     inputs:
       branch:
         description: "Branch to validate"
         required: true
-        default: "main"
+        default: "master"
       sha:
         description: "SHA to validate"
         required: true

--- a/.github/workflows/validate-pkgbuilds.yml
+++ b/.github/workflows/validate-pkgbuilds.yml
@@ -11,6 +11,10 @@ jobs:
 
       - name: Validate PKGBUILDs
         run: bun .github/scripts/validate-pkgbuilds.js
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
 
 name: Validate PKGBUILDs
 


### PR DESCRIPTION
This should only run when a PR has PKGBUILD changes and only for the package that is being added in the PR. On push to the main branch, the previous validation of all packages should still happen. The same applies to manually triggering the workflow in the Actions tab.

cc @vnepogodin @SoulHarsh007 

Closes #835