### PR TITLE
mesa: Disable anti-lag layer by default

### DIFF
--- a/mesa/mesa/.SRCINFO
+++ b/mesa/mesa/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = mesa
 	pkgdesc = Open-source OpenGL drivers
 	pkgver = 25.2.4
-	pkgrel = 2
+	pkgrel = 3
 	epoch = 1
 	url = https://www.mesa3d.org/
 	arch = x86_64
@@ -59,6 +59,7 @@ pkgbase = mesa
 	source = https://archive.mesa3d.org/mesa-25.2.4.tar.xz.sig
 	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34242.patch
 	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37137.patch
+	source = https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37509.patch
 	source = zerocopy-0.8.13.tar.gz::https://crates.io/api/v1/crates/zerocopy/0.8.13/download
 	source = ucd-trie-0.1.6.tar.gz::https://crates.io/api/v1/crates/ucd-trie/0.1.6/download
 	source = pest_meta-2.8.0.tar.gz::https://crates.io/api/v1/crates/pest_meta/2.8.0/download
@@ -96,6 +97,7 @@ pkgbase = mesa
 	sha256sums = SKIP
 	sha256sums = 1e83a132618ebc2a2236779223ace94354f22b3372ce739ee6641e83f2d0f9e8
 	sha256sums = 2ee4a8dcba2ac1a162ac8b7d1751d9a363d0249df06897a4cf905ec9f59d17df
+	sha256sums = 0d6ac888f4401acab2f9a99cf2fd7d8a06ec2503ebf2807a8835eae6e06a4758
 	sha256sums = 67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d
 	sha256sums = ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9
 	sha256sums = 7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0
@@ -127,6 +129,7 @@ pkgbase = mesa
 	b2sums = SKIP
 	b2sums = 04e5b824029b66f28a9dc97a44d1b879964d3ef44214c426977cfe59e9b0d71256c13373053a204fd8fc3f9dac1f1e33070caf561738eb2344eefd8c6f8e59d7
 	b2sums = 7d10b4f79a31feb74d8064a91f148cbf714fcdd31714076731c099e11b1b39bc0dc7f8cff5d87e311264fa9cb4c93e03f3f77be1814bbd0cb8b66b989a89d313
+	b2sums = c65ad8486f84fb44fcd23967f19738e187fec8feb8973b54dd0a993ca3bf02b791fd3fa66831c92cf6cd325a9acd3303a7857d9c5fe8720ba737426f8703d502
 	b2sums = 431439d31632d177aeb15f910b4f546efa76d54fc74fc8e140399dc5e54eca33fd606f11dbfb48fa83067c8474ee512e62751895d5948367b65ab08b984284e5
 	b2sums = a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823
 	b2sums = 9a73962e1e38b84131ab2350b69a1f5d611c549533eec73e898c394a9b9442f357bb5d5f59e1be12270dd29bdf237dc2d21786c0c2210736e224ef5d48300dcf
@@ -174,9 +177,9 @@ pkgname = mesa
 	depends = zlib
 	depends = zstd
 	optdepends = opengl-man-pages: for the OpenGL API man pages
-	provides = libva-mesa-driver=1:25.2.4-2
-	provides = mesa-libgl=1:25.2.4-2
-	provides = mesa-vdpau=1:25.2.4-2
+	provides = libva-mesa-driver=1:25.2.4-3
+	provides = mesa-libgl=1:25.2.4-3
+	provides = mesa-vdpau=1:25.2.4-3
 	provides = libva-driver
 	provides = opengl-driver
 	provides = vdpau-driver

--- a/mesa/mesa/PKGBUILD
+++ b/mesa/mesa/PKGBUILD
@@ -26,7 +26,7 @@ pkgname=(
   mesa-docs
 )
 pkgver=25.2.4
-pkgrel=2
+pkgrel=3
 epoch=1
 pkgdesc="Open-source OpenGL drivers"
 url="https://www.mesa3d.org/"
@@ -99,6 +99,7 @@ source=(
   "https://archive.mesa3d.org/mesa-$pkgver.tar.xz"{,.sig}
   https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34242.patch # Anti lag
   https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37137.patch # Anti Lag Fix
+  https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37509.patch # Disable anti-lag by default
 )
 validpgpkeys=(
   946D09B5E4C9845E63075FF1D961C596A7203456 # Andres Gomez <tanty@igalia.com>
@@ -158,6 +159,7 @@ sha256sums=('a370b4c549cbfbe646b319e34d73edb50ed883978f5e95133f282f0eae39ab52'
             'SKIP'
             '1e83a132618ebc2a2236779223ace94354f22b3372ce739ee6641e83f2d0f9e8'
             '2ee4a8dcba2ac1a162ac8b7d1751d9a363d0249df06897a4cf905ec9f59d17df'
+            '0d6ac888f4401acab2f9a99cf2fd7d8a06ec2503ebf2807a8835eae6e06a4758'
             '67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d'
             'ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9'
             '7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0'
@@ -189,6 +191,7 @@ b2sums=('5f9e89efb11977c8d86f92e705280af7dc136f4031d192571518c6fb9d73eb31c269f38
         'SKIP'
         '04e5b824029b66f28a9dc97a44d1b879964d3ef44214c426977cfe59e9b0d71256c13373053a204fd8fc3f9dac1f1e33070caf561738eb2344eefd8c6f8e59d7'
         '7d10b4f79a31feb74d8064a91f148cbf714fcdd31714076731c099e11b1b39bc0dc7f8cff5d87e311264fa9cb4c93e03f3f77be1814bbd0cb8b66b989a89d313'
+        'c65ad8486f84fb44fcd23967f19738e187fec8feb8973b54dd0a993ca3bf02b791fd3fa66831c92cf6cd325a9acd3303a7857d9c5fe8720ba737426f8703d502'
         '431439d31632d177aeb15f910b4f546efa76d54fc74fc8e140399dc5e54eca33fd606f11dbfb48fa83067c8474ee512e62751895d5948367b65ab08b984284e5'
         'a6d47c903be6094423d89b8ec3ca899d0a84df6dbd6e76632bb6c9b9f40ad9c216f8fa400310753d392f85072756b43ac3892e0a2c4d55f87ab6463002554823'
         '9a73962e1e38b84131ab2350b69a1f5d611c549533eec73e898c394a9b9442f357bb5d5f59e1be12270dd29bdf237dc2d21786c0c2210736e224ef5d48300dcf'


### PR DESCRIPTION
This creates issues [1] and crashes [2] even where anti-lag should not actually be used. This can still be activated via the `ENABLE_LAYER_MESA_ANTI_LAG` variable.

[1] - https://gitlab.freedesktop.org/mesa/mesa/-/issues/13724 
[2] - https://gitlab.freedesktop.org/mesa/mesa/-/issues/13941