### PR TITLE
[zstd] Enable vectorized XXH64 for `znver4`

### DIFF
--- a/zstd/lib32-zstd/PKGBUILD
+++ b/zstd/lib32-zstd/PKGBUILD
@@ -3,6 +3,8 @@
 # Contributor: Andrzej Giniewicz <gginiu@gmail.com>
 # Contributor: Johan Förberg <johan@forberg.se>
 
+_optimize_znver4=${_optimize_znver4-}
+
 _pkgname=zstd
 pkgname=lib32-zstd
 pkgver=1.5.7
@@ -54,8 +56,8 @@ build() {
   # Znver4, since unlike Intel u-archs, it doesn't suffer from high AVX-512 latency.
   xxh64_vectorize=''
 
-  if  [[ "$CARCH" == "znver4" ]]; then
-    xxh64_vectorize='-DXXH_ENABLE_AUTOVECTORIZE'
+  if [ -n "$_optimize_znver4" ]; then
+    xxh64_vectorize="-DXXH64_UPDATE_VECTORIZE=ON"
   fi
 
   cmake -S build/cmake -B build -G Ninja \

--- a/zstd/zstd-pgo/PKGBUILD
+++ b/zstd/zstd-pgo/PKGBUILD
@@ -4,6 +4,8 @@
 # Contributor: Johan Förberg <johan@forberg.se>
 # PGO Version: Laio O. Seman <laio@ieee.org>
 
+_optimize_znver4=${_optimize_znver4-}
+
 pkgname=zstd
 pkgver=1.5.7
 pkgrel=2
@@ -66,8 +68,8 @@ build() {
   # Znver4, since unlike Intel u-archs, it doesn't suffer from high AVX-512 latency.
   xxh64_vectorize=''
 
-  if  [[ "$CARCH" == "znver4" ]]; then
-    xxh64_vectorize='-DXXH_ENABLE_AUTOVECTORIZE'
+  if [ -n "$_optimize_znver4" ]; then
+    xxh64_vectorize="-DXXH64_UPDATE_VECTORIZE=ON"
   fi
 
   # First build pass: Generate profile

--- a/zstd/zstd/PKGBUILD
+++ b/zstd/zstd/PKGBUILD
@@ -3,6 +3,8 @@
 # Contributor: Andrzej Giniewicz <gginiu@gmail.com>
 # Contributor: Johan Förberg <johan@forberg.se>
 
+_optimize_znver4=${_optimize_znver4-}
+
 pkgname=zstd
 pkgver=1.5.7
 pkgrel=2
@@ -51,8 +53,8 @@ build() {
   # Znver4, since unlike Intel u-archs, it doesn't suffer from high AVX-512 latency.
   xxh64_vectorize=''
 
-  if  [[ "$CARCH" == "znver4" ]]; then
-    xxh64_vectorize='-DXXH_ENABLE_AUTOVECTORIZE'
+  if [ -n "$_optimize_znver4" ]; then
+    xxh64_vectorize="-DXXH64_UPDATE_VECTORIZE=ON"
   fi
 
   cmake -S build/cmake -B build -G Ninja \


### PR DESCRIPTION
As of facebook/zstd#3819, "auto vectorization of xxhash64" is disabled when AVX-512 is present due to the high latency of the Skylake-X implementation of AVX-512.

Other Intel uarchs also suffer from this high latency, but `znver4` and `znver5` do not, according to uops.info.

This PR re-enables auto vectorization for XXH64 on builds targeting `znver4` by conditionally adding the `XXH_ENABLE_AUTOVECTORIZE` flag according to the `CARCH` variable in the `PKGBUILD` script for `zstd`, `zstd-pgo`, and `lib32-zstd`.

According to [facebook/zstd/lib/common/xxhash.h](https://github.com/facebook/zstd/blob/dev/lib/common/xxhash.h), "Autovectorization of XXH64 tends to be detrimental, though the exact outcome may change depending on exact cpu and compiler version. For information, it has been reported as detrimental for Skylake-X, but possibly beneficial for Zen4."