### PR TITLE
Update pacman PKGBUILD

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -56,6 +56,9 @@ checkdepends=(
 optdepends=(
   'base-devel: required to use makepkg'
   'perl-locale-gettext: translation support in makepkg-template'
+  'ttf-firacode-nerd: for a pretty progress bar in makepkg'
+  'ttf-iosevka-nerd: for a pretty progress bar in makepkg'
+  'ttf-juliamono-nerd-font: for a pretty progress bar in makepkg'
 )
 provides=('libalpm.so')
 backup=(etc/pacman.conf


### PR DESCRIPTION
Windows Terminal does not ship with a font that supports the Private Use Area characters (U+EE00–U+EE05) used by `PrettyProgressBar`, causing it to fall back to rendering a replacement character instead of the intended progress bar.

This is particularly noticeable for WSL users, who are likely running Windows Terminal. After some debugging, I traced the issue to the fact that these glyphs are only implemented in specific fonts — FiraCode, Iosevka, and JuliaMono — as noted in the original patch.

Adding these as `optdepends` gives WSL (and other Windows Terminal) users a clear signal that one of these fonts is required to correctly display `PrettyProgressBar`, rather than leaving them to debug it themselves.
Debugging and pr was done by me but this message was done by Claude