### PR TITLE
[zstd] Fix XXH autovectorization flags

### DIFF
--- a/zstd/lib32-zstd/PKGBUILD
+++ b/zstd/lib32-zstd/PKGBUILD
@@ -47,9 +47,6 @@ build() {
   export ASMFLAGS="-m32"
   export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"
 
-  export CFLAGS+=' -ffat-lto-objects'
-  export CXXFLAGS+=' -ffat-lto-objects'
-
   # https://github.com/facebook/zstd/issues/3819
   # XXH64_update can be vectorized with AVX-512, but this is disabled by default
   # due to Skylake's high latency for AVX-512 instructions. Re-enable this for
@@ -57,8 +54,11 @@ build() {
   xxh64_vectorize=''
 
   if [ -n "$_optimize_znver4" ]; then
-    xxh64_vectorize="-DXXH64_UPDATE_VECTORIZE=ON"
+    xxh64_vectorize="-DXXH_ENABLE_AUTOVECTORIZE=ON"
   fi
+
+  export CFLAGS+=" -ffat-lto-objects ${xxh64_vectorize}"
+  export CXXFLAGS+=" -ffat-lto-objects ${xxh64_vectorize}"
 
   cmake -S build/cmake -B build -G Ninja \
     -DCMAKE_BUILD_TYPE=None \
@@ -67,8 +67,7 @@ build() {
     -DZSTD_BUILD_CONTRIB=ON \
     -DZSTD_BUILD_STATIC=OFF \
     -DZSTD_BUILD_TESTS=ON \
-    -DZSTD_PROGRAMS_LINK_SHARED=ON \
-    ${xxh64_vectorize}
+    -DZSTD_PROGRAMS_LINK_SHARED=ON
   cmake --build build
 }
 

--- a/zstd/zstd-pgo/PKGBUILD
+++ b/zstd/zstd-pgo/PKGBUILD
@@ -59,8 +59,6 @@ prepare() {
 
 build() {
   cd ${pkgname}-${pkgver}
-  export CFLAGS+=' -ffat-lto-objects'
-  export CXXFLAGS+=' -ffat-lto-objects'
 
   # https://github.com/facebook/zstd/issues/3819
   # XXH64_update can be vectorized with AVX-512, but this is disabled by default
@@ -69,8 +67,11 @@ build() {
   xxh64_vectorize=''
 
   if [ -n "$_optimize_znver4" ]; then
-    xxh64_vectorize="-DXXH64_UPDATE_VECTORIZE=ON"
+    xxh64_vectorize="-DXXH_ENABLE_AUTOVECTORIZE=ON"
   fi
+
+  export CFLAGS+=" -ffat-lto-objects ${xxh64_vectorize}"
+  export CXXFLAGS+=" -ffat-lto-objects ${xxh64_vectorize}"
 
   # First build pass: Generate profile
   cmake -S build/cmake -B build -G Ninja \
@@ -83,7 +84,6 @@ build() {
       -DZSTD_BUILD_STATIC=OFF \
       -DZSTD_BUILD_TESTS=ON \
       -DZSTD_PROGRAMS_LINK_SHARED=ON \
-      ${xxh64_vectorize} \
       -DPGO_GENERATE=ON \
       -DPGO_USE=OFF
   cmake --build build

--- a/zstd/zstd/PKGBUILD
+++ b/zstd/zstd/PKGBUILD
@@ -44,8 +44,6 @@ prepare() {
 
 build() {
   cd ${pkgname}-${pkgver}
-  export CFLAGS+=' -ffat-lto-objects'
-  export CXXFLAGS+=' -ffat-lto-objects'
 
   # https://github.com/facebook/zstd/issues/3819
   # XXH64_update can be vectorized with AVX-512, but this is disabled by default
@@ -54,8 +52,11 @@ build() {
   xxh64_vectorize=''
 
   if [ -n "$_optimize_znver4" ]; then
-    xxh64_vectorize="-DXXH64_UPDATE_VECTORIZE=ON"
+    xxh64_vectorize="-DXXH_ENABLE_AUTOVECTORIZE=ON"
   fi
+
+  export CFLAGS+=" -ffat-lto-objects ${xxh64_vectorize}"
+  export CXXFLAGS+=" -ffat-lto-objects ${xxh64_vectorize}"
 
   cmake -S build/cmake -B build -G Ninja \
     -DCMAKE_BUILD_TYPE=None \
@@ -66,8 +67,7 @@ build() {
     -DZSTD_BUILD_CONTRIB=ON \
     -DZSTD_BUILD_STATIC=OFF \
     -DZSTD_BUILD_TESTS=ON \
-    -DZSTD_PROGRAMS_LINK_SHARED=ON \
-    ${xxh64_vectorize}
+    -DZSTD_PROGRAMS_LINK_SHARED=ON
   cmake --build build
 }
 


### PR DESCRIPTION
After CachyOS/CachyOS-PKGBUILDS#903, I inspected the built package binary disassembly and, to my dismay, noticed that `libzstd.so` was byte-identical to the build without the autovectorization flag that was added. Drats.

Turns out that the `-DXXH64_UPDATE_VECTORIZE` CMake flag was never actually implemented into ZSTD, so the XXHash-specific flag must be passed through via `CFLAGS`. Since some were already being set for these builds, I just added the conditionally-set vectorization flag into there.

Inspecting the built binaries confirms that this, finally, allows autovectorization to take place.

Benchmarks run on my Zen 5 laptop (which, being a laptop chip, is very similar to Zen 4 in regards to AVX performance) show around a 2% speedup on workloads that use `--check`. Since `--check` is enabled by default in ZSTD, this should be an all-around improvement.