### PR TITLE
Add Lansing 2600 CDN mirror

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -32,8 +32,9 @@ Server = https://at.cachyos.org/repo/$arch/$repo
 Server = https://de-nue.soulharsh007.dev/cachyos/repo/$arch/$repo
 ## USA Mirror much thanks to Soulharsh!
 Server = https://us-mnz.soulharsh007.dev/cachyos/repo/$arch/$repo
-## USA Mirror provided by Lansing 2600 in Lansing, MI, USA
+## USA Mirror & CDN mirror provided by Lansing 2600 in Lansing, MI, USA
 Server = https://mirrors.lansing2600.org/cachyos/repo/$arch/$repo
+Server = https://cdn.lansing2600.org/cachyos/repo/$arch/$repo
 ## China Mirror 10GBs much thanks to eScience Center, Nanjing University!
 Server = https://mirror.nju.edu.cn/cachyos/repo/$arch/$repo
 ## China Mirror much thanks to University of Science and Technology of China!


### PR DESCRIPTION
Added a CDN redirector to stuff the CloudFlare cache in case others are down.