### PR TITLE
asusctl: install the new asus-shutdown binary

### DIFF
--- a/asusctl/PKGBUILD
+++ b/asusctl/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(
   rog-control-center
 )
 pkgver=6.3.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A control daemon, tools, and a collection of crates for interacting with ASUS ROG laptops"
 arch=('x86_64')
 url="https://asus-linux.org"
@@ -79,7 +79,8 @@ package_asusctl() {
     install-asusd \
     install-asusd_user \
     install-data-asusd \
-    install-data-asusd_user
+    install-data-asusd_user \
+    install-asus-shutdown
 }
 
 package_rog-control-center() {


### PR DESCRIPTION
asusctl added a new binary `asus-shutdown` in version 6.3.5 that needs to be installed for the package to function correctly.