### PR TITLE
Set SUID permission on galileo-mura-extractor

### DIFF
--- a/handheld/galileo-mura/.SRCINFO
+++ b/handheld/galileo-mura/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = galileo-mura
 	pkgdesc = Utilities for setting and reading mura correction on Galileo
 	pkgver = 0.9
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/evlaV/galileo-mura-extractor
 	arch = x86_64
 	license = MIT

--- a/handheld/galileo-mura/PKGBUILD
+++ b/handheld/galileo-mura/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=galileo-mura
 pkgver=0.9
-pkgrel=3
+pkgrel=4
 pkgdesc="Utilities for setting and reading mura correction on Galileo"
 arch=(x86_64)
 url="https://github.com/evlaV/galileo-mura-extractor"
@@ -24,5 +24,8 @@ package() {
     cd "galileo-mura-extractor"
 
     DESTDIR="$pkgdir" meson install -C build --skip-subprojects
+
+    chmod u+s "$pkgdir/usr/bin/galileo-mura-extractor"
+
     install -Dm 644 LICENSE -t "${pkgdir}"/usr/share/licenses/galileo-mura/
 }


### PR DESCRIPTION
```
systemctl --user status galileo-mura-setup.service
○ galileo-mura-setup.service - galileo mura setup
     Loaded: loaded (/usr/lib/systemd/user/galileo-mura-setup.service; static)
     Active: inactive (dead)

Mar 16 00:55:59 steamdeck systemd[1165]: Starting galileo mura setup...
Mar 16 00:55:59 steamdeck galileo-mura-setup[1347]: Must be ran as root via suid.
Mar 16 00:55:59 steamdeck systemd[1165]: galileo-mura-setup.service: Main process exited, code=exited, status=1/FAILURE
Mar 16 00:55:59 steamdeck systemd[1165]: galileo-mura-setup.service: Failed with result 'exit-code'.
Mar 16 00:55:59 steamdeck systemd[1165]: Failed to start galileo mura setup.
```

This changes the permission from `.rwxr-xr-x` to `.rwsr-xr-x`.

CC: @1Naim
