### PR TITLE
sdboot-manage: Add extra check before removing orphan entry

### DIFF
--- a/systemd-boot-manager/sdboot-manage
+++ b/systemd-boot-manager/sdboot-manage
@@ -226,8 +226,7 @@ remove_orphan_entries() {
             | uniq | sort)); do
         while read -r entry; do
             local kerneldir="${entry%.*}"
-            kerneldir="${kerneldir##*/}"
-            if [ ! -d "/usr/src/${kerneldir}" ]; then
+            if [ ! -d "/usr/src/${kerneldir##*/}" ]; then
                 remove_entry "${entry}"
             fi
         done < <(grep -l "${kernel}" "${ESP}"/loader/entries/*)


### PR DESCRIPTION
The "sdboot-manage remove" command may remove valid entries.

In the case having "linux-cachyos" and "linux-cachyos-evvdf" kernels, uninstalling "linux-cachyos" followed with "sdboot-manage remove" will also wipe the "linux-cachyos-eevdf" boot configuration file.

This is because the shorter kernel name matches the eevdf entry. Add check ensuring the "/usr/src/[kernel]" dir does not exists.