### PR TITLE
cachyos-niri-noctalia: update PKGBUILD to latest commit

### DIFF
--- a/cachyos-niri-noctalia/.SRCINFO
+++ b/cachyos-niri-noctalia/.SRCINFO
@@ -34,7 +34,7 @@ pkgbase = cachyos-niri-noctalia
 	depends = cachyos-nord-gtk-theme-git
 	provides = cachyos-desktop-settings
 	conflicts = cachyos-desktop-settings
-	source = git+https://github.com/cachyos/cachyos-niri-noctalia#commit=497b23b1fe9aeebffeab8e04f6a60bf0971296d5
-	sha512sums = fa090918b66128c8fc674fd09e73960e44a56c6c17d063e88187f205dd09cdb473528a0cebf40318a2d341230734c9739e4f8b28b936d2a19a37c937f4a2827d
+	source = git+https://github.com/cachyos/cachyos-niri-noctalia#commit=911122088ceeb9bb9eed45965e725963303dd853
+	sha512sums = 8696ec4c288a9db51d368c0d325dd5ce17ba2cfd2e87fecfb1c51b24f2faa864c82c80717a3469c174e4557483ba6a5141a04d080ac666f3db8b1031dce8b710
 
 pkgname = cachyos-niri-noctalia

--- a/cachyos-niri-noctalia/PKGBUILD
+++ b/cachyos-niri-noctalia/PKGBUILD
@@ -1,6 +1,4 @@
-# Maintainer: Vladislav Nepogodin <nepogodin.vlad@gmail.com>
-# Contributor: SoulHarsh007 <admin@soulharsh007.dev>
-# Contributor: Shendisx <aarrayyzuelo@protonmail.com>
+# Maintainer: Lysec <admin@lysec.dev>
 
 pkgname=cachyos-niri-noctalia
 pkgdesc='CachyOS Niri (+Noctalia) settings'
@@ -10,8 +8,8 @@ arch=('any')
 url="https://github.com/cachyos/$pkgname"
 license=(GPL-3.0-only)
 makedepends=('coreutils' 'git')
-source=(git+$url#commit=497b23b1fe9aeebffeab8e04f6a60bf0971296d5)
-sha512sums=('fa090918b66128c8fc674fd09e73960e44a56c6c17d063e88187f205dd09cdb473528a0cebf40318a2d341230734c9739e4f8b28b936d2a19a37c937f4a2827d')
+source=(git+$url#commit=911122088ceeb9bb9eed45965e725963303dd853)
+sha512sums=('8696ec4c288a9db51d368c0d325dd5ce17ba2cfd2e87fecfb1c51b24f2faa864c82c80717a3469c174e4557483ba6a5141a04d080ac666f3db8b1031dce8b710')
 depends=(
   adw-gtk-theme
   cachyos-alacritty-config


### PR DESCRIPTION
I just pushed the changes to the `cachyos-niri-noctalia` repo as discussed with @ptr1337 . We now don't hardcode the initial keyboard layout but let locale1 handle it. Thus I had to update the PKGBUILD to the latest commit.