### PR TITLE
nvidia-utils: Reworked entire the limit-vram-usage

### DIFF
--- a/nvidia/nvidia-utils/limit-vram-usage
+++ b/nvidia/nvidia-utils/limit-vram-usage
@@ -2,91 +2,26 @@
     "rules": [
         {
             "pattern": {
-                "feature": "procname",
-                "matches": "Proton Pass"
+                "op": "or",
+                "sub": [
+                    { "feature": "procname", "matches": "Proton Pass" },
+                    { "feature": "procname", "matches": "Proton Mail" },
+                    { "feature": "procname", "matches": "vesktop" },
+                    { "feature": "procname", "matches": "discord" },
+                    { "feature": "procname", "matches": "DiscordCanary" },
+                    { "feature": "procname", "matches": "spotify" },
+                    { "feature": "procname", "matches": "chromium" },
+                    { "feature": "procname", "matches": "chrome" },
+                    { "feature": "procname", "matches": "ghostty" },
+                    { "feature": "procname", "matches": "webcord" },
+                    { "feature": "procname", "matches": "brave" },
+                    { "feature": "procname", "matches": "firefox" },
+                    { "feature": "procname", "matches": "alacritty" },
+                    { "feature": "procname", "matches": "konsole" },
+                    { "feature": "procname", "matches": "niri" }
+                ]
             },
             "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "Proton Mail"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "vesktop"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "spotify"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "discord"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "chromium"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "chrome"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "ghostty"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "webcord"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "brave"
-            },
-            "profile": "No VidMem Reuse"
-        },
-        {
-            "pattern": {
-                "feature": "procname",
-                "matches": "alacritty"
-            },
-            "profile": "No VidMem Reuse"
-        }
-    ],
-    "profiles": [
-        {
-            "name": "No VidMem Reuse",
-            "settings": [
-                {
-                    "key": "GLVidHeapReuseRatio",
-                    "value": 1
-                }
-            ]
         }
     ]
 }


### PR DESCRIPTION
Hello, i'm here to proposing a major changes to limit-vram-usage

- We discoreved that `GLVidHeapReuseRatio` is set to 0 on nvidia side so i dropped the declaration on the file
- Instead to use patterns as rules i replaced with `or` syntax and `sub matches` (i tested and it is working fine)
- I added more matches like (DiscordCanary, firefox, Niri)

As WIP we need to see if we need to put as matches too gnome_shell and kwin_wayland 

Best Regards,
NextWorks