### PR TITLE
Request to Add Two CachyOS Mirrors in South Korea

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -70,3 +70,6 @@ Server = https://mirror.jura12.ru/repo/$arch/$repo
 Server = https://mirror.cachy-arch.ru/cachyos/repo/$arch/$repo
 ## Russia Mirror much thanks to wan666 from metrosg.ru
 Server = https://wan.metrosg.ru/cachyos/repo/$arch/$repo
+## Republic of Korea Mirror much thanks to Keiminem from Keiverse
+Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
+Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo


### PR DESCRIPTION
## Request to Add Two CachyOS Mirrors to the Official Mirror List

Dear CachyOS Team,

I would like to request the inclusion of our two CachyOS mirrors in the official mirror list.

Both mirror setups have been completed and are now fully operational for public use. Please note that the following two mirrors should be registered separately.

### Mirrors

- **Mirror 1:** https://mirror.keiminem.com/
- **Mirror 2:** https://mirror2.keiminem.com/

### Mirror Details

- **Location:** Gumi-si, Republic of Korea
- **Repository Scope:** Full CachyOS repositories
- **Sync Methods:** rsync / rsync-ssl / http / https
- **Network Capacity:** Each mirror is connected through a dedicated 2 Gbps enterprise line
- **Sync Interval:** Every 10 minutes

For reference, we are currently operating an official Arch Linux Tier 1 mirror, and these CachyOS mirrors are hosted and maintained under the same infrastructure standards.

Although the sync interval is configured to run every 10 minutes, the synchronization process terminates immediately when no file changes are detected. Therefore, I believe this should not place unnecessary load on the upstream server.

However, if you would prefer a different synchronization interval, please let me know your preferred schedule and I will be happy to adjust it accordingly.

I would appreciate it if you could review both mirrors and add them separately to the official CachyOS mirror list.

Please let me know if any additional information or verification is required.

Thank you for your time and consideration.