### PR TITLE
changes to the *.krfoss.org country code

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -105,7 +105,7 @@ Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
 ## tier=2 code=KR
 Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo
 ## Republic of Korea Mirror much thanks to ROKFOSS
-## tier=2 code=KR
+## tier=2 code=GLOBAL
 Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
-## tier=2 code=KR
+## tier=2 code=GLOBAL
 Server = https://mirror5.krfoss.org/cachyos/repo/$arch/$repo


### PR DESCRIPTION
`*.krfoss.org` uses cloudflare and connects to the nearest cloudflare server, so it has been changed to global