### PR TITLE
plasma-login-manager: update git version

### DIFF
--- a/plasma-login-manager/.SRCINFO
+++ b/plasma-login-manager/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = plasma-login-manager
 	pkgdesc = Plasma Login Manager
-	pkgver = 6.4.git20250830
+	pkgver = 6.4.git20251020
 	pkgrel = 1
 	url = https://kde.org/plasma-desktop/
 	arch = x86_64
@@ -30,11 +30,11 @@ pkgbase = plasma-login-manager
 	depends = qt6-declarative
 	depends = sh
 	depends = systemd-libs
-	source = git+https://invent.kde.org/plasma/plasma-login-manager#commit=ae219f754b4b12875e45ccc4fae52953bbd0ca5d
+	source = git+https://invent.kde.org/plasma/plasma-login-manager#commit=bbdfab263c60181c23a8552bc4ff2af88758b5dc
 	source = plasmalogin
 	source = plasmalogin-greeter
 	source = plasmalogin-autologin
-	sha256sums = 5050c63dce296ccb069eacb9996faa11564f3bf8d5f0d89916b08b9252f1f737
+	sha256sums = 954fa7aefad282fbe816a6df295f764587576ace5da8556743f4dd2d2ba15b61
 	sha256sums = d7394292a65ae463926c2c3d2cb4e67bbfeb20995450c8e4c92fe5a28e7c4254
 	sha256sums = 3406bce46be8450e28ddbccfbcd0e1f8fa585d57da8833ff7294cf3aee84bb46
 	sha256sums = 1a84cf752782b03b53f66188013bf7e4af4f5e6feb7266bfe58c3faaa20777b4

--- a/plasma-login-manager/PKGBUILD
+++ b/plasma-login-manager/PKGBUILD
@@ -2,9 +2,9 @@
 # Maintainer: VolRen <VolRencs@proton.me>
 
 pkgname=plasma-login-manager
-pkgver=6.4.git20250830
+pkgver=6.4.git20251020
 pkgrel=1
-_commit=ae219f754b4b12875e45ccc4fae52953bbd0ca5d
+_commit=bbdfab263c60181c23a8552bc4ff2af88758b5dc
 arch=(x86_64)
 pkgdesc='Plasma Login Manager'
 url='https://kde.org/plasma-desktop/'
@@ -36,7 +36,7 @@ makedepends=(extra-cmake-modules
              qt6-tools)
 source=(git+https://invent.kde.org/plasma/plasma-login-manager#commit=$_commit
         plasmalogin{,-greeter,-autologin})
-sha256sums=('5050c63dce296ccb069eacb9996faa11564f3bf8d5f0d89916b08b9252f1f737'
+sha256sums=('954fa7aefad282fbe816a6df295f764587576ace5da8556743f4dd2d2ba15b61'
             'd7394292a65ae463926c2c3d2cb4e67bbfeb20995450c8e4c92fe5a28e7c4254'
             '3406bce46be8450e28ddbccfbcd0e1f8fa585d57da8833ff7294cf3aee84bb46'
             '1a84cf752782b03b53f66188013bf7e4af4f5e6feb7266bfe58c3faaa20777b4')


### PR DESCRIPTION
Changes have been made on gitlab to add theme synchronization.

Which in turn fixes it: https://github.com/CachyOS/CachyOS-Live-ISO/pull/60#issuecomment-3324760873