### PR TITLE
add a south korea cachyos mirror (updated)

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -73,10 +73,7 @@ Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
 Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo
 ## Republic of Korea Mirror much thanks to Hemino
 Server = https://mirror.hemino.net/cachyos/repo/$arch/$repo
-## Republic of Korea Mirror much thanks to kmw
-Server = https://mirror.distly.kr/cachyos/repo/$arch/$repo
-## Repulbic of Korea Mirror mutch thanks to parkard
-Server = https://mirror.wane.kr/cachyos/repo/$arch/$repo
-## Republic of Korea Mirror much thanks to X from ROKFOSS
+## Republic of Korea Mirror much thanks to X and parkard from ROKFOSS
 Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
+Server = https://mirror4.krfoss.org/cachyos/repo/$arch/$repo
 Server = https://mirrors.krfoss.org/cachyos/repo/$arch/$repo

--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -73,3 +73,10 @@ Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
 Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo
 ## Republic of Korea Mirror much thanks to Hemino
 Server = https://mirror.hemino.net/cachyos/repo/$arch/$repo
+## Republic of Korea Mirror much thanks to kmw
+Server = https://mirror.distly.kr/cachyos/repo/$arch/$repo
+## Repulbic of Korea Mirror mutch thanks to parkard
+Server = https://mirror.wane.kr/cachyos/repo/$arch/$repo
+## Republic of Korea Mirror much thanks to X from ROKFOSS
+Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
+Server = https://mirrors.krfoss.org/cachyos/repo/$arch/$repo


### PR DESCRIPTION
ROKFOSS is a FOSS mirroring project in South Korea and uses CDNs such as Cloudflare and Fastly.
`mirror5.krfoss.org` was already registered under a different address (hemino.net), so I updated the information.

Mirror using **Cloudflare**:
- https://mirror.krfoss.org/
- https://mirror4.krfoss.org/

Mirrors using **Fastly**:
- https://mirrors.krfoss.org/

**Update: some mirrors that do not use CDN have been removed or changed due to potential issues**