### PR TITLE
Update mainline SVT-AV1 3.1.2 to SVT-AV1 4.0.0

### DIFF
--- a/svt-av1/PKGBUILD
+++ b/svt-av1/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: Thomas Schneider <maxmusterm@gmail.com>
 
 pkgname=svt-av1
-pkgver=3.1.2
-pkgrel=2
+pkgver=4.0.0
+pkgrel=1
 pkgdesc='Scalable Video Technology AV1 encoder and decoder'
 arch=(x86_64)
 url=https://gitlab.com/AOMediaCodec/SVT-AV1
@@ -20,7 +20,7 @@ makedepends=(
   ninja
 )
 source=(git+https://gitlab.com/AOMediaCodec/SVT-AV1.git#tag=v${pkgver})
-b2sums=('11a0233d45624a476e829e2b8fc5e0dac00b4ff77a4c6284abc38590258022684cbd6e4eb139050a20b688ed801205e0017f269a58794b4ed06a7079fd022c98')
+b2sums=('9c49206efd0d6d5a80f19adc48b5cb6662dff3340adf30dfa0d17efbc160095a8dc21dc2b56671f90caabeda590b92702c301c107267229dd7f7417293bc46ba')
 
 prepare() {
    # to build with PGO we need to remove that


### PR DESCRIPTION
Title is the commit itself.

A fairly modest ask if I say so myself.

Considering how powerful some of the options are in svt-av1 4.0.0, it's a great idea to update it early.