### PR TITLE
nodejs: enable LTO

### DIFF
--- a/nodejs/.SRCINFO
+++ b/nodejs/.SRCINFO
@@ -23,7 +23,6 @@ pkgbase = nodejs
 	depends = zlib
 	depends = zstd
 	optdepends = npm: nodejs package manager
-	options = !lto
 	source = git+https://github.com/nodejs/node.git#tag=v26.2.0?signed
 	validpgpkeys = 8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600
 	validpgpkeys = 890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4

--- a/nodejs/PKGBUILD
+++ b/nodejs/PKGBUILD
@@ -40,7 +40,6 @@ makedepends=(
   'python'
 )
 optdepends=('npm: nodejs package manager')
-options=('!lto')
 source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed")
 
 sha512sums=('dde978219d900786ebff9aa7076f3c9d26ed8926089acd5776ec616c3b6e8592ac212a68baea4441c512f9e5cc38e6002a806926db70933de07abfe698c1b2e5')
@@ -60,6 +59,7 @@ _common_flags=(
 
 _configure_args=(
   --ninja
+  --enable-lto
   --prefix=/usr
   --with-intl=system-icu
   --without-npm


### PR DESCRIPTION
LTO (Link Time Optimization) has been enabled for `nodejs` in the Arch Linux official repository,