### PR TITLE
cachyos-handheld: migrate scx service

### DIFF
--- a/handheld/cachyos-handheld/.SRCINFO
+++ b/handheld/cachyos-handheld/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-handheld
 	pkgdesc = CachyOS - Handheld!
 	pkgver = 1.2.4
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/CachyOS/CachyOS-Handheld
 	install = cachyos-handheld.install
 	arch = any

--- a/handheld/cachyos-handheld/PKGBUILD
+++ b/handheld/cachyos-handheld/PKGBUILD
@@ -1,8 +1,9 @@
 # Maintainer: Peter Jung <admin@ptr1337.dev>
+# Maintainer: Vladislav Nepogodin (vnepogodin) <vnepogodin@cachyos.org>
 
 pkgname=cachyos-handheld
 pkgver=1.2.4
-pkgrel=1
+pkgrel=2
 arch=('any')
 license=('GPL-3.0-later')
 pkgdesc='CachyOS - Handheld!'
@@ -21,7 +22,7 @@ validpgpkeys=(
 )
 makedepends=('git')
 depends=('gamescope-session-git' 'mangohud' 'jq' 'dmidecode' 'glew' 'glfw' 'glxinfo' 'curl' 'tar'
-         'scx-scheds' 'qt5-tools' 'gamescope-session-steam-git' 'jupiter-hw-support'
+         'scx-scheds' 'scx-tools' 'qt5-tools' 'gamescope-session-steam-git' 'jupiter-hw-support'
          'gamescope' 'lib32-gamescope' 'cachyos-vapor' 'cachyos-alacritty-config'
          'steam')
 

--- a/handheld/cachyos-handheld/cachyos-handheld.install
+++ b/handheld/cachyos-handheld/cachyos-handheld.install
@@ -1,4 +1,4 @@
-SERVICES=("bluetooth" "scx")
+SERVICES=("bluetooth" "scx_loader")
 
 update_user() {
   # edit user name for sddm autologin and decky environment variables
@@ -18,7 +18,13 @@ update_user() {
 }
 
 scx_lavd_default() {
-  sed -i 's/SCX_SCHEDULER=.*/SCX_SCHEDULER=scx_lavd/' /etc/default/scx
+  # migrate all users to scx_loader
+  local config_path="/etc/scx_loader.toml"
+  if [[ ! -f "$config_path" ]]; then
+     cat <<'EOF' > "$config_path"
+default_sched = "scx_lavd"
+EOF
+  fi
 }
 
 steamos_steam() {
@@ -70,6 +76,9 @@ post_install() {
 }
 
 post_upgrade() {
+  # Use scx_lavd as default scheduler
+  scx_lavd_default
+
   # Update files to reflect the changes
   echo "Updating Handheld Configs."
   update_user


### PR DESCRIPTION
scx.service was removed in scx-scheds 1.0.17

see https://github.com/sched-ext/scx/commit/c3b6b3c066ad5e8997c5aabd068c4718cd9f5f48
