### PR TITLE
Explicitly depend on kdialog for cachyos-calamares-qt6-next-limine

### DIFF
--- a/cachyos-calamares/PKGBUILD
+++ b/cachyos-calamares/PKGBUILD
@@ -45,6 +45,11 @@ depends=(
   upower
   yaml-cpp
 )
+
+if [[ "$_bootloader" = limine ]]; then
+  depends+=(kdialog)
+fi
+
 makedepends=(
   boost
   cmake


### PR DESCRIPTION
Assuming we're moving forward with https://github.com/CachyOS/CachyOS-Live-ISO/pull/73, new Live ISO will replace yad with kdialog. Also [quoting] @ventureoo :

> > https://github.com/CachyOS/cachyos-calamares/blob/cachyos-refind-qt6-dev/src/modules/bootloader/main.py
> 
> No, it's not. This dialog is specific only for Limine branch. I will rewrite it using kdialog as soon as this PR will be merged.

This will make new calamares depend on kdialog as well. I think I need to come up with a plan to make sure users' old ISOs won't break.

* Old ISO, new calamares

Given that the initial install script upgrades calamares after picking a bootloader, new calamares will be running on old ISO (e.g. `251129`) where there is no kdialog. This PR fixes this situation by installing kdialog as a dependency of calamares.

* New ISO, old calamares

Occasionally, [testing ISO is being downloaded in Discord][iso] for early testing. Old calamares packages will break on them for the lack of yad.

This can be mitigated by merging this PR & building new calamares packages before https://github.com/CachyOS/CachyOS-Live-ISO/pull/73 gets merged, preventing this situation completely.

Ideally there should be a time window of at least 1 day to wait for all the mirrors to catch up syncing.

[iso]: https://discord.com/channels/862292009423470592/1419709045819838485/1446571927907995791
[quoting]: https://github.com/CachyOS/CachyOS-Live-ISO/pull/73#discussion_r2602421207