### PR TITLE
cachyos-rate-mirrors: Add fallback in case geoip.kde.org is down

### DIFF
--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -104,7 +104,12 @@ rate_repository_mirrors() {
 
 # Prefer mirrors that are geographically close, especially in countries that
 # have regional blockages
-country="$(curl --connect-timeout 10 -sSL 'https://geoip.kde.org/v1/ubiquity' | grep -Po '<CountryCode>\K([A-Z]{2})')"
+country="$(curl --connect-timeout 10 -sSL 'https://geoip.kde.org/v1/ubiquity' 2>/dev/null | grep -Po '<CountryCode>\K([A-Z]{2})')"
+
+# Fallback to ifconfig.co if KDE GeoIP is unavailable
+if [ -z "$country" ]; then
+    country="$(curl --connect-timeout 10 -sSL 'https://ifconfig.co/country-iso' 2>/dev/null | grep -Po '^[A-Z]{2}$')"
+fi
 
 if [ -n "$country" ]; then
     export RATE_MIRRORS_ENTRY_COUNTRY="$country"


### PR DESCRIPTION
geoip.kde.org was today down resulted into failed ranking of the mirrors as well as issues at installation. Add fallback