### PR TITLE
wine-cachyos-opt: Fix permissions for xalia installation

### DIFF
--- a/wine-cachyos-opt/PKGBUILD
+++ b/wine-cachyos-opt/PKGBUILD
@@ -215,6 +215,8 @@ package() {
   cd "$srcdir"
   install -d -m755 "$pkgdir"/opt/"${pkgname//-opt}"/share/xalia
   unzip xalia-${_xaliaver}-net48-mono.zip -d "$pkgdir"/opt/"${pkgname//-opt}"/share/xalia
+  # Fix permissions
+  chmod -R go-w "$pkgdir"/opt/"${pkgname//-opt}"/share/xalia
 }
 
 # vim:set ts=8 sts=2 sw=2 et:

--- a/wine-cachyos/PKGBUILD
+++ b/wine-cachyos/PKGBUILD
@@ -223,6 +223,8 @@ package() {
   cd "$srcdir"
   install -d -m755 "$pkgdir"/usr/share/xalia
   unzip xalia-${_xaliaver}-net48-mono.zip -d "$pkgdir"/usr/share/xalia
+  # Fix permissions
+  chmod -R go-w "$pkgdir"/usr/share/xalia
 }
 
 # vim:set ts=8 sts=2 sw=2 et:


### PR DESCRIPTION
Xalia zip as extracted produces files which are world writable. Fix the permissions afterwards.