### PR TITLE
plasma-login-manager: fix for plasma 6.5

### DIFF
--- a/plasma-login-manager/.SRCINFO
+++ b/plasma-login-manager/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = plasma-login-manager
 	pkgdesc = Plasma Login Manager
 	pkgver = 6.4.git20251020
-	pkgrel = 1
+	pkgrel = 2
 	url = https://kde.org/plasma-desktop/
 	arch = x86_64
 	license = GPL-2.0-or-later
@@ -34,9 +34,11 @@ pkgbase = plasma-login-manager
 	source = plasmalogin
 	source = plasmalogin-greeter
 	source = plasmalogin-autologin
+	source = plasma6.5-fix.patch
 	sha256sums = 954fa7aefad282fbe816a6df295f764587576ace5da8556743f4dd2d2ba15b61
 	sha256sums = d7394292a65ae463926c2c3d2cb4e67bbfeb20995450c8e4c92fe5a28e7c4254
 	sha256sums = 3406bce46be8450e28ddbccfbcd0e1f8fa585d57da8833ff7294cf3aee84bb46
 	sha256sums = 1a84cf752782b03b53f66188013bf7e4af4f5e6feb7266bfe58c3faaa20777b4
+	sha256sums = 86e86be2c6727f0a9962c26b09faa0b3157d46ddb28284f33ab106914166fcf4
 
 pkgname = plasma-login-manager

--- a/plasma-login-manager/PKGBUILD
+++ b/plasma-login-manager/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=plasma-login-manager
 pkgver=6.4.git20251020
-pkgrel=1
+pkgrel=2
 _commit=bbdfab263c60181c23a8552bc4ff2af88758b5dc
 arch=(x86_64)
 pkgdesc='Plasma Login Manager'
