### PR TITLE
ci: fix PR changes not detected by validate-pkgbuilds

### DIFF
--- a/.github/workflows/validate-pkgbuilds.yml
+++ b/.github/workflows/validate-pkgbuilds.yml
@@ -17,8 +17,8 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF: ${{ github.ref }}
-          BASE_REF: origin/${{ github.base_ref }}
-          HEAD_REF: origin/${{ github.head_ref }}
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.sha }}
 
 name: Validate PKGBUILDs
 


### PR DESCRIPTION
At the moment, the PRs are always green because the BASE and HEAD refs are the same (`origin/master`), which doesn't detect any changes. E.g., https://github.com/CachyOS/CachyOS-PKGBUILDS/pull/871/checks

<img width="543" height="348" alt="image" src="https://github.com/user-attachments/assets/4de1950d-dc9b-4d2c-9aed-e655414470eb" />

This should hopefully fix the issue by using the commit's SHA instead of what was used before.

Example test run https://github.com/azdanov/CachyOS-PKGBUILDS/actions/runs/18100784454/job/51502912207