### PR TITLE
Unlock browser.tabs.unloadOnLowMemory

### DIFF
--- a/cachyos-firefox-settings/cachyos.js
+++ b/cachyos-firefox-settings/cachyos.js
@@ -227,7 +227,7 @@ pref("browser.safebrowsing.provider.mozilla.updateURL", "", locked);
 pref("browser.safebrowsing.reportPhishURL", "", locked);
 
 // Performance tweaks
-pref("browser.tabs.unloadOnLowMemory", true, locked); // Unload unused tabs
+pref("browser.tabs.unloadOnLowMemory", true); // Unload unused tabs
 pref("content.notify.interval", 100000); // page reflow timer, lower redrawn rendering timer, increases responsiveness but increase total load time
 pref("network.dnsCacheExpiration", 3600); // Time DNS entries are cached in seconds.
 pref("network.http.max-connections", 1800); //https://kb.mozillazine.org/Network.http.max-connections


### PR DESCRIPTION
In my day to day usage, whenever I'm running background tasks, Firefox aggressively unloads background tabs I tab out of. This resets my scrolled spot in long documents, logs me out of pages, erases progress in unsaved pages; it just disrupts my workflow in all sorts of ways.

And not in a low memory situation, either. When this happens, I have usually have gigabytes of RAM free, and none (or a negligable amount) of swap used.

Hence I'd like the option to at least disable this behavior in Firefox.

***

...But it's not impossible for me to work around, either. Is there a reason this setting is locked?