### PR TITLE
Cachy-Update: Drop the qt6-wayland optional dependency

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachy-update
 	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
 	pkgver = 3.15.7
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/CachyOS/cachy-update
 	arch = any
 	license = GPL-3.0-or-later
@@ -29,7 +29,6 @@ pkgbase = cachy-update
 	optdepends = libnotify: Desktop notifications support on new available updates
 	optdepends = vim: Default diff program for pacdiff
 	optdepends = neovim: Default diff program for pacdiff if EDITOR=nvim
-	optdepends = qt6-wayland: Systray applet support on Wayland
 	optdepends = sudo: Privilege elevation
 	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cachy-update
 pkgver=3.15.7
-pkgrel=1
+pkgrel=2
 pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
 arch=('any')
@@ -19,7 +19,6 @@ optdepends=('paru: AUR Packages support'
             'libnotify: Desktop notifications support on new available updates'
             'vim: Default diff program for pacdiff'
             'neovim: Default diff program for pacdiff if EDITOR=nvim'
-            'qt6-wayland: Systray applet support on Wayland'
             'sudo: Privilege elevation'
             'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')


### PR DESCRIPTION
https://archlinux.org/todo/qt6-wayland-dependency-cleanup/