@@ -35,11 +35,18 @@ makedepends=(extra-cmake-modules
              git
              qt6-tools)
 source=(git+https://invent.kde.org/plasma/plasma-login-manager#commit=$_commit
-        plasmalogin{,-greeter,-autologin})
+        plasmalogin{,-greeter,-autologin}
+        plasma6.5-fix.patch)
 sha256sums=('954fa7aefad282fbe816a6df295f764587576ace5da8556743f4dd2d2ba15b61'
             'd7394292a65ae463926c2c3d2cb4e67bbfeb20995450c8e4c92fe5a28e7c4254'
             '3406bce46be8450e28ddbccfbcd0e1f8fa585d57da8833ff7294cf3aee84bb46'
-            '1a84cf752782b03b53f66188013bf7e4af4f5e6feb7266bfe58c3faaa20777b4')
+            '1a84cf752782b03b53f66188013bf7e4af4f5e6feb7266bfe58c3faaa20777b4'
+            '86e86be2c6727f0a9962c26b09faa0b3157d46ddb28284f33ab106914166fcf4')
+# https://invent.kde.org/plasma/plasma-login-manager/-/merge_requests/26
+prepare() {
+  cd $pkgname
+  git apply -v ../plasma6.5-fix.patch
+}
 
 build() {
   cmake -B build -S $pkgname \

--- a/plasma-login-manager/plasma6.5-fix.patch
+++ b/plasma-login-manager/plasma6.5-fix.patch
@@ -1,0 +1,119 @@
+From 0460b58b5efd4450e074a39227dc9a9fd589ccad Mon Sep 17 00:00:00 2001
+From: Oliver Beard <olib141@outlook.com>
+Date: Mon, 20 Oct 2025 12:57:22 +0100
+Subject: [PATCH] frontend/wallpaper: Adapt to WallpaperItem config changes
+
+This commit fixes the wallpaper by adapting to changes in how the wallpaper loads configuration in libplasma@c7e0ba9b.
+
+BUG: 507842
+---
+ src/frontend/wallpaper/wallpaperapp.cpp | 49 +++++++++++++++++--------
+ src/frontend/wallpaper/wallpaperapp.h   |  2 -
+ 2 files changed, 33 insertions(+), 18 deletions(-)
+
+diff --git a/src/frontend/wallpaper/wallpaperapp.cpp b/src/frontend/wallpaper/wallpaperapp.cpp
+index 0f91836a..e09fe700 100644
+--- a/src/frontend/wallpaper/wallpaperapp.cpp
++++ b/src/frontend/wallpaper/wallpaperapp.cpp
+@@ -6,38 +6,28 @@
+     SPDX-License-Identifier: GPL-2.0-or-later
+ */
+ 
++#include <QFile>
++#include <QQmlContext>
++#include <QQuickItem>
++
++#include <KConfigLoader>
++#include <KConfigPropertyMap>
+ #include <KPackage/PackageLoader>
+ #include <KWindowSystem>
+ 
+ #include <LayerShellQt/Shell>
+ 
+ #include "plasmaloginsettings.h"
+-#include "wallpaperintegration.h"
+ 
+ #include "wallpaperwindow.h"
+ 
+ #include "wallpaperapp.h"
+ 
+-class WallpaperItem : public WallpaperIntegration
+-{
+-    Q_OBJECT
+-public:
+-    explicit WallpaperItem(QQuickItem *parent = nullptr)
+-        : WallpaperIntegration(parent)
+-    {
+-        setConfig(PlasmaLoginSettings::getInstance().sharedConfig());
+-        setPluginName(PlasmaLoginSettings::getInstance().wallpaperPluginId());
+-        init();
+-    }
+-};
+-
+ WallpaperApp::WallpaperApp(int &argc, char **argv)
+     : QGuiApplication(argc, argv)
+ {
+     LayerShellQt::Shell::useLayerShell();
+ 
+-    qmlRegisterType<WallpaperItem>("org.kde.plasma.plasmoid", 2, 0, "WallpaperItem");
+-
+     m_wallpaperPackage = KPackage::PackageLoader::self()->loadPackage(QStringLiteral("Plasma/Wallpaper"));
+     m_wallpaperPackage.setPath(PlasmaLoginSettings::getInstance().wallpaperPluginId());
+ 
+@@ -64,6 +54,10 @@ void WallpaperApp::adoptScreen(QScreen *screen)
+     window->setVisible(true);
+     m_windows << window;
+ 
++    connect(screen, &QScreen::geometryChanged, this, [window](const QRect &geometry) {
++        window->setGeometry(geometry);
++    });
++
+     connect(screen, &QObject::destroyed, window, [this, window]() {
+         m_windows.removeAll(window);
+         window->deleteLater();
+@@ -79,7 +73,30 @@ void WallpaperApp::setupWallpaperPlugin(WallpaperWindow *window)
+         return;
+     }
+ 
++    const QString xmlPath = m_wallpaperPackage.filePath(QByteArrayLiteral("config"), QStringLiteral("main.xml"));
++
++    const KConfigGroup cfg = PlasmaLoginSettings::getInstance()
++                                 .sharedConfig()
++                                 ->group(QStringLiteral("Greeter"))
++                                 .group(QStringLiteral("Wallpaper"))
++                                 .group(PlasmaLoginSettings::getInstance().wallpaperPluginId());
++
++    KConfigLoader *configLoader;
++    if (xmlPath.isEmpty()) {
++        configLoader = new KConfigLoader(cfg, nullptr, this);
++    } else {
++        QFile file(xmlPath);
++        configLoader = new KConfigLoader(cfg, &file, this);
++    }
++
++    KConfigPropertyMap *config = new KConfigPropertyMap(configLoader, this);
++    // potd (picture of the day) is using a kded to monitor changes and
++    // cache data for the lockscreen. Let's notify it.
++    config->setNotify(true);
++
+     window->setSource(QUrl::fromLocalFile(m_wallpaperPackage.filePath("mainscript")));
++    window->rootObject()->setProperty("configuration", QVariant::fromValue(config));
++    window->rootObject()->setProperty("pluginName", PlasmaLoginSettings::getInstance().wallpaperPluginId());
+ }
+ 
+ #include "wallpaperapp.moc"
+diff --git a/src/frontend/wallpaper/wallpaperapp.h b/src/frontend/wallpaper/wallpaperapp.h
+index d771d99a..8d63713f 100644
+--- a/src/frontend/wallpaper/wallpaperapp.h
++++ b/src/frontend/wallpaper/wallpaperapp.h
+@@ -18,8 +18,6 @@ namespace PlasmaQuick
+ class QuickViewSharedEngine;
+ }
+ 
+-class WallpaperIntegration;
+-
+ class WallpaperWindow;
+ 
+ class WallpaperApp : public QGuiApplication
+-- 
+GitLab


### PR DESCRIPTION
I have added a patch that should fix the black screen on plasma 6.5, so that there are no errors merge preferably right after the release of plasma 6.5