### PR TITLE
rate-mirrors: remove vendored openssl and re-enable LTO

### DIFF
--- a/rate-mirrors/PKGBUILD
+++ b/rate-mirrors/PKGBUILD
@@ -8,9 +8,8 @@ pkgdesc="Everyday-use client-side map-aware mirror ranking tool"
 arch=(x86_64)
 url="https://github.com/westandskif/rate-mirrors"
 license=('CC-BY-NC-SA-3.0')
-depends=('glibc' 'gcc-libs')
+depends=('glibc' 'gcc-libs' 'openssl')
 makedepends=('git' 'cargo')
-options=(!lto)
 source=(
     "${pkgname}::git+$url.git#tag=v${pkgver}"
     https://github.com/CachyOS/rate-mirrors/commit/29d2f3beb572187d0ece1e81e78b4e5612b563b2.patch
@@ -34,7 +33,7 @@ prepare() {
 
 build() {
   cd "$pkgname"
-  cargo build --release --frozen
+  OPENSSL_NO_VENDOR=true cargo build --release --frozen
 }
 
 package() {


### PR DESCRIPTION
Link against the system-provided openssl instead of the bundled copy.

After removing vendored openssl, link-time optimization (LTO) can be enabled again.