### PR TITLE
nodejs: remove vendored libffi

### DIFF
--- a/nodejs/PKGBUILD
+++ b/nodejs/PKGBUILD
@@ -66,6 +66,7 @@ _configure_args=(
   --shared-ada
   --shared-brotli
   --shared-cares
+  --shared-libffi
   --shared-libuv
   --shared-nghttp2
   --shared-nghttp3


### PR DESCRIPTION
Link against the system-provided libffi instead of the bundled copy.