### PR TITLE
nodejs: update to 25.0.0

### DIFF
--- a/nodejs/.SRCINFO
+++ b/nodejs/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nodejs
 	pkgdesc = Evented I/O for V8 javascript ("Current" release)
-	pkgver = 24.10.0
+	pkgver = 25.0.0
 	pkgrel = 1
 	url = https://nodejs.org/
 	arch = x86_64
@@ -20,12 +20,12 @@ pkgbase = nodejs
 	depends = zlib
 	optdepends = npm: nodejs package manager
 	options = !lto
-	source = git+https://github.com/nodejs/node.git#tag=v24.10.0?signed
+	source = git+https://github.com/nodejs/node.git#tag=v25.0.0?signed
 	validpgpkeys = 8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600
 	validpgpkeys = 890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4
 	validpgpkeys = C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C
 	validpgpkeys = C0D6248439F1D5604AAFFB4021D900FFDB233756
 	validpgpkeys = 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356
-	sha512sums = 5cd02dd0c91bd40030f3fb4e6c78301cada7a3b8ef4e4e267c5697633dd996f08d0de9c3cc2c2a1f4769304d9554642c76aa2e10683d0f1e12768729d4b618b8
+	sha512sums = 1cc74927dec9958c579b64a414de64167ac5375af3e1c9fc956199bd10fa3ad373bc6d1d1b264fc69811989e9eaad4a9b3539e4ee340fc882cd8d701b99b752d
 
 pkgname = nodejs

--- a/nodejs/PKGBUILD
+++ b/nodejs/PKGBUILD
@@ -9,7 +9,7 @@
 # Contributor: TIanyi Cui <tianyicui@gmail.com>
 
 pkgname=nodejs
-pkgver=24.10.0
+pkgver=25.0.0
 pkgrel=1
 pkgdesc='Evented I/O for V8 javascript ("Current" release)'
 arch=('x86_64')
