### PR TITLE
nvidia-utils: fix format of NVIDIA app profile config

### DIFF
--- a/nvidia/nvidia-utils/.SRCINFO
+++ b/nvidia/nvidia-utils/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nvidia-utils
 	pkgver = 595.45.04
-	pkgrel = 2
+	pkgrel = 3
 	url = http://www.nvidia.com/
 	arch = x86_64
 	license = custom
@@ -31,7 +31,7 @@ pkgbase = nvidia-utils
 	sha256sums = 54f765d28020cee170d18229e58c46966a19efd4f0bb2053efaf88ba5204d281
 	sha256sums = a0088d49d46b699d1727e5944fd9aca5ede93ea3678dd5e91ca58084bc2fa0ee
 	sha256sums = b14f7a65359c05c373ddfc750cd4cf086a48e815489d93ad5cbe1dbf84bf8f5a
-	sha256sums = 65b39286f5abf441926743c8c9b90ddf1c691112d6b56bff373d233fcd617a3c
+	sha256sums = 6264d279bbae8eae6554ed78dd6e562da00cf71ffa5601ce5208099a98cd2c4d
 
 pkgname = nvidia-utils
 	pkgdesc = NVIDIA drivers utilities

--- a/nvidia/nvidia-utils/PKGBUILD
+++ b/nvidia/nvidia-utils/PKGBUILD
@@ -7,7 +7,7 @@
 pkgbase=nvidia-utils
 pkgname=('nvidia-utils' 'opencl-nvidia' 'nvidia-open-dkms')
 pkgver=595.45.04
-pkgrel=2
+pkgrel=3
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom')
@@ -40,7 +40,7 @@ sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
             '54f765d28020cee170d18229e58c46966a19efd4f0bb2053efaf88ba5204d281'
             'a0088d49d46b699d1727e5944fd9aca5ede93ea3678dd5e91ca58084bc2fa0ee'
             'b14f7a65359c05c373ddfc750cd4cf086a48e815489d93ad5cbe1dbf84bf8f5a'
-            '65b39286f5abf441926743c8c9b90ddf1c691112d6b56bff373d233fcd617a3c')
+            '6264d279bbae8eae6554ed78dd6e562da00cf71ffa5601ce5208099a98cd2c4d')
 
 
 create_links() {

--- a/nvidia/nvidia-utils/cuda-no-stable-perf-limit
+++ b/nvidia/nvidia-utils/cuda-no-stable-perf-limit
@@ -1,27 +1,51 @@
 {
+    "rules": [
+        {
+            "pattern": "obs",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "Discord",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "discord",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "DiscordCanary",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "vesktop",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "simplescreenrecorder",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "gpu-screen-recorder",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "spectacle",
+            "profile": "CudaNoStablePerfLimit"
+        },
+        {
+            "pattern": "webcord",
+            "profile": "CudaNoStablePerfLimit"
+        }
+    ],
     "profiles": [
         {
             "name": "CudaNoStablePerfLimit",
-            "settings": ["0x166c5e", 0]
-        }
-    ],
-    "rules": [
-        {
-            "pattern": {
-                "op": "or",
-                "sub": [
-                    { "feature": "procname", "matches": "obs" },
-                    { "feature": "procname", "matches": "Discord" },
-                    { "feature": "procname", "matches": "discord" },
-                    { "feature": "procname", "matches": "DiscordCanary" },
-                    { "feature": "procname", "matches": "vesktop" },
-                    { "feature": "procname", "matches": "simplescreenrecorder" },
-                    { "feature": "procname", "matches": "gpu-screen-recorder" },
-                    { "feature": "procname", "matches": "spectacle" },
-                    { "feature": "procname", "matches": "webcord" }
-                ]
-            },
-            "profile": "CudaNoStablePerfLimit"
+            "settings": [
+                {
+                    "key": "0x166c5e",
+                    "value": 0
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Fix an issue where NVIDIA settings do not show the cuda-no-stable-perf-limit app profile because the format was incorrect.

<img width="1297" height="526" alt="image" src="https://github.com/user-attachments/assets/69f907a3-3a09-4534-bcad-5dab146b971a" />
