### PR TITLE
cahcyos-rate-mirrors:China rate mirrors

### DIFF
--- a/cachyos-rate-mirrors/cachyos-rate-mirrors
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors
@@ -113,9 +113,35 @@ rate_repository_mirrors() {
         fi
     done
 
-    die "rate-mirrors failed after ${max_retries} attempts for [${repo}]. Please check your network connection and try again."
+    # Insert CN mirrors first for China region (GitHub is DNS tainted, slow intl access)
+    if [ "$country" = "CN" ] && [ "$repo" = "cachyos" ]; then
+        force_cn_mirrors
+        return 0
+    else
+        die "rate-mirrors failed after ${max_retries} attempts for [${repo}]. Please check your network connection and try again."
+    fi
 }
 
+force_cn_mirrors() {
+    local mirror domain index
+    local -a cn_mirrors=(
+        'https://mirror.nju.edu.cn/cachyos/repo/$arch/$repo'
+        'https://mirrors.ustc.edu.cn/cachyos/repo/$arch/$repo'
+    )
+
+    local -i line=1
+    for ((index=0; index < ${#cn_mirrors[@]}; index++)); do
+        mirror="${cn_mirrors[$index]}"
+        domain="${mirror##*://}"
+        domain="${domain%%/*}"
+        if curl -sL --connect-timeout 5 "https://${domain}" &>/dev/null; then
+            sed -i "$((line))iServer = ${mirror}" "${MIRRORS_DEFAULT_DIR}/cachyos-mirrorlist"
+            ((line++))
+        else
+            error "Failed to connect with ${domain} mirror"
+        fi
+    done
+}
 
 force_ru_mirrors() {
     local mirror domain index


### PR DESCRIPTION
It was discussed on the [forum](https://discuss.cachyos.org/t/cachyos-installation-issue-vulnerability-in-network-restricted-regions/26707) before.
Added a mechanism to retry three times, and if it fails, it will use a method similar to the ru region to force the mirror to be specified
To be honest, the CN mirror source is not expected to change much, so if you don't want to use a complicated retry mechanism, just run `force_cn_mirrors` in the main process.