@@ -39,7 +39,7 @@ makedepends=(
 optdepends=('npm: nodejs package manager')
 options=('!lto')
 source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed")
-sha512sums=('5cd02dd0c91bd40030f3fb4e6c78301cada7a3b8ef4e4e267c5697633dd996f08d0de9c3cc2c2a1f4769304d9554642c76aa2e10683d0f1e12768729d4b618b8')
+sha512sums=('1cc74927dec9958c579b64a414de64167ac5375af3e1c9fc956199bd10fa3ad373bc6d1d1b264fc69811989e9eaad4a9b3539e4ee340fc882cd8d701b99b752d')
 validpgpkeys=(
   '8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600' # Michaël Zasso (Targos) <targos@protonmail.com>
   '890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4' # RafaelGSS <rafael.nunu@hotmail.com>


### PR DESCRIPTION
Resolves: https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/893

<details>

```
ILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_postmortem_metadata.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_task_runner.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_path.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_per_process.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_platform.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_quic_cid.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_quic_error.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_quic_tokens.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_report.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_sockaddr.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_string_bytes.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_traced_value.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_util.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/googletest/libgtest.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/googletest/libgtest_main.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/histogram/libhistogram.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/nbytes/libnbytes.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libabseil.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ncrypto/libncrypto.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/inspector_protocol/libcrdtp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libplatform.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/llhttp/libllhttp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/uvwasi/libuvwasi.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ada/libada.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libsimdutf.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/sqlite/libsqlite.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/zstd/libzstd.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libbase.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_zlib.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libhighway.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers_slow.a -lz -luv -lsimdjson -lbrotlidec -lbrotlienc -lcares -lnghttp2 -lnghttp3 -lngtcp2 -lcrypto -lssl -licui18n -licuuc -ldl -Wl,--end-group
  LD_LIBRARY_PATH=/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.host:/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../.; mkdir -p /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen; "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/node_mksnapshot" "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/node_snapshot.cc"
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/src/node_main.o ../src/node_main.cc '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-DNODE_OPENSSL_CONF_NAME=nodejs_conf' '-DICU_NO_USER_DATA_OVERRIDE' '-D__STDC_FORMAT_MACROS' '-DNODE_ARCH="x64"' '-DNODE_PLATFORM="linux"' '-DNODE_WANT_INTERNALS=1' '-D__POSIX__' '-DNODE_USE_V8_PLATFORM=1' '-DNODE_HAVE_I18N_SUPPORT=1' '-DHAVE_OPENSSL=1' '-DHAVE_AMARO=1' '-DXXH_NAMESPACE=ZSTD_' '-DZSTD_MULTITHREAD' '-DZSTD_DISABLE_ASM' -I../src -I../deps/v8/include -I../deps/postject -I../deps/histogram/src -I../deps/histogram/include -I../deps/llhttp/include -I../deps/uvwasi/include -I../deps/ada -I../deps/v8/third_party/simdutf -I../deps/sqlite -I../deps/zstd/lib  -Wall -Wextra -Wno-unused-parameter -Wno-restrict -pthread -Wall -Wextra -Wno-unused-parameter -m64 -O3 -fno-omit-frame-pointer -fprofile-use -fprofile-correction  -fno-rtti -fno-exceptions -fno-strict-aliasing -std=gnu++20 -MMD -MF /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/.deps//home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/src/node_main.o.d.raw  -march=native -O3 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -fno-semantic-interposition -Wno-error=coverage-mismatch -c
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/gen/node_snapshot.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/node_snapshot.cc '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-DNODE_OPENSSL_CONF_NAME=nodejs_conf' '-DICU_NO_USER_DATA_OVERRIDE' '-D__STDC_FORMAT_MACROS' '-DNODE_ARCH="x64"' '-DNODE_PLATFORM="linux"' '-DNODE_WANT_INTERNALS=1' '-D__POSIX__' '-DNODE_USE_V8_PLATFORM=1' '-DNODE_HAVE_I18N_SUPPORT=1' '-DHAVE_OPENSSL=1' '-DHAVE_AMARO=1' '-DXXH_NAMESPACE=ZSTD_' '-DZSTD_MULTITHREAD' '-DZSTD_DISABLE_ASM' -I../src -I../deps/v8/include -I../deps/postject -I../deps/histogram/src -I../deps/histogram/include -I../deps/llhttp/include -I../deps/uvwasi/include -I../deps/ada -I../deps/v8/third_party/simdutf -I../deps/sqlite -I../deps/zstd/lib  -Wall -Wextra -Wno-unused-parameter -Wno-restrict -pthread -Wall -Wextra -Wno-unused-parameter -m64 -O3 -fno-omit-frame-pointer -fprofile-use -fprofile-correction  -fno-rtti -fno-exceptions -fno-strict-aliasing -std=gnu++20 -MMD -MF /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/.deps//home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/gen/node_snapshot.o.d.raw  -march=native -O3 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -fno-semantic-interposition -Wno-error=coverage-mismatch -c
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/node -pthread -rdynamic /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node_text_start/src/large_pages/node_text_start.o -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a -Wl,--no-whole-archive -Wl,-z,noexecstack -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a -Wl,--no-whole-archive -Wl,-z,relro -Wl,-z,now -m64 -fprofile-use -fprofile-correction  -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now          -Wl,-z,pack-relative-relocs -Wl,--start-group /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/src/node_main.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/gen/node_snapshot.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/histogram/libhistogram.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode_text_start.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libplatform.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/llhttp/libllhttp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/uvwasi/libuvwasi.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ada/libada.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libsimdutf.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/sqlite/libsqlite.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/zstd/libzstd.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/nbytes/libnbytes.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libabseil.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/inspector_protocol/libcrdtp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ncrypto/libncrypto.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libbase.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_zlib.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libhighway.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers_slow.a -lz -luv -lsimdjson -lbrotlidec -lbrotlienc -lcares -lnghttp2 -lnghttp3 -lngtcp2 -lcrypto -lssl -licui18n -licuuc -ldl -Wl,--end-group
rm 6a019bfaed71858553b8471545ac460f3784edf8.intermediate ec0667893b6225f3f851dfcb0f6c62b65fb6795d.intermediate 65ea95a24e43162a9c684853a9eab26239dd48ae.intermediate df33be58d16afd798f40515fe0dc95f1b5206e20.intermediate
if [ ! -r node ] || [ ! -L node ]; then \
  ln -fs out/Release/node node; fi
==> Entering fakeroot environment...
==> Starting package()...
make -C out BUILDTYPE=Release V=0
  touch 65ea95a24e43162a9c684853a9eab26239dd48ae.intermediate
  LD_LIBRARY_PATH=/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.host:/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../tools/v8_gypfiles; mkdir -p /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/inspector-generated-output-root/src/inspector/protocol /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/inspector-generated-output-root/include/inspector; /usr/bin/python3.13 ../../deps/v8/third_party/inspector_protocol/code_generator.py --jinja_dir ../../deps/v8/third_party --output_base "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/inspector-generated-output-root/src/inspector" --config ../../deps/v8/src/inspector/inspector_protocol_config.json --config_value "protocol.path=../../deps/v8/include/js_protocol.pdl" --inspector_protocol_dir ../../deps/v8/third_party/inspector_protocol
  touch ec0667893b6225f3f851dfcb0f6c62b65fb6795d.intermediate
  LD_LIBRARY_PATH=/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.host:/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../tools/v8_gypfiles; mkdir -p /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/test/torque /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/third_party/v8/builtins /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/src/wasm /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/src/builtins /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/src/objects /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/src/debug /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated/src/ic; "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/torque" -o "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/torque-generated" -v8-root ../../deps/v8 src/builtins/aggregate-error.tq src/builtins/array-at.tq src/builtins/array-concat.tq src/builtins/array-copywithin.tq src/builtins/array-every.tq src/builtins/array-filter.tq src/builtins/array-find.tq src/builtins/array-findindex.tq src/builtins/array-findlast.tq src/builtins/array-findlastindex.tq src/builtins/array-flat.tq src/builtins/array-foreach.tq src/builtins/array-from-async.tq src/builtins/array-from.tq src/builtins/array-isarray.tq src/builtins/array-join.tq src/builtins/array-lastindexof.tq src/builtins/array-map.tq src/builtins/array-of.tq src/builtins/array-reduce-right.tq src/builtins/array-reduce.tq src/builtins/array-reverse.tq src/builtins/array-shift.tq src/builtins/array-slice.tq src/builtins/array-some.tq src/builtins/array-splice.tq src/builtins/array-to-reversed.tq src/builtins/array-to-sorted.tq src/builtins/array-to-spliced.tq src/builtins/array-unshift.tq src/builtins/array-with.tq src/builtins/array.tq src/builtins/arraybuffer.tq src/builtins/base.tq src/builtins/boolean.tq src/builtins/builtins-bigint.tq src/builtins/builtins-string.tq src/builtins/cast.tq src/builtins/collections.tq src/builtins/constructor.tq src/builtins/conversion.tq src/builtins/convert.tq src/builtins/console.tq src/builtins/data-view.tq src/builtins/finalization-registry.tq src/builtins/frames.tq src/builtins/frame-arguments.tq src/builtins/function.tq src/builtins/growable-fixed-array.tq src/builtins/ic-callable.tq src/builtins/ic.tq src/builtins/internal-coverage.tq src/builtins/internal.tq src/builtins/iterator.tq src/builtins/iterator-from.tq src/builtins/iterator-helpers.tq src/builtins/map-groupby.tq src/builtins/math.tq src/builtins/number.tq src/builtins/object-fromentries.tq src/builtins/object-groupby.tq src/builtins/object.tq src/builtins/promise-abstract-operations.tq src/builtins/promise-all.tq src/builtins/promise-all-element-closure.tq src/builtins/promise-any.tq src/builtins/promise-constructor.tq src/builtins/promise-finally.tq src/builtins/promise-jobs.tq src/builtins/promise-misc.tq src/builtins/promise-race.tq src/builtins/promise-reaction-job.tq src/builtins/promise-resolve.tq src/builtins/promise-then.tq src/builtins/promise-try.tq src/builtins/promise-withresolvers.tq src/builtins/proxy-constructor.tq src/builtins/proxy-delete-property.tq src/builtins/proxy-get-property.tq src/builtins/proxy-get-prototype-of.tq src/builtins/proxy-has-property.tq src/builtins/proxy-is-extensible.tq src/builtins/proxy-prevent-extensions.tq src/builtins/proxy-revocable.tq src/builtins/proxy-revoke.tq src/builtins/proxy-set-property.tq src/builtins/proxy-set-prototype-of.tq src/builtins/proxy.tq src/builtins/reflect.tq src/builtins/regexp-exec.tq src/builtins/regexp-match-all.tq src/builtins/regexp-match.tq src/builtins/regexp-replace.tq src/builtins/regexp-search.tq src/builtins/regexp-source.tq src/builtins/regexp-split.tq src/builtins/regexp-test.tq src/builtins/regexp.tq src/builtins/set-difference.tq src/builtins/set-intersection.tq src/builtins/set-is-disjoint-from.tq src/builtins/set-is-subset-of.tq src/builtins/set-is-superset-of.tq src/builtins/set-symmetric-difference.tq src/builtins/set-union.tq src/builtins/string-at.tq src/builtins/string-endswith.tq src/builtins/string-html.tq src/builtins/string-includes.tq src/builtins/string-indexof.tq src/builtins/string-iswellformed.tq src/builtins/string-iterator.tq src/builtins/string-match-search.tq src/builtins/string-pad.tq src/builtins/string-repeat.tq src/builtins/string-replaceall.tq src/builtins/string-slice.tq src/builtins/string-startswith.tq src/builtins/string-substr.tq src/builtins/string-substring.tq src/builtins/string-towellformed.tq src/builtins/string-trim.tq src/builtins/suppressed-error.tq src/builtins/symbol.tq src/builtins/torque-internal.tq src/builtins/typed-array-at.tq src/builtins/typed-array-createtypedarray.tq src/builtins/typed-array-every.tq src/builtins/typed-array-entries.tq src/builtins/typed-array-filter.tq src/builtins/typed-array-find.tq src/builtins/typed-array-findindex.tq src/builtins/typed-array-findlast.tq src/builtins/typed-array-findlastindex.tq src/builtins/typed-array-foreach.tq src/builtins/typed-array-from.tq src/builtins/typed-array-keys.tq src/builtins/typed-array-of.tq src/builtins/typed-array-reduce.tq src/builtins/typed-array-reduceright.tq src/builtins/typed-array-set.tq src/builtins/typed-array-slice.tq src/builtins/typed-array-some.tq src/builtins/typed-array-sort.tq src/builtins/typed-array-subarray.tq src/builtins/typed-array-to-reversed.tq src/builtins/typed-array-to-sorted.tq src/builtins/typed-array-values.tq src/builtins/typed-array-with.tq src/builtins/typed-array.tq src/builtins/weak-ref.tq src/ic/handler-configuration.tq src/objects/allocation-site.tq src/objects/api-callbacks.tq src/objects/arguments.tq src/objects/bigint.tq src/objects/call-site-info.tq src/objects/cell.tq src/objects/bytecode-array.tq src/objects/contexts.tq src/objects/data-handler.tq src/objects/debug-objects.tq src/objects/descriptor-array.tq src/objects/embedder-data-array.tq src/objects/feedback-cell.tq src/objects/feedback-vector.tq src/objects/fixed-array.tq src/objects/foreign.tq src/objects/free-space.tq src/objects/heap-number.tq src/objects/heap-object.tq src/objects/js-array-buffer.tq src/objects/js-array.tq src/objects/js-atomics-synchronization.tq src/objects/js-collection-iterator.tq src/objects/js-collection.tq src/objects/js-disposable-stack.tq src/objects/js-function.tq src/objects/js-generator.tq src/objects/js-iterator-helpers.tq src/objects/js-objects.tq src/objects/js-promise.tq src/objects/js-proxy.tq src/objects/js-raw-json.tq src/objects/js-regexp-string-iterator.tq src/objects/js-regexp.tq src/objects/js-shadow-realm.tq src/objects/js-shared-array.tq src/objects/js-struct.tq src/objects/js-temporal-objects.tq src/objects/js-weak-refs.tq src/objects/literal-objects.tq src/objects/map.tq src/objects/megadom-handler.tq src/objects/microtask.tq src/objects/module.tq src/objects/name.tq src/objects/oddball.tq src/objects/hole.tq src/objects/trusted-object.tq src/objects/ordered-hash-table.tq src/objects/primitive-heap-object.tq src/objects/promise.tq src/objects/property-array.tq src/objects/property-cell.tq src/objects/property-descriptor-object.tq src/objects/prototype-info.tq src/objects/regexp-match-info.tq src/objects/scope-info.tq src/objects/script.tq src/objects/shared-function-info.tq src/objects/source-text-module.tq src/objects/string.tq src/objects/struct.tq src/objects/swiss-hash-table-helpers.tq src/objects/swiss-name-dictionary.tq src/objects/synthetic-module.tq src/objects/template-objects.tq src/objects/templates.tq src/objects/torque-defined-classes.tq src/objects/turbofan-types.tq src/objects/turboshaft-types.tq test/torque/test-torque.tq third_party/v8/builtins/array-sort.tq src/objects/intl-objects.tq src/objects/js-break-iterator.tq src/objects/js-collator.tq src/objects/js-date-time-format.tq src/objects/js-display-names.tq src/objects/js-duration-format.tq src/objects/js-list-format.tq src/objects/js-locale.tq src/objects/js-number-format.tq src/objects/js-plural-rules.tq src/objects/js-relative-time-format.tq src/objects/js-segment-iterator.tq src/objects/js-segmenter.tq src/objects/js-segments.tq src/builtins/js-to-js.tq src/builtins/js-to-wasm.tq src/builtins/wasm.tq src/builtins/wasm-strings.tq src/builtins/wasm-to-js.tq src/debug/debug-wasm-objects.tq src/wasm/wasm-objects.tq
  touch df33be58d16afd798f40515fe0dc95f1b5206e20.intermediate
  LD_LIBRARY_PATH=/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.host:/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../.; mkdir -p /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/src/node/inspector/protocol; /usr/bin/python3.13 deps/inspector_protocol/code_generator.py --inspector_protocol_dir deps/inspector_protocol --jinja_dir tools/inspector_protocol --output_base "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/src/" --config src/inspector/node_protocol_config.json
  touch 6a019bfaed71858553b8471545ac460f3784edf8.intermediate
  LD_LIBRARY_PATH=/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.host:/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../tools/v8_gypfiles; mkdir -p /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni; "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/mksnapshot" --turbo_instruction_scheduling --stress-turbo-late-spilling "--target_os=linux" "--target_arch=x64" --startup_src "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/snapshot.cc" --embedded_variant Default --embedded_src "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/embedded.S" --concurrent-builtin-generation "--concurrent-turbofan-max-threads=0" --no-native-code-counters
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/snapshot.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/snapshot.cc '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-DNODE_OPENSSL_CONF_NAME=nodejs_conf' '-DICU_NO_USER_DATA_OVERRIDE' '-DV8_GYP_BUILD' '-DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64' '-D__STDC_FORMAT_MACROS' '-DV8_TARGET_ARCH_X64' '-DV8_HAVE_TARGET_OS' '-DV8_TARGET_OS_LINUX' '-DV8_EMBEDDER_STRING="-node.28"' '-DENABLE_DISASSEMBLER' '-DV8_PROMISE_INTERNAL_FIELD_COUNT=1' '-DV8_ENABLE_PRIVATE_MAPPING_FORK_OPTIMIZATION' '-DV8_SHORT_BUILTIN_CALLS' '-DOBJECT_PRINT' '-DV8_INTL_SUPPORT' '-DV8_ATOMIC_OBJECT_FIELD_WRITES' '-DV8_ENABLE_LAZY_SOURCE_POSITIONS' '-DV8_USE_SIPHASH' '-DNDEBUG' '-DV8_WIN64_UNWINDING_INFO' '-DV8_ENABLE_REGEXP_INTERPRETER_THREADED_DISPATCH' '-DV8_USE_ZLIB' '-DV8_ENABLE_LEAPTIERING' '-DV8_ENABLE_SPARKPLUG' '-DV8_ENABLE_MAGLEV' '-DV8_ENABLE_TURBOFAN' '-DV8_ENABLE_WEBASSEMBLY' '-DV8_ENABLE_JAVASCRIPT_PROMISE_HOOKS' '-DV8_ENABLE_CONTINUATION_PRESERVED_EMBEDDER_DATA' '-DV8_ALLOCATION_FOLDING' '-DV8_ALLOCATION_SITE_TRACKING' '-DV8_ADVANCED_BIGINT_ALGORITHMS' '-DV8_ENABLE_WASM_SIMD256_REVEC' -I../deps/v8 -I../deps/v8/include -I/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/generate-bytecode-output-root -I/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen -I../deps/v8/third_party/abseil-cpp  -pthread -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Wno-int-in-bool-context -Wno-deprecated -Wno-stringop-overflow -Wno-stringop-overread -Wno-restrict -Wno-array-bounds -Wno-nonnull -Wno-dangling-pointer -flax-vector-conversions -m64 -O3 -fno-omit-frame-pointer -fprofile-use -fprofile-correction -fdata-sections -ffunction-sections -O3 -fno-rtti -fno-exceptions -fno-strict-aliasing -std=gnu++20 -Wno-invalid-offsetof -MMD -MF /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/.deps//home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/snapshot.o.d.raw  -march=native -O3 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -fno-semantic-interposition -Wno-error=coverage-mismatch -c
  cc -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/embedded.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/embedded.S '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-DNODE_OPENSSL_CONF_NAME=nodejs_conf' '-DICU_NO_USER_DATA_OVERRIDE' '-DV8_GYP_BUILD' '-DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64' '-D__STDC_FORMAT_MACROS' '-DV8_TARGET_ARCH_X64' '-DV8_HAVE_TARGET_OS' '-DV8_TARGET_OS_LINUX' '-DV8_EMBEDDER_STRING="-node.28"' '-DENABLE_DISASSEMBLER' '-DV8_PROMISE_INTERNAL_FIELD_COUNT=1' '-DV8_ENABLE_PRIVATE_MAPPING_FORK_OPTIMIZATION' '-DV8_SHORT_BUILTIN_CALLS' '-DOBJECT_PRINT' '-DV8_INTL_SUPPORT' '-DV8_ATOMIC_OBJECT_FIELD_WRITES' '-DV8_ENABLE_LAZY_SOURCE_POSITIONS' '-DV8_USE_SIPHASH' '-DNDEBUG' '-DV8_WIN64_UNWINDING_INFO' '-DV8_ENABLE_REGEXP_INTERPRETER_THREADED_DISPATCH' '-DV8_USE_ZLIB' '-DV8_ENABLE_LEAPTIERING' '-DV8_ENABLE_SPARKPLUG' '-DV8_ENABLE_MAGLEV' '-DV8_ENABLE_TURBOFAN' '-DV8_ENABLE_WEBASSEMBLY' '-DV8_ENABLE_JAVASCRIPT_PROMISE_HOOKS' '-DV8_ENABLE_CONTINUATION_PRESERVED_EMBEDDER_DATA' '-DV8_ALLOCATION_FOLDING' '-DV8_ALLOCATION_SITE_TRACKING' '-DV8_ADVANCED_BIGINT_ALGORITHMS' '-DV8_ENABLE_WASM_SIMD256_REVEC' -I../deps/v8 -I../deps/v8/include -I/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/generate-bytecode-output-root -I/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen -I../deps/v8/third_party/abseil-cpp  -pthread -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Wno-int-in-bool-context -Wno-deprecated -Wno-stringop-overflow -Wno-stringop-overread -Wno-restrict -Wno-array-bounds -Wno-nonnull -Wno-dangling-pointer -flax-vector-conversions -m64 -O3 -fno-omit-frame-pointer -fprofile-use -fprofile-correction -fdata-sections -ffunction-sections -O3  -MMD -MF /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/.deps//home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/v8_snapshot/geni/embedded.o.d.raw  -march=native -O3 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -fno-semantic-interposition -Wno-error=coverage-mismatch -c
rm -f /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a ar-file-list; mkdir -p `dirname /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a`
ar crsT /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a @/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a.ar-file-list
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/cctest -pthread -rdynamic -Wl,-z,noexecstack -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a -Wl,--no-whole-archive -Wl,-z,relro -Wl,-z,now -m64 -fprofile-use -fprofile-correction  -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now          -Wl,-z,pack-relative-relocs -Wl,--start-group /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/src/node_snapshot_stub.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/inspector/test_node_protocol.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/node_test_fixture.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_aliased_buffer.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_base64.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_base_object_ptr.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_cppgc.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_crypto_clienthello.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_dataqueue.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_environment.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_inspector_socket.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_inspector_socket_server.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_json_utils.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_linked_binding.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_lru_cache.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_api.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_crypto.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_crypto_env.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_postmortem_metadata.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_node_task_runner.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_path.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_per_process.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_platform.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_quic_cid.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_quic_error.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_quic_tokens.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_report.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_sockaddr.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_string_bytes.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_traced_value.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/cctest/test/cctest/test_util.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/googletest/libgtest.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/googletest/libgtest_main.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/histogram/libhistogram.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/nbytes/libnbytes.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libabseil.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ncrypto/libncrypto.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/inspector_protocol/libcrdtp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libplatform.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/llhttp/libllhttp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/uvwasi/libuvwasi.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ada/libada.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libsimdutf.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/sqlite/libsqlite.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/zstd/libzstd.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libbase.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_zlib.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libhighway.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers_slow.a -lz -luv -lsimdjson -lbrotlidec -lbrotlienc -lcares -lnghttp2 -lnghttp3 -lngtcp2 -lcrypto -lssl -licui18n -licuuc -ldl -Wl,--end-group
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/embedtest -pthread -rdynamic -Wl,-z,noexecstack -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a -Wl,--no-whole-archive -Wl,-z,relro -Wl,-z,now -m64 -fprofile-use -fprofile-correction  -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now          -Wl,-z,pack-relative-relocs -Wl,--start-group /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/embedtest/src/node_snapshot_stub.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/embedtest/test/embedding/embedtest.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/histogram/libhistogram.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/nbytes/libnbytes.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libplatform.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/llhttp/libllhttp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/uvwasi/libuvwasi.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ada/libada.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libsimdutf.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/sqlite/libsqlite.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/zstd/libzstd.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libabseil.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/inspector_protocol/libcrdtp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ncrypto/libncrypto.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libbase.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_zlib.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libhighway.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers_slow.a -lz -luv -lsimdjson -lbrotlidec -lbrotlienc -lcares -lnghttp2 -lnghttp3 -lngtcp2 -lcrypto -lssl -licui18n -licuuc -ldl -Wl,--end-group
  touch /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/fuzz_ClientHelloParser.stamp
  touch /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/fuzz_env.stamp
  touch /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/fuzz_strings.stamp
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/node_mksnapshot -pthread -rdynamic -Wl,-z,noexecstack -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a -Wl,--no-whole-archive -Wl,-z,relro -Wl,-z,now -m64 -fprofile-use -fprofile-correction  -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now          -Wl,-z,pack-relative-relocs -Wl,--start-group /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node_mksnapshot/src/node_snapshot_stub.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node_mksnapshot/tools/snapshot/node_mksnapshot.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/histogram/libhistogram.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/nbytes/libnbytes.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ncrypto/libncrypto.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libplatform.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/llhttp/libllhttp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/uvwasi/libuvwasi.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ada/libada.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libsimdutf.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/sqlite/libsqlite.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/zstd/libzstd.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libabseil.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/inspector_protocol/libcrdtp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libbase.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_zlib.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libhighway.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers_slow.a -lz -luv -lsimdjson -lbrotlidec -lbrotlienc -lcares -lnghttp2 -lnghttp3 -lngtcp2 -lcrypto -lssl -licui18n -licuuc -ldl -Wl,--end-group
  LD_LIBRARY_PATH=/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.host:/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../.; mkdir -p /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen; "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/node_mksnapshot" "/home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/node_snapshot.cc"
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/gen/node_snapshot.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj/gen/node_snapshot.cc '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-DNODE_OPENSSL_CONF_NAME=nodejs_conf' '-DICU_NO_USER_DATA_OVERRIDE' '-D__STDC_FORMAT_MACROS' '-DNODE_ARCH="x64"' '-DNODE_PLATFORM="linux"' '-DNODE_WANT_INTERNALS=1' '-D__POSIX__' '-DNODE_USE_V8_PLATFORM=1' '-DNODE_HAVE_I18N_SUPPORT=1' '-DHAVE_OPENSSL=1' '-DHAVE_AMARO=1' '-DXXH_NAMESPACE=ZSTD_' '-DZSTD_MULTITHREAD' '-DZSTD_DISABLE_ASM' -I../src -I../deps/v8/include -I../deps/postject -I../deps/histogram/src -I../deps/histogram/include -I../deps/llhttp/include -I../deps/uvwasi/include -I../deps/ada -I../deps/v8/third_party/simdutf -I../deps/sqlite -I../deps/zstd/lib  -Wall -Wextra -Wno-unused-parameter -Wno-restrict -pthread -Wall -Wextra -Wno-unused-parameter -m64 -O3 -fno-omit-frame-pointer -fprofile-use -fprofile-correction  -fno-rtti -fno-exceptions -fno-strict-aliasing -std=gnu++20 -MMD -MF /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/.deps//home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/gen/node_snapshot.o.d.raw  -march=native -O3 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -fno-semantic-interposition -Wno-error=coverage-mismatch -c
  g++ -o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/node -pthread -rdynamic /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node_text_start/src/large_pages/node_text_start.o -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a -Wl,--no-whole-archive -Wl,-z,noexecstack -Wl,--whole-archive /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a -Wl,--no-whole-archive -Wl,-z,relro -Wl,-z,now -m64 -fprofile-use -fprofile-correction  -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now          -Wl,-z,pack-relative-relocs -Wl,--start-group /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/src/node_main.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/node/gen/node_snapshot.o /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/histogram/libhistogram.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/libnode_text_start.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_snapshot.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libplatform.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/llhttp/libllhttp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/uvwasi/libuvwasi.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ada/libada.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libsimdutf.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/sqlite/libsqlite.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/zstd/libzstd.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/nbytes/libnbytes.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libabseil.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/inspector_protocol/libcrdtp.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/deps/ncrypto/libncrypto.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_libbase.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_zlib.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libhighway.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_compiler.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers.a /home/lin/CachyOS-PKGBUILDS/nodejs/src/node/out/Release/obj.target/tools/v8_gypfiles/libv8_initializers_slow.a -lz -luv -lsimdjson -lbrotlidec -lbrotlienc -lcares -lnghttp2 -lnghttp3 -lngtcp2 -lcrypto -lssl -licui18n -licuuc -ldl -Wl,--end-group
rm 6a019bfaed71858553b8471545ac460f3784edf8.intermediate ec0667893b6225f3f851dfcb0f6c62b65fb6795d.intermediate 65ea95a24e43162a9c684853a9eab26239dd48ae.intermediate df33be58d16afd798f40515fe0dc95f1b5206e20.intermediate
if [ ! -r node ] || [ ! -L node ]; then \
  ln -fs out/Release/node node; fi
/usr/bin/python3.13 tools/install.py install --dest-dir '/home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs' --prefix '/usr'
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/bin/node
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/share/doc/node/gdbinit
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/share/doc/node/lldb_commands.py
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/share/man/man1/node.1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/CHANGELOG.md
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/LICENSE.md
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/README.md
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/package.json
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/corepack.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/npm.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/npx.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/pnpm.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/pnpx.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/yarn.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/yarnpkg.js
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/dist/lib/corepack.cjs
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/corepack
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/corepack.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/corepack.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/npm
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/npm.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/npm.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/npx
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/npx.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/npx.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/pnpm
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/pnpm.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/pnpm.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/pnpx
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/pnpx.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/pnpx.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/yarn
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/yarn.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/yarn.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/yarnpkg
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/yarnpkg.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/yarnpkg.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/corepack
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/corepack.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/corepack.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/npm
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/npm.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/npm.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/npx
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/npx.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/npx.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/pnpm
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/pnpm.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/pnpm.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/pnpx
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/pnpx.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/pnpx.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/yarn
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/yarn.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/yarn.ps1
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/yarnpkg
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/yarnpkg.cmd
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/lib/node_modules/corepack/shims/nodewin/yarnpkg.ps1
symlinking ../lib/node_modules/corepack/dist/corepack.js -> /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/bin/corepack
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/config.gypi
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/common.gypi
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/node.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/node_api.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/js_native_api.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/js_native_api_types.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/node_api_types.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/node_buffer.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/node_object_wrap.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/node_version.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-container.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-cppgc.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-date.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-embedder-heap.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-embedder-state-scope.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-exception.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-extension.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-external.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-forward.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-function.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-handle-base.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-initialization.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-locker.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-microtask-queue.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-microtask.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-primitive-object.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-promise.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-proxy.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-regexp.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-script.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-snapshot.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-statistics.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-typed-array.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-value-serializer.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-value.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-wasm.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-weak-callback-info.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-array-buffer.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-callbacks.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-context.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-data.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-debug.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-function-callback.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-internal.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-isolate.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-json.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-local-handle.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-maybe.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-memory-span.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-message.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-object.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-persistent-handle.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-platform.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-primitive.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-profiler.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-sandbox.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-source-location.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-template.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-traced-handle.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-unwinder.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8-version.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/v8config.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/common.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/custom-space.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/default-platform.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/explicit-management.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/garbage-collected.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/heap-consistency.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/heap-handle.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/heap-state.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/heap-statistics.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/heap.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/liveness-broker.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/macros.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/name-provider.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/object-size-trait.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/prefinalizer.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/process-heap-statistics.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/sentinel-pointer.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/source-location.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/testing.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/type-traits.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/allocation.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/cross-thread-persistent.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/member.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/persistent.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/platform.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/trace-trait.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/visitor.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/api-constants.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/atomic-entry-flag.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/base-page-handle.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/caged-heap-local-data.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/caged-heap.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/compiler-specific.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/conditional-stack-allocated.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/member-storage.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/persistent-node.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/write-barrier.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/finalizer-trait.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/gc-info.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/logging.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/name-trait.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/cppgc/internal/pointer-policies.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/libplatform/libplatform-export.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/libplatform/libplatform.h
installing /home/lin/CachyOS-PKGBUILDS/nodejs/pkg/nodejs/usr/include/node/libplatform/v8-tracing.h
==> Tidying install...
  -> Removing libtool files...
  -> Purging unwanted files...
  -> Removing static library files...
  -> Stripping unneeded symbols from binaries and libraries...
  -> Compressing man and info pages...
==> Checking for packaging issues...
==> Creating package "nodejs"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: nodejs 24.10.0-1 (Пн 13 окт 2025 01:59:31)
⏎                                                                     

~/CachyOS-PKGBUILDS/nodejs nodejs 1h 26m 43s
❯ 
sudo pacman -U nodejs-24.10.0-1-x86_64.pkg.tar.zst
[sudo] password for lin: 
loading packages...
resolving dependencies...
looking for conflicting packages...

Package (1)  New Version  Net Change

nodejs       24.10.0-1     61,96 MiB

Total Installed Size:  61,96 MiB

:: Proceed with installation? [Y/n] Y
(1/1) checking keys in keyring                     [------------] 100%
(1/1) checking package integrity                   [------------] 100%
(1/1) loading package files                        [------------] 100%
(1/1) checking for file conflicts                  [------------] 100%
:: Running pre-transaction hooks...
(1/2) Performing snapper pre snapshots for the following configurations...
==> root: 46
(2/2) Wait for limine-snapper-sync to finish before updating, installing or removing.
:: Processing package changes...
(1/1) installing nodejs                            [------------] 100%
Optional dependencies for nodejs
    npm: nodejs package manager
:: Running post-transaction hooks...
(1/2) Arming ConditionNeedsUpdate...
(2/2) Performing snapper post snapshots for the following configurations...
==> root: 47

~/CachyOS-PKGBUILDS/nodejs nodejs 15s
❯ 
node --version
v24.10.0

~/CachyOS-PKGBUILDS/nodejs nodejs
❯ 

```

</details>