### PR TITLE
electron39: add Electron 39.5.2 with glibc 2.43 fix

### DIFF
--- a/electron39/PKGBUILD
+++ b/electron39/PKGBUILD
@@ -1,0 +1,688 @@
+# Maintainer: Roberto Ramirez (jobeto86) <https://github.com/jobeto86>
+# Contributor: Caleb Maclennan <caleb@alerque.com>
+# Contributor: loqs <bugs-archlinux@entropy-collector.net>
+# Contributor: kxxt <rsworktech@outlook.com>
+
+# Based on upstream Arch electron PKGBUILD with CachyOS-specific patches.
+# https://releases.electronjs.org/
+# https://gitlab.com/Matt.Jolly/chromium-patches/-/tags
+
+# Note: source array can be synced with an Electron release after updating $pkgver with:
+# bash -c 'source PKGBUILD; _update_sources'
+
+pkgver=39.5.2
+_gcc_patches=142
+pkgrel=1
+_major_ver=${pkgver%%.*}
+pkgname="electron${_major_ver}"
+pkgdesc='Build cross platform desktop apps with web technologies'
+arch=(x86_64)
+url='https://electronjs.org'
+license=(MIT BSD-3-Clause)
+depends=(c-ares
+         gcc-libs # libgcc_s.so
+         glibc # libc.so libm.so
+         gtk3 libgtk-3.so
+         libevent
+         libffi libffi.so
+         libpulse libpulse.so
+         nss # libnss3.so
+         zlib libz.so)
+makedepends=(clang
+             compiler-rt
+             git
+             gn
+             gperf
+             java-runtime-headless
+             libnotify
+             libva
+             lld
+             llvm
+             ninja
+             nodejs
+             npm
+             patchutils
+             pciutils
+             pipewire
+             python
+             python-httplib2
+             python-pyparsing
+             python-requests
+             python-six
+             qt5-base
+             rsync
+             rust
+             rust-bindgen
+             wget
+             yarn)
+optdepends=('kde-cli-tools: file deletion support (kioclient5)'
+            'pipewire: WebRTC desktop sharing under Wayland'
+            'qt5-base: enable Qt5 with --enable-features=AllowQt'
+            'gtk4: for --gtk-version=4 (GTK4 IME might work better on Wayland)'
+            'trash-cli: file deletion support (trash-put)'
+            'xdg-utils: open URLs with desktop'\''s default (xdg-email, xdg-open)')
+options=('!lto') # Electron adds its own flags for ThinLTO
+source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+        https://gitlab.com/Matt.Jolly/chromium-patches/-/archive/$_gcc_patches/chromium-patches-$_gcc_patches.tar.bz2
+        # Chromium patches
+        compiler-rt-adjust-paths.patch
+        chromium-138-nodejs-version-check.patch
+        chromium-138-rust-1.86-mismatched_lifetime_syntaxes.patch
+        chromium-141-cssstylesheet-iwyu.patch
+        fix-sys-seccomp-glibc243.patch
+        # CachyOS specific
+        increase-fortify-level.patch
+        # Electron
+        default_app-icon.patch
+        electron-launcher.sh
+        electron.desktop
+        jinja-python-3.10.patch
+        use-system-libraries-in-node.patch
+        makepkg-source-roller.py
+        # BEGIN managed sources
+        chromium-mirror::git+https://github.com/chromium/chromium.git#tag=142.0.7444.265
+        chromium-mirror_third_party_nan::git+https://github.com/nodejs/nan.git#commit=e14bdcd1f72d62bca1d541b66da43130384ec213
+        chromium-mirror_third_party_electron_node::git+https://github.com/nodejs/node.git#tag=v22.22.0
+        chromium-mirror_third_party_engflow-reclient-configs::git+https://github.com/EngFlow/reclient-configs.git#commit=955335c30a752e9ef7bff375baab5e0819b6c00d
+        chromium-mirror_third_party_clang-format_script::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git#commit=37f6e68a107df43b7d7e044fd36a13cbae3413f2
+        chromium-mirror_third_party_compiler-rt_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git#commit=05f2a5dd0d1386777ae9d7fac9da776f82e7e0f2
+        chromium-mirror_third_party_libc++_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git#commit=b77132b512d5411f8393fd3decb3abaeaf1d3ec8
+        chromium-mirror_third_party_libc++abi_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git#commit=864f61dc9253d56586ada34c388278565ef513f6
+        chromium-mirror_third_party_libunwind_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git#commit=322be580a5a193a921c349a15747eeeb9a716ad1
+        chromium-mirror_third_party_llvm-libc_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git#commit=0c61a55402c6a0d9d6ca2aeb3c6a2613a8bc8c55
+        chromium-mirror_chrome_test_data_perf_canvas_bench::git+https://chromium.googlesource.com/chromium/canvas_bench.git#commit=a7b40ea5ae0239517d78845a5fc9b12976bfc732
+        chromium-mirror_chrome_test_data_perf_frame_rate_content::git+https://chromium.googlesource.com/chromium/frame_rate/content.git#commit=c10272c88463efeef6bb19c9ec07c42bc8fe22b9
+        chromium-mirror_chrome_test_data_xr_webvr_info::git+https://chromium.googlesource.com/external/github.com/toji/webvr.info.git#commit=c58ae99b9ff9e2aa4c524633519570bf33536248
+        chromium-mirror_media_cdm_api::git+https://chromium.googlesource.com/chromium/cdm.git#commit=a4cbc4325e6de42ead733f2af43c08292d0e65a8
+        chromium-mirror_net_third_party_quiche_src::git+https://quiche.googlesource.com/quiche.git#commit=c0df0d316bd7e4ddf44e5ba094b5c5b061d94b0c
+        chromium-mirror_testing_libfuzzer_fuzzers_wasm_corpus::git+https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git#commit=1df5e50a45db9518a56ebb42cb020a94a090258b
+        chromium-mirror_third_party_angle::git+https://chromium.googlesource.com/angle/angle.git#commit=7628a2726022fc768f2464ed5060bbc97e13f77a
+        chromium-mirror_third_party_anonymous_tokens_src::git+https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git#commit=50e04fb27eacd49a5e2bfde5977ac689e13ebeeb
+        chromium-mirror_third_party_readability_src::git+https://chromium.googlesource.com/external/github.com/mozilla/readability.git#commit=1f0ec42686c89a4a1c71789849f7ffde349ab197
+        chromium-mirror_third_party_content_analysis_sdk_src::git+https://chromium.googlesource.com/external/github.com/chromium/content_analysis_sdk.git#commit=9a408736204513e0e95dd2ab3c08de0d95963efc
+        chromium-mirror_third_party_dav1d_libdav1d::git+https://chromium.googlesource.com/external/github.com/videolan/dav1d.git#commit=af5cf2b1e7f03d6f6de84477e1ca8eed1f3eb03d
+        chromium-mirror_third_party_dawn::git+https://dawn.googlesource.com/dawn.git#commit=95f9c2b375395cc82941babdf1e9f0cf60a32831
+        chromium-mirror_third_party_highway_src::git+https://chromium.googlesource.com/external/github.com/google/highway.git#commit=84379d1c73de9681b54fbe1c035a23c7bd5d272d
+        chromium-mirror_third_party_google_benchmark_src::git+https://chromium.googlesource.com/external/github.com/google/benchmark.git#commit=761305ec3b33abf30e08d50eb829e19a802581cc
+        chromium-mirror_third_party_libpfm4_src::git+https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git#commit=964baf9d35d5f88d8422f96d8a82c672042e7064
+        chromium-mirror_third_party_boringssl_src::git+https://boringssl.googlesource.com/boringssl.git#commit=91f3df0a20f6d3dd3e2f749b4a2730b68c3d585e
+        chromium-mirror_third_party_breakpad_breakpad::git+https://chromium.googlesource.com/breakpad/breakpad.git#commit=a1220f673dc44632e821bd1a217089e5a159a203
+        chromium-mirror_third_party_cast_core_public_src::git+https://chromium.googlesource.com/cast_core/public.git#commit=f5ee589bdaea60418f670fa176be15ccb9a34942
+        chromium-mirror_third_party_catapult::git+https://chromium.googlesource.com/catapult.git#commit=04c85a1d0e324464c6be4b3d193b47cb6177d03a
+        chromium-mirror_third_party_ced_src::git+https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git#commit=ba412eaaacd3186085babcd901679a48863c7dd5
+        chromium-mirror_third_party_cld_3_src::git+https://chromium.googlesource.com/external/github.com/google/cld_3.git#commit=b48dc46512566f5a2d41118c8c1116c4f96dc661
+        chromium-mirror_third_party_colorama_src::git+https://chromium.googlesource.com/external/colorama.git#commit=3de9f013df4b470069d03d250224062e8cf15c49
+        chromium-mirror_third_party_cpu_features_src::git+https://chromium.googlesource.com/external/github.com/google/cpu_features.git#commit=936b9ab5515dead115606559502e3864958f7f6e
+        chromium-mirror_third_party_cpuinfo_src::git+https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git#commit=877328f188a3c7d1fa855871a278eb48d530c4c0
+        chromium-mirror_third_party_crc32c_src::git+https://chromium.googlesource.com/external/github.com/google/crc32c.git#commit=d3d60ac6e0f16780bcfcc825385e1d338801a558
+        chromium-mirror_third_party_cros_system_api::git+https://chromium.googlesource.com/chromiumos/platform2/system_api.git#commit=c33ff08e2b27ddaed22c8799fefd3a4b7d3c49a9
+        chromium-mirror_third_party_crossbench::git+https://chromium.googlesource.com/crossbench.git#commit=f6e9d3627685e3bcb82d5a24c1f075b8dd0d881c
+        chromium-mirror_third_party_crossbench-web-tests::git+https://chromium.googlesource.com/chromium/web-tests.git#commit=3c76c8201f0732fe9781742229ab8ac43bf90cbf
+        chromium-mirror_third_party_depot_tools::git+https://chromium.googlesource.com/chromium/tools/depot_tools.git#commit=675a3a9ccd7cf9367bb4caa58c30f08b56d45ef5
+        chromium-mirror_third_party_devtools-frontend_src::git+https://chromium.googlesource.com/devtools/devtools-frontend.git#commit=747b0d1aebe33e5fc3d32677eb88315ab000eb5e
+        chromium-mirror_third_party_dom_distiller_js_dist::git+https://chromium.googlesource.com/chromium/dom-distiller/dist.git#commit=199de96b345ada7c6e7e6ba3d2fa7a6911b8767d
+        chromium-mirror_third_party_dragonbox_src::git+https://chromium.googlesource.com/external/github.com/jk-jeon/dragonbox.git#commit=6c7c925b571d54486b9ffae8d9d18a822801cbda
+        chromium-mirror_third_party_eigen3_src::git+https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git#commit=430e35fbd15d3c946d2d2ba19ec41c16ba217cb3
+        chromium-mirror_third_party_farmhash_src::git+https://chromium.googlesource.com/external/github.com/google/farmhash.git#commit=816a4ae622e964763ca0862d9dbd19324a1eaf45
+        chromium-mirror_third_party_fast_float_src::git+https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git#commit=cb1d42aaa1e14b09e1452cfdef373d051b8c02a4
+        chromium-mirror_third_party_federated_compute_src::git+https://chromium.googlesource.com/external/github.com/google-parfait/federated-compute.git#commit=e51058dfe7888094ecc09cda38bfceffd4d4664b
+        chromium-mirror_third_party_ffmpeg::git+https://chromium.googlesource.com/chromium/third_party/ffmpeg.git#commit=9e751092c9498b84bbb77e2e0689ef9f50fe608f
+        chromium-mirror_third_party_flac::git+https://chromium.googlesource.com/chromium/deps/flac.git#commit=807e251d9f8c5dd6059e547931e9c6a4251967af
+        chromium-mirror_third_party_flatbuffers_src::git+https://chromium.googlesource.com/external/github.com/google/flatbuffers.git#commit=1c514626e83c20fffa8557e75641848e1e15cd5e
+        chromium-mirror_third_party_fontconfig_src::git+https://chromium.googlesource.com/external/fontconfig.git#commit=f0ed9c3f43161d3555f6f7a5234b22fe7ca60727
+        chromium-mirror_third_party_fp16_src::git+https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git#commit=3d2de1816307bac63c16a297e8c4dc501b4076df
+        chromium-mirror_third_party_gemmlowp_src::git+https://chromium.googlesource.com/external/github.com/google/gemmlowp.git#commit=16e8662c34917be0065110bfcd9cc27d30f52fdf
+        chromium-mirror_third_party_freetype_src::git+https://chromium.googlesource.com/chromium/src/third_party/freetype2.git#commit=d3668e00da732654b50e4e81f982544ed6e26390
+        chromium-mirror_third_party_fxdiv_src::git+https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git#commit=63058eff77e11aa15bf531df5dd34395ec3017c8
+        chromium-mirror_third_party_harfbuzz-ng_src::git+https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git#commit=7d936359a27abb2d7cb14ecc102463bb15c11843
+        chromium-mirror_third_party_ink_src::git+https://chromium.googlesource.com/external/github.com/google/ink.git#commit=4e6081ad7052f97df7d77e1d87cea2d70c18a47b
+        chromium-mirror_third_party_ink_stroke_modeler_src::git+https://chromium.googlesource.com/external/github.com/google/ink-stroke-modeler.git#commit=fe79520c9ad7d2d445d26d3c59fda6fc54eb4d5c
+        chromium-mirror_third_party_instrumented_libs::git+https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git#commit=69015643b3f68dbd438c010439c59adc52cac808
+        chromium-mirror_third_party_emoji-segmenter_src::git+https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git#commit=955936be8b391e00835257059607d7c5b72ce744
+        chromium-mirror_third_party_oak_src::git+https://chromium.googlesource.com/external/github.com/project-oak/oak.git#commit=96c00a6c99ac382f3f3a8f376bc7a70890d1adaa
+        chromium-mirror_third_party_ots_src::git+https://chromium.googlesource.com/external/github.com/khaledhosny/ots.git#commit=46bea9879127d0ff1c6601b078e2ce98e83fcd33
+        chromium-mirror_third_party_libgav1_src::git+https://chromium.googlesource.com/codecs/libgav1.git#commit=c05bf9be660cf170d7c26bd06bb42b3322180e58
+        chromium-mirror_third_party_googletest_src::git+https://chromium.googlesource.com/external/github.com/google/googletest.git#commit=244cec869d12e53378fa0efb610cd4c32a454ec8
+        chromium-mirror_third_party_hunspell_dictionaries::git+https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git#commit=41cdffd71c9948f63c7ad36e1fb0ff519aa7a37e
+        chromium-mirror_third_party_icu::git+https://chromium.googlesource.com/chromium/deps/icu.git#commit=1b2e3e8a421efae36141a7b932b41e315b089af8
+        chromium-mirror_third_party_jsoncpp_source::git+https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git#commit=42e892d96e47b1f6e29844cc705e148ec4856448
+        chromium-mirror_third_party_leveldatabase_src::git+https://chromium.googlesource.com/external/leveldb.git#commit=4ee78d7ea98330f7d7599c42576ca99e3c6ff9c5
+        chromium-mirror_third_party_libFuzzer_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git#commit=bea408a6e01f0f7e6c82a43121fe3af4506c932e
+        chromium-mirror_third_party_fuzztest_src::git+https://chromium.googlesource.com/external/github.com/google/fuzztest.git#commit=e101ca021a40733d0fa76a3bd9b49b5f76da4f8a
+        chromium-mirror_third_party_domato_src::git+https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git#commit=053714bccbda79cf76dac3fee48ab2b27f21925e
+        chromium-mirror_third_party_libaddressinput_src::git+https://chromium.googlesource.com/external/libaddressinput.git#commit=2610f7b1043d6784ada41392fc9392d1ea09ea07
+        chromium-mirror_third_party_libaom_source_libaom::git+https://aomedia.googlesource.com/aom.git#commit=2a70ad7bee390757eaa83aff12f310ba53915e9f
+        chromium-mirror_third_party_crabbyavif_src::git+https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git#commit=3ba05863e84fd3acb4f4af2b4545221b317a2e55
+        chromium-mirror_third_party_nearby_src::git+https://chromium.googlesource.com/external/github.com/google/nearby-connections.git#commit=0bad8b0c9877f92eeeb550654f1ea51a71a085e4
+        chromium-mirror_third_party_securemessage_src::git+https://chromium.googlesource.com/external/github.com/google/securemessage.git#commit=fa07beb12babc3b25e0c5b1f38c16aa8cb6b8f84
+        chromium-mirror_third_party_jetstream_main::git+https://chromium.googlesource.com/external/github.com/WebKit/JetStream.git#commit=b400dd340af3457890ec7b4a903fefb02fcf2dc6
+        chromium-mirror_third_party_speedometer_main::git+https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git#commit=06449bdc34789a7459393405dd777e02d78a3743
+        chromium-mirror_third_party_ukey2_src::git+https://chromium.googlesource.com/external/github.com/google/ukey2.git#commit=0275885d8e6038c39b8a8ca55e75d1d4d1727f47
+        chromium-mirror_third_party_cros-components_src::git+https://chromium.googlesource.com/external/google3/cros_components.git#commit=7ccdbf60606671c2c057628125908fbfef9bd0c8
+        chromium-mirror_third_party_libdrm_src::git+https://chromium.googlesource.com/chromiumos/third_party/libdrm.git#commit=ad78bb591d02162d3b90890aa4d0a238b2a37cde
+        chromium-mirror_third_party_expat_src::git+https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git#commit=69d6c054c1bd5258c2a13405a7f5628c72c177c2
+        chromium-mirror_third_party_libipp_libipp::git+https://chromium.googlesource.com/chromiumos/platform2/libipp.git#commit=2209bb84a8e122dab7c02fe66cc61a7b42873d7f
+        chromium-mirror_third_party_libjpeg_turbo::git+https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git#commit=e14cbfaa85529d47f9f55b0f104a579c1061f9ad
+        chromium-mirror_third_party_liblouis_src::git+https://chromium.googlesource.com/external/liblouis-github.git#commit=9700847afb92cb35969bdfcbbfbbb74b9c7b3376
+        chromium-mirror_third_party_libphonenumber_dist::git+https://chromium.googlesource.com/external/libphonenumber.git#commit=9d46308f313f2bf8dbce1dfd4f364633ca869ca7
+        chromium-mirror_third_party_libprotobuf-mutator_src::git+https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git#commit=7bf98f78a30b067e22420ff699348f084f802e12
+        chromium-mirror_third_party_libsrtp::git+https://chromium.googlesource.com/chromium/deps/libsrtp.git#commit=a52756acb1c5e133089c798736dd171567df11f5
+        chromium-mirror_third_party_libsync_src::git+https://chromium.googlesource.com/aosp/platform/system/core/libsync.git#commit=f4f4387b6bf2387efbcfd1453af4892e8982faf6
+        chromium-mirror_third_party_libva-fake-driver_src::git+https://chromium.googlesource.com/chromiumos/platform/libva-fake-driver.git#commit=a9bcab9cd6b15d4e3634ca44d5e5f7652c612194
+        chromium-mirror_third_party_libvpx_source_libvpx::git+https://chromium.googlesource.com/webm/libvpx.git#commit=8d00aca60b951444582b1373e4e47f0ca6e0871c
+        chromium-mirror_third_party_libwebm_source::git+https://chromium.googlesource.com/webm/libwebm.git#commit=f2a982d748b80586ae53b89a2e6ebbc305848b8c
+        chromium-mirror_third_party_libwebp_src::git+https://chromium.googlesource.com/webm/libwebp.git#commit=b0e8039062eedbcb20ebb1bad62bfeaee2b94ec6
+        chromium-mirror_third_party_libyuv::git+https://chromium.googlesource.com/libyuv/libyuv.git#commit=94417b9d213364905ce849c25719b819b8dbbaaa
+        chromium-mirror_third_party_lss::git+https://chromium.googlesource.com/linux-syscall-support.git#commit=ed31caa60f20a4f6569883b2d752ef7522de51e0
+        chromium-mirror_third_party_material_color_utilities_src::git+https://chromium.googlesource.com/external/github.com/material-foundation/material-color-utilities.git#commit=13434b50dcb64a482cc91191f8cf6151d90f5465
+        chromium-mirror_third_party_minigbm_src::git+https://chromium.googlesource.com/chromiumos/platform/minigbm.git#commit=3018207f4d89395cc271278fb9a6558b660885f5
+        chromium-mirror_third_party_nasm::git+https://chromium.googlesource.com/chromium/deps/nasm.git#commit=e2c93c34982b286b27ce8b56dd7159e0b90869a2
+        chromium-mirror_third_party_neon_2_sse_src::git+https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git#commit=eb8b80b28f956275e291ea04a7beb5ed8289e872
+        chromium-mirror_third_party_openh264_src::git+https://chromium.googlesource.com/external/github.com/cisco/openh264.git#commit=652bdb7719f30b52b08e506645a7322ff1b2cc6f
+        chromium-mirror_third_party_openscreen_src::git+https://chromium.googlesource.com/openscreen.git#commit=4654d7968ac1a1e825a84bd4d85acadd7993c49a
+        chromium-mirror_third_party_openxr_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenXR-SDK.git#commit=57572a0e91890fe7183de25a62153aec955d64ba
+        chromium-mirror_third_party_pdfium::git+https://pdfium.googlesource.com/pdfium.git#commit=e95c6ead2f97716c98526ec42d5fd9ebb50e6e23
+        chromium-mirror_third_party_perfetto::git+https://chromium.googlesource.com/external/github.com/google/perfetto.git#commit=d5bbee7afdf259af4212929ccbff467dd5349953
+        chromium-mirror_third_party_protobuf-javascript_src::git+https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript.git#commit=e6d763860001ba1a76a63adcff5efb12b1c96024
+        chromium-mirror_third_party_pthreadpool_src_934f177b::git+https://chromium.googlesource.com/external/github.com/google/pthreadpool.git#commit=f5a07eddbf4be8f23e29e60a2ccf66b78b71f119
+        chromium-mirror_third_party_pyelftools::git+https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git#commit=19b3e610c86fcadb837d252c794cb5e8008826ae
+        chromium-mirror_third_party_quic_trace_src::git+https://chromium.googlesource.com/external/github.com/google/quic-trace.git#commit=ed3deb8a056b260c59f2fd42af6dfa3db48a8cad
+        chromium-mirror_third_party_pywebsocket3_src::git+https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/pywebsocket3.git#commit=50602a14f1b6da17e0b619833a13addc6ea78bc2
+        chromium-mirror_third_party_re2_src::git+https://chromium.googlesource.com/external/github.com/google/re2.git#commit=cd7b2823a8375371f7efe6dae17837c9ab407693
+        chromium-mirror_third_party_ruy_src::git+https://chromium.googlesource.com/external/github.com/google/ruy.git#commit=9940fbf1e0c0863907e77e0600b99bb3e2bc2b9f
+        chromium-mirror_third_party_search_engines_data_resources::git+https://chromium.googlesource.com/external/search_engines_data.git#commit=94eb2a9a225078cb5f40e82fd890bce387c8121a
+        chromium-mirror_third_party_skia::git+https://skia.googlesource.com/skia.git#commit=f4ed99d2443962782cf5f8b4dd27179f131e7cbe
+        chromium-mirror_third_party_smhasher_src::git+https://chromium.googlesource.com/external/smhasher.git#commit=0ff96f7835817a27d0487325b6c16033e2992eb5
+        chromium-mirror_third_party_snappy_src::git+https://chromium.googlesource.com/external/github.com/google/snappy.git#commit=32ded457c0b1fe78ceb8397632c416568d6714a0
+        chromium-mirror_third_party_sqlite_src::git+https://chromium.googlesource.com/chromium/deps/sqlite.git#commit=7d348fc79216a09b864ff881d8561a6222301666
+        chromium-mirror_third_party_swiftshader::git+https://swiftshader.googlesource.com/SwiftShader.git#commit=5f1c459a11bb4899301e89609cbf7547f9f31e20
+        chromium-mirror_third_party_text-fragments-polyfill_src::git+https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git#commit=c036420683f672d685e27415de0a5f5e85bdc23f
+        chromium-mirror_third_party_tflite_src::git+https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git#commit=313f58ae85278ced9ccc7f90ee630bdf8735c52f
+        chromium-mirror_third_party_vulkan-deps::git+https://chromium.googlesource.com/vulkan-deps.git#commit=02470a3c2773a9fa236c7e8dacd72deb4b5131e3
+        chromium-mirror_third_party_glslang_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang.git#commit=a57276bf558f5cf94d3a9854ebdf5a2236849a5a
+        chromium-mirror_third_party_spirv-cross_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross.git#commit=b8fcf307f1f347089e3c46eb4451d27f32ebc8d3
+        chromium-mirror_third_party_spirv-headers_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git#commit=01e0577914a75a2569c846778c2f93aa8e6feddd
+        chromium-mirror_third_party_spirv-tools_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git#commit=d5d5b61e2d5ae9b98ef403b3f3f922711812888a
+        chromium-mirror_third_party_vulkan-headers_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers.git#commit=a4f8ada9f4f97c45b8c89c57997be9cebaae65d2
+        chromium-mirror_third_party_vulkan-loader_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader.git#commit=f703f919c30c5b67958d35d40a4297cb3823ed78
+        chromium-mirror_third_party_vulkan-tools_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools.git#commit=d643b80d6ba8c191bc289fdda52867c3bb3c190b
+        chromium-mirror_third_party_vulkan-utility-libraries_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries.git#commit=4322db5906e67b57ec9c327e6afe3d98ed893df7
+        chromium-mirror_third_party_vulkan-validation-layers_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers.git#commit=83d96b88de7b85c3f29545170857e54e348421b2
+        chromium-mirror_third_party_vulkan_memory_allocator::git+https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git#commit=cb0597213b0fcb999caa9ed08c2f88dc45eb7d50
+        chromium-mirror_third_party_wayland_src::git+https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git#commit=a156431ea66fe67d69c9fbba8a8ad34dabbab81c
+        chromium-mirror_third_party_wayland-protocols_src::git+https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git#commit=efbc060534be948b63e1f395d69b583eebba3235
+        chromium-mirror_third_party_wayland-protocols_kde::git+https://chromium.googlesource.com/external/github.com/KDE/plasma-wayland-protocols.git#commit=0b07950714b3a36c9b9f71fc025fc7783e82926e
+        chromium-mirror_third_party_wayland-protocols_gtk::git+https://chromium.googlesource.com/external/github.com/GNOME/gtk.git#commit=40ebed3a03aef096addc0af09fec4ec529d882a0
+        chromium-mirror_third_party_webdriver_pylib::git+https://chromium.googlesource.com/external/github.com/SeleniumHQ/selenium/py.git#commit=1e954903022e9386b9acf452c24f4458dd4c4fc1
+        chromium-mirror_third_party_webgl_src::git+https://chromium.googlesource.com/external/khronosgroup/webgl.git#commit=c01b768bce4a143e152c1870b6ba99ea6267d2b0
+        chromium-mirror_third_party_webgpu-cts_src::git+https://chromium.googlesource.com/external/github.com/gpuweb/cts.git#commit=b62c3fc76c9c644a8597399b0d23f7032cabb366
+        chromium-mirror_third_party_webpagereplay::git+https://chromium.googlesource.com/webpagereplay.git#commit=9057e5d942f2bfcee71cc20415a7f86c966241f8
+        chromium-mirror_third_party_webrtc::git+https://webrtc.googlesource.com/src.git#commit=29d6eabaf0b5c1a62af6e7fd03adebf5e1a446e8
+        chromium-mirror_third_party_wuffs_src::git+https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git#commit=e3f919ccfe3ef542cfc983a82146070258fb57f8
+        chromium-mirror_third_party_weston_src::git+https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git#commit=bdba2f9adaca673fd58339d8140bc04727ee279d
+        chromium-mirror_third_party_xdg-utils::git+https://chromium.googlesource.com/chromium/deps/xdg-utils.git#commit=cb54d9db2e535ee4ef13cc91b65a1e2741a94a44
+        chromium-mirror_third_party_xnnpack_src::git+https://chromium.googlesource.com/external/github.com/google/XNNPACK.git#commit=4d098efeac50c44a7c03e6feb1794908db4c3158
+        chromium-mirror_third_party_zstd_src::git+https://chromium.googlesource.com/external/github.com/facebook/zstd.git#commit=89d685e42dbcf815a16ed0fcd7d050ef74ccad96
+        chromium-mirror_v8::git+https://chromium.googlesource.com/v8/v8.git#commit=8fa4e7c7469cd4d321e2241b86f684d52197a615
+        chromium-mirror_third_party_angle_third_party_glmark2_src::git+https://chromium.googlesource.com/external/github.com/glmark2/glmark2.git#commit=6edcf02205fd1e8979dc3f3964257a81959b80c8
+        chromium-mirror_third_party_angle_third_party_rapidjson_src::git+https://chromium.googlesource.com/external/github.com/Tencent/rapidjson.git#commit=781a4e667d84aeedbeb8184b7b62425ea66ec59f
+        chromium-mirror_third_party_angle_third_party_VK-GL-CTS_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS.git#commit=c67cffddd65aba724950e062343fa1cc89560b33
+        chromium-mirror_third_party_dawn_buildtools::git+https://chromium.googlesource.com/chromium/src/buildtools.git#commit=958004daacdd90070d44b236a1581c81d71740ca
+        chromium-mirror_third_party_dawn_build::git+https://chromium.googlesource.com/chromium/src/build.git#commit=0c8d2cd8fbe6a0755441ba3f6402bb241a3f6f1e
+        chromium-mirror_third_party_dawn_tools_clang::git+https://chromium.googlesource.com/chromium/src/tools/clang.git#commit=8e6c4696e2aee88cf2c60c1e6a527069fb735c14
+        chromium-mirror_third_party_dawn_tools_memory::git+https://chromium.googlesource.com/chromium/src/tools/memory.git#commit=3c7b1f4daab1520239cb172059e2e16684fd3128
+        chromium-mirror_third_party_dawn_tools_valgrind::git+https://chromium.googlesource.com/chromium/src/tools/valgrind.git#commit=da34b95fdbf2032df6cda5f3828c2ba421592644
+        chromium-mirror_third_party_dawn_tools_mb::git+https://chromium.googlesource.com/chromium/src/tools/mb.git#commit=6c50647ee969539f9371fafdeeb38d6b2c13dc34
+        chromium-mirror_third_party_dawn_testing::git+https://chromium.googlesource.com/chromium/src/testing.git#commit=2b39694741d609b78948e2330a47d684e723f229
+        chromium-mirror_third_party_dawn_third_party_jinja2::git+https://chromium.googlesource.com/chromium/src/third_party/jinja2.git#commit=e2d024354e11cc6b041b0cff032d73f0c7e43a07
+        chromium-mirror_third_party_dawn_third_party_markupsafe::git+https://chromium.googlesource.com/chromium/src/third_party/markupsafe.git#commit=0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794
+        chromium-mirror_third_party_dawn_third_party_glfw::git+https://chromium.googlesource.com/external/github.com/glfw/glfw.git#commit=b35641f4a3c62aa86a0b3c983d163bc0fe36026d
+        chromium-mirror_third_party_dawn_third_party_zlib::git+https://chromium.googlesource.com/chromium/src/third_party/zlib.git#commit=caf4afa1afc92e16fef429f182444bed98a46a6c
+        chromium-mirror_third_party_dawn_third_party_abseil-cpp::git+https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp.git#commit=9d692d669253232c024b20ae19d2ff0b581ee1cd
+        chromium-mirror_third_party_dawn_third_party_dxc::git+https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler.git#commit=2b58d6d865832f7146d6e22e2106e562458bbd0a
+        chromium-mirror_third_party_dawn_third_party_dxheaders::git+https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers.git#commit=980971e835876dc0cde415e8f9bc646e64667bf7
+        chromium-mirror_third_party_dawn_third_party_khronos_OpenGL-Registry::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry.git#commit=5bae8738b23d06968e7c3a41308568120943ae77
+        chromium-mirror_third_party_dawn_third_party_khronos_EGL-Registry::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry.git#commit=7dea2ed79187cd13f76183c4b9100159b9e3e071
+        chromium-mirror_third_party_dawn_third_party_webgpu-headers_src::git+https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers.git#commit=53a87a3d8cb4c32ec026978ce003020741df6f53
+        chromium-mirror_third_party_dawn_third_party_protobuf::git+https://chromium.googlesource.com/chromium/src/third_party/protobuf.git#commit=fef7a765bb0d1122d32b99f588537b83e2dffe7b
+        chromium-mirror_third_party_dawn_tools_protoc_wrapper::git+https://chromium.googlesource.com/chromium/src/tools/protoc_wrapper.git#commit=8ad6d21544b14c7f753852328d71861b363cc512
+        chromium-mirror_third_party_dawn_third_party_partition_alloc::git+https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator.git#commit=fae4df38cef9720a13dd55a6b1d20600919e671b
+        chromium-mirror_third_party_openscreen_src_third_party_tinycbor_src::git+https://chromium.googlesource.com/external/github.com/intel/tinycbor.git#commit=d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7
+        # END managed sources
+        )
+sha256sums=(
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP')
+
+# Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
+# Keys are the names in the above script; values are the dependencies in Arch
+# plus any so names that are provided + linked
+declare -gA _system_libs=(
+  [brotli]=brotli
+  # [dav1d]="dav1d libdav1d.so"
+  # [ffmpeg]="ffmpeg libavcodec.so libavcodec.so libavformat.so libavutil.so"
+  [flac]="flac libFLAC.so"
+  [fontconfig]="fontconfig libfontconfig.so"
+  [freetype]="freetype2 libfreetype.so"
+  [harfbuzz-ng]="harfbuzz libharfbuzz.so libharfbuzz-subset.so"
+  # [icu]="icu libicui18n.so libicuuc.so"
+  # [jsoncpp]="jsoncpp libjsoncpp.so"  # needs libstdc++
+  # [libaom]=aom
+  # [libavif]=libavif
+  [libdrm]=libdrm # libdrm.so
+  [libjpeg]="libjpeg-turbo libjpeg.so"
+  [libpng]="libpng libpng16.so"
+  # [libvpx]=libvpx
+  # [libwebp]="libwebp libwebpdemux.so libwebpmux.so libwebp.so"
+  [libxml]="libxml2 libxml2.so"
+  [libxslt]="libxslt libxslt.so"
+  [opus]="opus libopus.so"
+  # [re2]="re2 libre2.so" # needs libstdc++
+  # [snappy]=snappy # needs libstdc++
+  # [woff2]="woff2 libwoff2dec.so" # needs libstdc++
+  [zlib]=minizip # libminizip.so
+)
+_unwanted_bundled_libs=(
+  $(printf "%s\n" ${!_system_libs[@]} | sed 's/^libjpeg$/&_turbo/')
+)
+depends+=(${_system_libs[@]})
+
+_update_sources() {
+  python makepkg-source-roller.py update "v$pkgver" "$pkgname"
+  updpkgsums
+}
+
+prepare() {
+  sed -i "s|@ELECTRON@|${pkgname}|" electron-launcher.sh
+  sed -i "s|@ELECTRON@|${pkgname}|" electron.desktop
+  sed -i "s|@ELECTRON_NAME@|Electron ${_major_ver}|" electron.desktop
+
+  cp -r chromium-mirror_third_party_depot_tools depot_tools
+  export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+
+  echo "Putting together electron sources"
+  # Generate gclient gn args file and prepare-electron-source-tree.sh
+  python makepkg-source-roller.py generate electron/DEPS $pkgname
+  rbash prepare-electron-source-tree.sh "$CARCH"
+  mv electron src/electron
+
+  echo "Running hooks..."
+  src/build/landmines.py
+  src/build/util/lastchange.py -o src/build/util/LASTCHANGE
+  src/build/util/lastchange.py -m GPU_LISTS_VERSION \
+    --revision-id-only --header src/gpu/config/gpu_lists_version.h
+  src/build/util/lastchange.py -m SKIA_COMMIT_HASH \
+    -s src/third_party/skia --header src/skia/ext/skia_commit_hash.h
+  src/build/util/lastchange.py \
+    -s src/third_party/dawn --revision src/gpu/webgpu/DAWN_VERSION
+  src/tools/update_pgo_profiles.py --target=linux update \
+    --gs-url-base=chromium-optimization-profiles/pgo_profiles
+
+  src/third_party/node/update_npm_deps
+
+  src/electron/script/apply_all_patches.py \
+      src/electron/patches/config.json
+
+  # https://github.com/nodejs/node/issues/48444
+  export UV_USE_IO_URING=0
+
+  pushd src
+  pushd electron
+  yarn install --frozen-lockfile
+  popd
+
+  echo "Applying local patches..."
+
+  # https://crbug.com/893950
+  sed -i -e 's/\<xmlMalloc\>/malloc/' -e 's/\<xmlFree\>/free/' \
+         -e '1i #include <cstdlib>' \
+    third_party/blink/renderer/core/xml/*.cc \
+    third_party/blink/renderer/core/xml/parser/xml_document_parser.cc \
+    third_party/libxml/chromium/*.cc
+
+  ## Chromium patches
+  # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
+  patch -Np1 -i ../compiler-rt-adjust-paths.patch
+
+  # NodeJS version check workaround
+  patch -Np1 -i ../chromium-138-nodejs-version-check.patch
+
+  # Rust 1.86 lifetime syntax fix
+  patch -Np1 -i ../chromium-138-rust-1.86-mismatched_lifetime_syntaxes.patch
+
+  # CSSStyleSheet IWYU fix
+  patch -Np1 -i ../chromium-141-cssstylesheet-iwyu.patch
+
+  # glibc 2.43 seccomp fix
+  patch -Np1 -i ../fix-sys-seccomp-glibc243.patch
+
+  # CachyOS: increase FORTIFY_SOURCE level
+  patch -Np1 -i ../increase-fortify-level.patch
+
+  # Rust replaced libadler with libadler2
+  sed -i 's/"adler"/"adler2"/' build/rust/std/BUILD.gn
+
+  # Fixes for building with libstdc++ instead of libc++
+  for _patch in ../chromium-patches-*/*.patch; do
+    patch -Np1 -i "$_patch" || true
+  done
+
+  # Link to system tools required by the build
+  mkdir -p third_party/node/linux/node-linux-x64/bin
+  ln -sfn /usr/bin/node third_party/node/linux/node-linux-x64/bin/
+  mkdir -p third_party/jdk/current/bin
+  ln -sfn /usr/bin/java third_party/jdk/current/bin/
+  ln -sfn /usr/bin/clang-format buildtools/linux64
+
+  # Electron specific fixes
+  patch -Np1 -i "${srcdir}/jinja-python-3.10.patch" -d "third_party/electron_node/tools/inspector_protocol/jinja2"
+  patch -Np1 -i "${srcdir}/use-system-libraries-in-node.patch"
+  # patch -Np1 -i "${srcdir}/default_app-icon.patch"  # Icon from .desktop file
+
+  # Allow building against system libraries in official builds
+  echo "Patching Chromium for using system libraries..."
+  sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
+    tools/generate_shim_headers/generate_shim_headers.py
+  # Remove bundled libraries for which we will use the system copies
+  local _lib
+  for _lib in ${_unwanted_bundled_libs[@]}; do
+    find "third_party/$_lib" -type f \
+      \! -path "third_party/$_lib/chromium/*" \
+      \! -path "third_party/$_lib/google/*" \
+      \! -path "third_party/harfbuzz-ng/utils/hb_scoped.h" \
+        \! -regex '.*\.\(gn\|gni\|isolate\)' \
+        -delete
+  done
+
+  ./build/linux/unbundle/replace_gn_files.py \
+    --system-libraries "${!_system_libs[@]}"
+}
+
+build() {
+  cd src
+
+  export CC=clang
+  export CXX=clang++
+  export AR=ar
+  export NM=nm
+
+  local _flags=(
+    'custom_toolchain="//build/toolchain/linux/unbundle:default"'
+    'host_toolchain="//build/toolchain/linux/unbundle:default"'
+    'is_official_build=true' # implies is_cfi=true on x86_64
+    'symbol_level=0' # sufficient for backtraces on x86(_64)
+    'treat_warnings_as_errors=false'
+    'fatal_linker_warnings=false'
+    'disable_fieldtrial_testing_config=true'
+    'blink_enable_generated_code_formatting=false'
+    'ffmpeg_branding="Chrome"'
+    'proprietary_codecs=true'
+    'rtc_use_pipewire=true'
+    'link_pulseaudio=true'
+    'use_custom_libcxx=true' # https://github.com/llvm/llvm-project/issues/61705
+    'use_sysroot=false'
+    'use_system_libffi=true'
+    'enable_hangout_services_extension=true'
+    'enable_widevine=false'
+    'enable_nacl=false'
+    'thin_lto_enable_optimizations=true'
+  )
+
+  if [[ -n ${_system_libs[icu]+set} ]]; then
+    _flags+=('icu_use_data_file=false')
+  fi
+
+  local _clang_version=$(
+    clang --version | grep -m1 version | sed 's/.* \([0-9]\+\).*/\1/')
+
+  _flags+=(
+    'clang_base_path="/usr"'
+    'clang_use_chrome_plugins=false'
+    "clang_version=\"$_clang_version\""
+    'chrome_pgo_phase=2'
+  )
+
+  # Allow the use of nightly features with stable Rust compiler
+  # https://github.com/ungoogled-software/ungoogled-chromium/pull/2696#issuecomment-1918173198
+  export RUSTC_BOOTSTRAP=1
+
+  _flags+=(
+    'rust_sysroot_absolute="/usr"'
+    'rust_bindgen_root="/usr"'
+    "rustc_version=\"$(rustc --version)\""
+  )
+
+  # Facilitate deterministic builds (taken from build/config/compiler/BUILD.gn)
+  CFLAGS+='   -Wno-builtin-macro-redefined'
+  CXXFLAGS+=' -Wno-builtin-macro-redefined'
+  CPPFLAGS+=' -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__='
+
+  # Do not warn about unknown warning options
+  CFLAGS+='   -Wno-unknown-warning-option'
+  CXXFLAGS+=' -Wno-unknown-warning-option'
+
+  # Let Chromium set its own symbol level
+  CFLAGS=${CFLAGS/-g }
+  CXXFLAGS=${CXXFLAGS/-g }
+
+  # https://github.com/ungoogled-software/ungoogled-chromium-archlinux/issues/123
+  CFLAGS=${CFLAGS/-fexceptions}
+  CFLAGS=${CFLAGS/-fcf-protection}
+  CXXFLAGS=${CXXFLAGS/-fexceptions}
+  CXXFLAGS=${CXXFLAGS/-fcf-protection}
+
+  # This appears to cause random segfaults when combined with ThinLTO
+  # https://bugs.archlinux.org/task/73518
+  CFLAGS=${CFLAGS/-fstack-clash-protection}
+  CXXFLAGS=${CXXFLAGS/-fstack-clash-protection}
+
+  # https://crbug.com/957519#c122
+  CXXFLAGS=${CXXFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS}
+
+  export CHROMIUM_BUILDTOOLS_PATH="${PWD}/buildtools"
+  gn gen out/Release \
+      --args="import(\"//electron/build/args/release.gn\") ${_flags[*]}"
+  ninja -C out/Release electron electron_dist_zip
+}
+
+package() {
+  install -dm755 "${pkgdir:?}/usr/lib/${pkgname}"
+  bsdtar -xf src/out/Release/dist.zip -C "${pkgdir}/usr/lib/${pkgname}"
+
+  chmod u+s "${pkgdir}/usr/lib/${pkgname}/chrome-sandbox"
+
+  install -dm755 "${pkgdir}/usr/share/licenses/${pkgname}"
+  for l in "${pkgdir}/usr/lib/${pkgname}"/{LICENSE,LICENSES.chromium.html}; do
+    ln -s  \
+      "$(realpath --relative-to="${pkgdir}/usr/share/licenses/${pkgname}" "${l}")" \
+      "${pkgdir}/usr/share/licenses/${pkgname}"
+  done
+
+  install -Dm755 "${srcdir}/electron-launcher.sh" \
+    "${pkgdir}/usr/bin/${pkgname}"
+
+  # Install .desktop and icon file (see default_app-icon.patch)
+  install -Dm644 electron.desktop \
+    "${pkgdir}/usr/share/applications/${pkgname}.desktop"
+  install -Dm644 src/electron/default_app/icon.png \
+          "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+}

--- a/electron39/chromium-138-nodejs-version-check.patch
+++ b/electron39/chromium-138-nodejs-version-check.patch
@@ -1,0 +1,49 @@
+https://issues.chromium.org/issues/418397211
+From: Matt Jolly <kangie@gentoo.org>
+Date: Tue, 25 Mar 2025 13:33:48 +1000
+Subject: [PATCH] Remove nodejs version check
+
+Added in https://github.com/chromium/chromium/commit/0ff8528999941d7182be6fc77aeb12a110a3cd86,
+this change is only really useful for gclient checkouts and breaks the
+ability for downstreams to provide their own, compatible, nodejs
+version via the system package manager (or for use on arches other than
+those that Google provides binaries for):
+
+[ERR_ASSERTION]: Failed NodeJS version check: Expected version 'v22.11.0', but found 'v22.13.1'. Did you run 'gclient sync'
+
+This is google development footgun protection, working around
+poor development practices and gclient's inability to ensure
+that the source tree is in a consistent state. We don't need it
+here.
+
+Signed-off-by: Matt Jolly <kangie@gentoo.org>
+--- a/third_party/node/node.gni
++++ b/third_party/node/node.gni
+@@ -36,15 +36,5 @@ template("node") {
+       }
+     }
+ 
+-    # Automatically add a dependency to ":check_version" to ensure NodeJS is
+-    # always running the expected version, except when the ':check_version'
+-    # target itself is running in which case it shouldn't depend on itself.
+-    if (get_label_info(":" + target_name, "label_no_toolchain") !=
+-        "//third_party/node:check_version") {
+-      if (!defined(deps)) {
+-        deps = []
+-      }
+-      deps += [ "//third_party/node:check_version" ]
+-    }
+   }
+ }
+--- a/third_party/protobuf/proto_library.gni
++++ b/third_party/protobuf/proto_library.gni
+@@ -562,7 +562,6 @@ template("proto_library") {
+                   _protoc_gen_ts_path,
+                   "//tools/protoc_wrapper/protoc-gen-ts_proto.py",
+                 ] + _protoc_gen_ts_runtime_deps
+-      deps += [ "//third_party/node:check_version" ]
+     }
+ 
+     if (_generate_with_plugin) {
+-- 
+2.49.0

--- a/electron39/chromium-138-rust-1.86-mismatched_lifetime_syntaxes.patch
+++ b/electron39/chromium-138-rust-1.86-mismatched_lifetime_syntaxes.patch
@@ -1,0 +1,14 @@
+diff --git a/build/rust/cargo_crate.gni b/build/rust/cargo_crate.gni
+index 0e73b54..0e002ef 100644
+--- a/build/rust/cargo_crate.gni
++++ b/build/rust/cargo_crate.gni
+@@ -310,6 +310,9 @@
+       rustflags +=
+           [ "-Awarnings" ]  # Suppress other warnings in 3rd-party crates.
+ 
++      # TODO(crbug.com/424424323): Clean up and enable.
++      rustflags += [ "-Amismatched_lifetime_syntaxes" ]
++
+       if (!defined(build_native_rust_unit_tests)) {
+         build_native_rust_unit_tests = _crate_type != "proc-macro"
+       }

--- a/electron39/chromium-141-cssstylesheet-iwyu.patch
+++ b/electron39/chromium-141-cssstylesheet-iwyu.patch
@@ -1,0 +1,45 @@
+From f71f01773e427aaaf76563f1f2d24ee6ece2dce9 Mon Sep 17 00:00:00 2001
+From: Matt Jolly <kangie@gentoo.org>
+Date: Tue, 9 Sep 2025 12:44:09 +1000
+Subject: [PATCH 1/2] IWYU css_style_sheet.h
+
+issues.chromium.org/issues/429365675 replaces a bunch of includes with
+forward declarations. These builds clearly work with "normal" builds, which
+likely use C++ modules or precompiled headers, but break if your workflow
+does not use those features.
+
+Add appropriate includes to fix the build on Linux platforms.
+
+Signed-off-by: Matt Jolly <kangie@gentoo.org>
+--- a/third_party/blink/renderer/core/css/css_style_declaration.h
++++ b/third_party/blink/renderer/core/css/css_style_declaration.h
+@@ -23,6 +23,7 @@
+ 
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/core/css/css_property_names.h"
++#include "third_party/blink/renderer/core/css/css_style_sheet.h"
+ #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
+ #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+ #include "third_party/blink/renderer/platform/bindings/v8_binding.h"
+-- 
+2.50.1
+
+
+From 0a1de20a85504ed8cb40961f76631c1430ed634c Mon Sep 17 00:00:00 2001
+From: Matt Jolly <kangie@gentoo.org>
+Date: Tue, 9 Sep 2025 12:56:38 +1000
+Subject: [PATCH 2/2] IWYU css_style_sheet.h in generator
+
+Signed-off-by: Matt Jolly <kangie@gentoo.org>
+--- a/third_party/blink/renderer/bindings/scripts/bind_gen/observable_array.py
++++ b/third_party/blink/renderer/bindings/scripts/bind_gen/observable_array.py
+@@ -434,6 +434,7 @@ def generate_observable_array(observable_array_identifier):
+         component_export_header(api_component, for_testing),
+         "third_party/blink/renderer/bindings/core/v8/idl_types.h",
+         "third_party/blink/renderer/platform/bindings/observable_array.h",
++        "third_party/blink/renderer/core/css/css_style_sheet.h",
+     ])
+     source_node.accumulator.add_include_headers([
+         "third_party/blink/renderer/bindings/core/v8/generated_code_helper.h",
+-- 
+2.50.1

--- a/electron39/compiler-rt-adjust-paths.patch
+++ b/electron39/compiler-rt-adjust-paths.patch
@@ -1,0 +1,34 @@
+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+index b171ee13ce7ed..d5b4e4fdcd0c8 100644
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -171,16 +171,21 @@ template("clang_lib") {
+       } else if (is_linux || is_chromeos) {
+         if (current_cpu == "x64") {
+           _dir = "x86_64-unknown-linux-gnu"
++          _suffix = "-x86_64"
+         } else if (current_cpu == "x86") {
+           _dir = "i386-unknown-linux-gnu"
++          _suffix = "-i386"
+         } else if (current_cpu == "arm") {
+           _dir = "armv7-unknown-linux-gnueabihf"
+         } else if (current_cpu == "arm64") {
+           _dir = "aarch64-unknown-linux-gnu"
++          _suffix = "-aarch64"
+         } else if (current_cpu == "loong64") {
+           _dir = "loongarch64-unknown-linux-gnu"
++          _suffix = "-loongarch64"
+         } else if (current_cpu == "riscv64") {
+           _dir = "riscv64-unknown-linux-gnu"
++          _suffix = "-riscv64"
+         } else if (current_cpu == "ppc64") {
+           _dir = "ppc64le-unknown-linux-gnu"
+         } else if (current_cpu == "s390x") {
+@@ -188,6 +193,7 @@ template("clang_lib") {
+         } else {
+           assert(false)  # Unhandled cpu type
+         }
++        _dir = "linux"
+       } else if (is_fuchsia) {
+         if (current_cpu == "x64") {
+           _dir = "x86_64-unknown-fuchsia"

--- a/electron39/default_app-icon.patch
+++ b/electron39/default_app-icon.patch
@@ -1,0 +1,21 @@
+--- a/electron/default_app/default_app.ts
++++ b/electron/default_app/default_app.ts
+@@ -60,7 +60,7 @@
+   };
+
+   if (process.platform === 'linux') {
+-    options.icon = path.join(__dirname, 'icon.png');
++    options.icon = '/usr/share/pixmaps/electron.png';
+   }
+
+   mainWindow = new BrowserWindow(options);
+--- a/electron/filenames.gni
++++ b/electron/filenames.gni
+@@ -6,7 +6,6 @@
+   ]
+
+   default_app_static_sources = [
+-    "default_app/icon.png",
+     "default_app/index.html",
+     "default_app/package.json",
+     "default_app/styles.css",

--- a/electron39/electron-launcher.sh
+++ b/electron39/electron-launcher.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+name=@ELECTRON@
+flags_file="${XDG_CONFIG_HOME:-$HOME/.config}/${name}-flags.conf"
+fallback_file="${XDG_CONFIG_HOME:-$HOME/.config}/electron-flags.conf"
+
+lines=()
+if [[ -f "${flags_file}" ]]; then
+    mapfile -t lines < "${flags_file}"
+elif [[ -f "${fallback_file}" ]]; then
+    mapfile -t lines < "${fallback_file}"
+fi
+
+flags=()
+for line in "${lines[@]}"; do
+    if [[ ! "${line}" =~ ^[[:space:]]*#.* ]] && [[ -n "${line}" ]]; then
+        flags+=("${line}")
+    fi
+done
+
+: ${ELECTRON_IS_DEV:=0}
+export ELECTRON_IS_DEV
+: ${ELECTRON_FORCE_IS_PACKAGED:=true}
+export ELECTRON_FORCE_IS_PACKAGED
+
+exec /usr/lib/${name}/electron "${flags[@]}" "$@"

--- a/electron39/electron.desktop
+++ b/electron39/electron.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=@ELECTRON_NAME@
+Icon=@ELECTRON@
+Exec=@ELECTRON@ %u
+Categories=Development;GTK;
+StartupNotify=true

--- a/electron39/fix-sys-seccomp-glibc243.patch
+++ b/electron39/fix-sys-seccomp-glibc243.patch
@@ -1,0 +1,17 @@
+--- a/sandbox/linux/system_headers/linux_seccomp.h
++++ b/sandbox/linux/system_headers/linux_seccomp.h
+@@ -214,7 +214,9 @@
+ #endif
+
+-#ifndef SYS_SECCOMP
+-#define SYS_SECCOMP                   1
+-#endif
++#if !defined(SYS_SECCOMP) && !defined(__GLIBC_PREREQ)
++#define SYS_SECCOMP 1
++#elif !defined(SYS_SECCOMP) && defined(__GLIBC_PREREQ)
++#if !__GLIBC_PREREQ(2, 43)
++#define SYS_SECCOMP 1
++#endif
++#endif
+
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SECCOMP_H_

--- a/electron39/increase-fortify-level.patch
+++ b/electron39/increase-fortify-level.patch
@@ -1,0 +1,13 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index eb329bc88fec..7c98dfddcf8a 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -2054,7 +2054,7 @@ config("chromium_code") {
+       # Non-chromium code is not guaranteed to compile cleanly with
+       # _FORTIFY_SOURCE. Also, fortified build may fail when optimizations are
+       # disabled, so only do that for Release build.
+-      fortify_level = "2"
++      fortify_level = "3"
+ 
+       # ChromeOS's toolchain supports a high-quality _FORTIFY_SOURCE=3
+       # implementation with a few custom glibc patches. Use that if it's

--- a/electron39/jinja-python-3.10.patch
+++ b/electron39/jinja-python-3.10.patch
@@ -1,0 +1,22 @@
+--- a/runtime.py
++++ b/runtime.py
+@@ -315,7 +315,7 @@ class Context(with_metaclass(ContextMeta
+ 
+ # register the context as mapping if possible
+ try:
+-    from collections import Mapping
++    from collections.abc import Mapping
+     Mapping.register(Context)
+ except ImportError:
+     pass
+--- a/sandbox.py
++++ b/sandbox.py
+@@ -14,7 +14,7 @@
+ """
+ import types
+ import operator
+-from collections import Mapping
++from collections.abc import Mapping
+ from jinja2.environment import Environment
+ from jinja2.exceptions import SecurityError
+ from jinja2._compat import string_types, PY2

--- a/electron39/makepkg-source-roller.py
+++ b/electron39/makepkg-source-roller.py
@@ -1,0 +1,429 @@
+from collections import OrderedDict
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader
+from tempfile import NamedTemporaryFile
+from heapq import heappush
+from hashlib import sha1
+import sys
+import requests
+import base64
+import re
+import os
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def fetch_deps(url, rev):
+    # Get the DEPS file from the given URL and revision
+    if "googlesource.com" in url:
+        deps_url = f"{url}/+/{rev}/DEPS?format=text"
+        eprint(f"  Fetching {deps_url}")
+        response = requests.get(deps_url)
+        response.raise_for_status()
+        return base64.b64decode(response.text).decode("utf-8")
+    elif url.startswith("https://github.com/"):
+        if url.endswith(".git"):
+            url = url[: -len(".git")]
+        response = requests.get(f"{url}/raw/{rev}/DEPS")
+        response.raise_for_status()
+        return response.text
+    else:
+        raise Exception(f"Unimplemented for URL {url}")
+
+
+class Str:
+    def __init__(self, s):
+        self.inner = s
+
+    def __str__(self):
+        return self.inner
+
+
+def eval_condition(condition, globals_dict, locals_dict):
+    """Evaluate a DEPS condition string, treating unknown variables as False."""
+    try:
+        return eval(condition, globals_dict, locals_dict)
+    except NameError as e:
+        # Unknown variable (e.g. checkout_ai_evals in newer Chromium) — skip the dep
+        eprint(f"  Unknown condition variable ({e}), treating as False: {condition}")
+        return False
+
+
+ignored_dep_prefix = [
+    # MacOS specific
+    "src/third_party/squirrel.mac",
+    # Unnecessary parts
+    "src/docs/website",
+]
+
+
+def parse_deps(path, prefix="", is_src=False, vars=None, reverse_map=None):
+    """
+    path: Path to the DEPS file
+    prefix: Prefix to add when using recursedeps
+    is_src: Whether the current DEPS file is the one from "src" repo
+    vars: Override variables when generating gclient gn args file
+    reverse_map: Map from url to path. Used for de-duplication
+    """
+    spec = spec_from_loader("deps", SourceFileLoader("deps", path))
+    deps_module = module_from_spec(spec)
+
+    def var_substitute(var_name):
+        return deps_module.vars[var_name]
+
+    deps_module.Var = var_substitute
+    deps_module.Str = Str
+
+    spec.loader.exec_module(deps_module)
+
+    if not hasattr(deps_module, "vars"):
+        deps_module.vars = {}
+
+    for k in (
+        "checkout_win",
+        "checkout_mac",
+        "checkout_ios",
+        "checkout_chromeos",
+        "checkout_fuchsia",
+        "checkout_android",
+        "checkout_cxx_debugging_extension_deps",
+        # Skip architecture specific deps. They are prebuilt binaries and we should install them via pacman
+        "checkout_x86",
+        "checkout_x64",
+        "checkout_arm64",
+        "checkout_mips64",
+        "checkout_mips",
+        "checkout_arm",
+        "checkout_ppc",
+        "checkout_s390",
+        "checkout_riscv64",
+    ):
+        deps_module.vars[k] = False
+    deps_module.vars["checkout_linux"] = True
+    deps_module.vars["build_with_chromium"] = True
+    deps_module.vars["host_os"] = "linux"
+    use_relative_paths = (
+        hasattr(deps_module, "use_relative_paths") and deps_module.use_relative_paths
+    )
+
+    def url_and_revision(raw_url):
+        url = raw_url.format(**deps_module.vars)
+        url, rev = url.rsplit("@", 1)
+        if ".googlesource.com/" in url and not url.endswith(".git"):
+            # Unify url format by adding .git suffix (for de-duplication)
+            url += ".git"
+        return (url, rev)
+
+    def format_path(dep_name):
+        return dep_name if not use_relative_paths else f"{prefix}/{dep_name}"
+
+    real_deps = OrderedDict()
+    cipd_deps = {}
+    gcs_deps = {}
+    reverse_map = reverse_map or {}
+
+    def add_dep(dep_name, raw_url):
+        path = format_path(dep_name)
+        for ignored_prefix in ignored_dep_prefix:
+            if path.startswith(ignored_prefix):
+                eprint(f"Ignoring {path}")
+                return
+        url, rev = url_and_revision(raw_url)
+        real_deps[path] = (url, rev)
+        # Add to reverse map for de-duplication, use a heap to make sure the shortest path is chosen
+        heappush(reverse_map.setdefault(url, []), (len(path), path))
+
+    if not hasattr(deps_module, "deps"):
+        return real_deps, {}, cipd_deps, gcs_deps, reverse_map
+
+    for dep_name, dep_value in deps_module.deps.items():
+        if isinstance(dep_value, dict):
+            if "dep_type" in dep_value:
+                if dep_value["dep_type"] == "cipd":
+                    cipd_deps[format_path(dep_name)] = dep_value["packages"]
+                elif dep_value["dep_type"] == "gcs":
+                    if "condition" in dep_value and not eval_condition(
+                        dep_value["condition"], vars, deps_module.vars
+                    ):
+                        eprint(
+                            f"Skipping {format_path(dep_name)} because of unmet condition {dep_value['condition']}"
+                        )
+                        continue
+                    gcs_deps[format_path(dep_name)] = dep_value
+                else:
+                    raise Exception(f"Unknown DEP {dep_name} = {dep_value}")
+            else:
+                if "condition" in dep_value and not eval(
+                    dep_value["condition"], vars, deps_module.vars
+                ):
+                    eprint(
+                        f"Skipping {format_path(dep_name)} because of unmet condition {dep_value['condition']}"
+                    )
+                    continue
+                add_dep(dep_name, dep_value["url"])
+        elif isinstance(dep_value, str):
+            add_dep(dep_name, dep_value)
+        else:
+            raise Exception(f"Unknown DEP {dep_name} = {dep_value}")
+
+    gclient_gn_args = {}
+    vars = vars or {}
+
+    if is_src and hasattr(deps_module, "gclient_gn_args"):
+        for arg in deps_module.gclient_gn_args:
+            # electron vars overwrites chromium vars
+            gclient_gn_args[arg] = (deps_module.vars | vars).get(arg)
+
+    if hasattr(deps_module, "recursedeps"):
+        for dep in deps_module.recursedeps:
+            if dep not in real_deps:
+                eprint(f"Skipping recursive DEP {dep} as it's not found in deps dict")
+                continue
+            eprint(f"Fetching recursedep {dep}")
+            deps_text = fetch_deps(*real_deps[dep])
+            with NamedTemporaryFile(mode="w", delete=True) as f:
+                f.write(deps_text)
+                f.flush()
+                dep_deps, dep_gclient_gn_args, dep_cipd_deps, dep_gcs_deps, _ = (
+                    parse_deps(
+                        f.name,
+                        format_path(dep),
+                        dep == "src",
+                        deps_module.vars | vars,
+                        reverse_map,
+                    )
+                )
+                real_deps.update(dep_deps)
+                gclient_gn_args.update(dep_gclient_gn_args)
+                cipd_deps.update(dep_cipd_deps)
+                gcs_deps.update(dep_gcs_deps)
+    return real_deps, gclient_gn_args, cipd_deps, gcs_deps, reverse_map
+
+
+repos_with_changed_url = {
+    "https://chromium.googlesource.com/chromium/llvm-project/compiler-rt/lib/fuzzer.git",
+    "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf.git",
+    "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git"
+}
+
+
+def get_source_path(path, url, pkgname, reverse_map):
+    """returns the source path and whether it's deduplicated or not"""
+    deduplicated = False
+    if len(reverse_map[url]) > 1:
+        # Deduplicate, choose the shortest path
+        shortest = reverse_map[url][0][1]
+        if path != shortest:
+            eprint(f"Deduplicate:  {path} -> {shortest}")
+            deduplicated = True
+        path = shortest
+    flattened = path.replace("/", "_")
+    result = re.sub("^src", "chromium-mirror", flattened)
+    if url in repos_with_changed_url:
+        # To make makepkg happy when using SRCDEST
+        result += f"_{sha1(url.encode('utf-8')).hexdigest()[:8]}"
+    return result, deduplicated
+
+
+def generate_fragment(rev):
+    if "." in rev:
+        # Treat revisions that contain dot as tags
+        return f"tag={rev}"
+    else:
+        return f"commit={rev}"
+
+
+preferred_url_map = {
+    # Replace with github mirror
+    "https://chromium.googlesource.com/chromium/src.git": "https://github.com/chromium/chromium.git",
+}
+
+
+def get_preferred_url(url):
+    preferred_url = preferred_url_map.get(url)
+    return preferred_url or url
+
+
+def generate_source_list(deps, indent, extra_sources, pkgname, reverse_map):
+    for path, (url, rev) in deps.items():
+        source_path, deduplicated = get_source_path(path, url, pkgname, reverse_map)
+        if deduplicated:
+            # Skip the duplicated source
+            continue
+        yield f"{indent}{source_path}::git+{get_preferred_url(url)}#{generate_fragment(rev)}"
+    for s in extra_sources:
+        yield f"{indent}{s}"
+
+
+def generate_managed_scripts(deps, extra_cmds, pkgname, reverse_map):
+    script = """#!/usr/bin/env rbash
+set -e
+# Generated file. Do not modify by hand.
+# Usage: script <CARCH>
+place_subproject_into_tree () {
+    # place_subproject_into_tree flattened_path path should_copy
+    local parent_dir="$(dirname "$2")"
+    if [[ -n "$parent_dir" ]]; then
+        mkdir -p "$parent_dir"
+    fi
+    # Remove the target dir
+    rm -rf "$2"
+    if [[ "$3" == "true" ]]; then
+        cp -r "$1" "$2"
+    else
+        mv -v "$1" "$2"
+    fi
+}
+
+CARCH="$1"
+case "$CARCH" in
+    x86_64)
+        _go_arch=amd64;;
+    *)
+        _go_arch="$CARCH";;
+esac
+
+"""
+    for path, (url, rev) in deps.items():
+        source_path, deduplicated = get_source_path(path, url, pkgname, reverse_map)
+        if deduplicated:
+            shortest = reverse_map[url][0][1]
+            script += f"place_subproject_into_tree {shortest} {path} true\n"
+            script += f"git -C {path} checkout --detach {rev}\n"
+        else:
+            script += f"place_subproject_into_tree {source_path} {path} false\n"
+    # Additional Commands
+    script += "\n".join(extra_cmds)
+    filename = "prepare-electron-source-tree.sh"
+    with open(filename, "w") as f:
+        f.write(script)
+    return filename
+
+
+def update_pkgbuild(real_deps, reverse_map, extra_sources):
+    with open("PKGBUILD", "r") as f:
+        pkgbuild = f.read()
+    res = re.search(
+        "([ \t]*)# BEGIN managed sources\n((.|\n)*)([ \t]*)# END managed sources",
+        pkgbuild,
+        re.MULTILINE,
+    )
+    if res is None:
+        raise Exception("managed sources not found")
+    indent = res.group(1)
+    span = res.span(2)
+    pkgbuild = (
+        pkgbuild[: span[0]]
+        + "\n".join(
+            generate_source_list(real_deps, indent, extra_sources, pkgname, reverse_map)
+        )
+        + "\n"
+        + indent
+        + pkgbuild[span[1] :]
+    )
+
+    with open("PKGBUILD", "w") as f:
+        f.write(pkgbuild)
+
+
+def pyobj_to_gn_arg(k, v):
+    if isinstance(v, Str):
+        return f'{k} = "{v.inner}"'
+    elif isinstance(v, str):
+        return f'{k} = "{v}"'
+    elif isinstance(v, bool):
+        return f"{k} = {'true' if v else 'false'}"
+    else:
+        raise Exception(f"Cannot convert {k}={v} ({type(v)})to gn arg")
+
+
+def generate_gclient_args(args):
+    """
+    Writes gclient_args.gni
+    Returns command to copy it
+    """
+    with open("gclient_args.gni", "w") as f:
+        f.writelines(pyobj_to_gn_arg(k, v) + "\n" for k, v in args.items())
+
+    return "cp gclient_args.gni src/build/config/gclient_args.gni"
+
+
+def cipd_path_substitute(cipd_path):
+    # Assume PKGBUILD provides _go_arch variable
+    return cipd_path.replace("${{platform}}", "linux-${_go_arch}").replace(
+        "${{arch}}", "${_go_arch}"
+    )
+
+
+def generate_cipd_cmds(cipd_deps, enabled_deps):
+    for dep, is_optional in enabled_deps:
+        packages = cipd_deps.get(dep)
+        if packages is None:
+            if is_optional:
+                continue
+            else:
+                raise f"cipd dependency {dep} not found"
+        for package in packages:
+            yield f"cipd install {cipd_path_substitute(package['package'])} {package['version']} -root {dep}"
+
+
+def generate_gcs_cmds(gcs_deps):
+    for path, package in gcs_deps.items():
+        yield f"# Unhandled gcs dependency {path}: {package}"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        eprint(f"Usage: {sys.argv[0]} ACTION PATH_OR_ELECTRON_VERSION PKGNAME")
+        sys.exit(1)
+    action = sys.argv[1]
+    deps_path = sys.argv[2]
+    pkgname = sys.argv[3]
+    assert action in ("print", "update", "generate")
+    if not os.path.exists(deps_path):
+        # Get it from web
+        response = requests.get(
+            f"https://github.com/electron/electron/raw/{deps_path}/DEPS"
+        )
+        response.raise_for_status()
+        deps_text = response.text
+        with NamedTemporaryFile(mode="w", delete=True) as f:
+            f.write(deps_text)
+            f.flush()
+            git_deps, gargs, cipd_deps, gcs_deps, reverse_map = parse_deps(f.name)
+    else:
+        git_deps, gargs, cipd_deps, gcs_deps, reverse_map = parse_deps(deps_path)
+    if action == "print":
+        for name, value in git_deps.items():
+            print(f"git: {name} = {value}")
+        for name, value in cipd_deps.items():
+            print(f"cipd: {name} = {value}")
+    elif action == "update":
+        update_pkgbuild(git_deps, reverse_map, [])
+
+    if action == "generate" or action == "update":
+        garg_cmd = generate_gclient_args(gargs)
+        # cipd dependencies are usually binary blobs. Only add the necessary parts.
+        cipd_cmds = generate_cipd_cmds(
+            cipd_deps,
+            [
+                # (dependency path, is_optional)
+                (
+                    "src/third_party/screen-ai/linux",
+                    True,
+                ),  # only for new electron versions (probably >= 29)
+                # The esbuild version 0.14.13 is not compatible with the system one
+                ("src/third_party/devtools-frontend/src/third_party/esbuild", False),
+            ],
+        )
+        # gcs dependencies are usually binary blobs. They are not handled yet.
+        gcs_cmds = generate_gcs_cmds(gcs_deps)
+        managed_script = generate_managed_scripts(
+            git_deps,
+            [garg_cmd] + list(cipd_cmds) + list(gcs_cmds),
+            pkgname,
+            reverse_map,
+        )
+    print("Done")

--- a/electron39/use-system-libraries-in-node.patch
+++ b/electron39/use-system-libraries-in-node.patch
@@ -1,0 +1,59 @@
+--- a/third_party/electron_node/BUILD.gn
++++ b/third_party/electron_node/BUILD.gn
+@@ -9,6 +9,14 @@
+ # Please modify the gyp files if you are making changes to build system.
+ 
+ import("unofficial.gni")
++import("//build/config/linux/pkg_config.gni")
+ 
++pkg_config("cares") {
++  packages = [ "libcares" ]
++}
++
++pkg_config("nghttp2") {
++  packages = [ "libnghttp2" ]
++}
+ node_gn_build("node") {
+ }
+--- a/third_party/electron_node/unofficial.gni
++++ b/third_party/electron_node/unofficial.gni
+@@ -145,6 +145,8 @@
+   source_set("libnode") {
+     configs += [
+       ":node_internal_config",
++      ":cares",
++      ":nghttp2",
+       "//build/config/compiler:no_exit_time_destructors"
+     ]
+     public_configs = [
+@@ -161,10 +163,8 @@
+     ]
+     deps = [
+       ":run_node_js2c",
+-      "deps/cares",
+       "deps/histogram",
+       "deps/nbytes",
+-      "deps/nghttp2",
+       "deps/postject",
+       "deps/uvwasi",
+       "//third_party/zlib",
+@@ -247,19 +247,6 @@
+       sources += node_inspector.node_inspector_sources +
+                  node_inspector.node_inspector_generated_sources
+     }
+-    if (is_linux) {
+-      import("//build/config/linux/pkg_config.gni")
+-        if (use_system_cares) {
+-          pkg_config("cares") {
+-            packages = [ "libcares" ]
+-          }
+-        }
+-      if (use_system_nghttp2) {
+-        pkg_config("nghttp2") {
+-          packages = [ "libnghttp2" ]
+-        }
+-      }
+-    }
+   }
+ 
+   config("zstd_include_config") {


### PR DESCRIPTION
## Summary

- **New package**: `electron39` (Electron 39.5.2 / Chromium 142)
- **Critical fix**: `fix-sys-seccomp-glibc243.patch` — CachyOS ships glibc 2.43+ which introduces a `SYS_SECCOMP` macro that collides with Chromium's internal definition, breaking the build
- **Performance**: `thin_lto_enable_optimizations=true` + `increase-fortify-level.patch`
- **Complete PKGBUILD**: proper `prepare()`, `build()`, `package()` with 169 managed sources
- **Patched `makepkg-source-roller.py`**: handles new Chromium 142 DEPS variables (`checkout_ppc`, `checkout_ai_evals`, etc.) that the upstream script doesn't know about

## Patches included

| Patch | Purpose |
|---|---|
| `fix-sys-seccomp-glibc243.patch` | glibc 2.43 SYS_SECCOMP collision fix |
| `increase-fortify-level.patch` | Higher FORTIFY_SOURCE level |
| `compiler-rt-adjust-paths.patch` | compiler-rt >= 16 compatibility |
| `chromium-138-nodejs-version-check.patch` | NodeJS version check workaround |
| `chromium-138-rust-1.86-mismatched_lifetime_syntaxes.patch` | Rust 1.86 fix |
| `chromium-141-cssstylesheet-iwyu.patch` | CSSStyleSheet IWYU fix |
| `jinja-python-3.10.patch` | Jinja2 Python 3.10+ compatibility |
| `use-system-libraries-in-node.patch` | Use system libs in bundled Node |

## Test plan

- [ ] `makepkg -s` builds successfully on CachyOS
- [ ] Resulting package installs and launches (`electron39 --version`)
- [ ] Electron-based apps (e.g. VSCode, Discord) work with `electron39`

Replaces #1203 (closed due to deleted fork).