### PR TITLE
cachyos-rate-mirrors: sync `chaotic-aur` repo if available

### DIFF
--- a/cachyos-rate-mirrors/.SRCINFO
+++ b/cachyos-rate-mirrors/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-rate-mirrors
 	pkgdesc = CachyOS - Rate mirrors service
-	pkgver = 15
+	pkgver = 18
 	pkgrel = 1
 	url = https://github.com/CachyOS
 	arch = any
@@ -10,7 +10,7 @@ pkgbase = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors.service
 	source = cachyos-rate-mirrors.timer
-	sha256sums = f3df7c1fb77562b419ec7561310e794c45371c8705738393735b753b4e21b9a4
+	sha256sums = cec0c1c2d2ff95002d62d2c04a04478041f4f27eae3daf9fc2f93dc5b2c656d4
 	sha256sums = 599f7675454b0dd4f305051288c304e185cf9880df86f61588d1be7ffc041409
 	sha256sums = d8f45568d7bd4d4b5b2f8932afe4cc0af1cfb05960be59e13b982f1aadd28058
 

--- a/cachyos-rate-mirrors/PKGBUILD
+++ b/cachyos-rate-mirrors/PKGBUILD
@@ -1,8 +1,9 @@
 # Maintainer: Peter Jung <admin@ptr1337.dev>
 # Contributor: Michael Bolden Jnr SM9(); <me@sm9.dev>
+# Contributor: Erffy <github.com/erffy>
 
 pkgname=cachyos-rate-mirrors
-pkgver=17
+pkgver=18
 pkgrel=1
 groups=(cachyos)
 arch=('any')
@@ -15,7 +16,7 @@ source=(
     cachyos-rate-mirrors.service
     cachyos-rate-mirrors.timer
 )
-sha256sums=('2082ea1f064ca87468e20e56c02f8981d013bf5e94d2facd203d9a7a805c574c'
+sha256sums=('cec0c1c2d2ff95002d62d2c04a04478041f4f27eae3daf9fc2f93dc5b2c656d4'
             '599f7675454b0dd4f305051288c304e185cf9880df86f61588d1be7ffc041409'
             'd8f45568d7bd4d4b5b2f8932afe4cc0af1cfb05960be59e13b982f1aadd28058')
 

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -108,6 +108,17 @@ rate_repository_mirrors() {
     fi
 }
 
+# Checks whether a pacman repository is enabled.
+# If enabled, runs rate_repository_mirrors on the provided mirrorlist file.
+rate_if_repo_enabled() {
+    local repo="$1"
+    local mirrorfile="$2"
+
+    if pacman -Sl "$repo" >/dev/null 2>&1; then
+        rate_repository_mirrors "$repo" "$mirrorfile"
+    fi
+}
+
 # Special check for RU region where CDN77 mirror gets timeouted due to
 # blockings that mirror is applied by default on the ISO
 check_ru_location() {
@@ -133,6 +144,8 @@ cp -f --backup=simple --suffix="-backup" "${MIRRORS_DEFAULT_DIR}/cachyos-mirrorl
 
 sed -i 's|/$arch/|/$arch_v3/|g' "${MIRRORS_DEFAULT_DIR}/cachyos-v3-mirrorlist"
 sed -i 's|/$arch/|/$arch_v4/|g' "${MIRRORS_DEFAULT_DIR}/cachyos-v4-mirrorlist"
+
+rate_if_repo_enabled "chaotic-aur" "${MIRRORS_DEFAULT_DIR}/chaotic-mirrorlist"
 
 # In the case of a more restrictive umask setting ( 0077 for example ), give read-permissions back to 'Group/Other'.
 # This fixes a case where the third party package wrapper Aura ( https://github.com/fosskers/aura ) tries to parse


### PR DESCRIPTION
- Introduced `rate_if_repo_enabled` function to conditionally rate mirrors for a repository only if it exists.
- Added logic to sync the `chaotic-aur` repository automatically when it is present.