### PR TITLE
re-enable rokfoss mirror, update hemino.net address and remove two mirrors

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -71,9 +71,6 @@ Server = https://wan.metrosg.ru/cachyos/repo/$arch/$repo
 ## Republic of Korea Mirror much thanks to Keiminem from Keiverse
 Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
 Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo
-## Republic of Korea Mirror much thanks to Hemino
-#Server = https://mirror.hemino.net/cachyos/repo/$arch/$repo
-## Republic of Korea Mirror much thanks to X and parkard from ROKFOSS
-#Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
-#Server = https://mirror4.krfoss.org/cachyos/repo/$arch/$repo
-#Server = https://mirrors.krfoss.org/cachyos/repo/$arch/$repo
+## Republic of Korea Mirror much thanks to ROKFOSS
+Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
+Server = https://mirror5.krfoss.org/cachyos/repo/$arch/$repo


### PR DESCRIPTION
removed  `mirror4.krfoss.org` and `mirrors.krfoss.org`.

re-enabled the rokfoss mirror (`mirror.krfoss.org`) and replaced `mirror.hemino.net` with `mirror5.krfoss.org`.