### PR TITLE
cachyos-rate-mirrors: stop rating on boot, run every 10d

### DIFF
--- a/cachyos-rate-mirrors/.SRCINFO
+++ b/cachyos-rate-mirrors/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-rate-mirrors
 	pkgdesc = CachyOS - Rate mirrors service
 	pkgver = 23
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/CachyOS
 	install = cachyos-rate-mirrors.install
 	arch = any
@@ -14,7 +14,7 @@ pkgbase = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors.hook
 	sha256sums = c8eefdede7b115ee7f4a59d6f631e491a0698c3a930c2fc2d2e9e710b4feaad2
 	sha256sums = a70233ee2e082e2e5a11503f048d06c80f566be4b7d664e4afee7051befc5420
-	sha256sums = 256966d791f94b9a8587cc314eef078277974ed2ff4b0c46b860d92b0d658366
+	sha256sums = 308658cae1df8fa694ac406dd61b870bde826d976d7eb8d8f5fda2e6ece5781f
 	sha256sums = 631cd984e0b77f58be2cee48748a49eab2c56d51622e397defbf464574aec0f4
 
 pkgname = cachyos-rate-mirrors

--- a/cachyos-rate-mirrors/PKGBUILD
+++ b/cachyos-rate-mirrors/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cachyos-rate-mirrors
 pkgver=23
-pkgrel=1
+pkgrel=2
 groups=(cachyos)
 arch=('any')
 install=$pkgname.install
@@ -19,7 +19,7 @@ source=(
 )
 sha256sums=('c8eefdede7b115ee7f4a59d6f631e491a0698c3a930c2fc2d2e9e710b4feaad2'
             'a70233ee2e082e2e5a11503f048d06c80f566be4b7d664e4afee7051befc5420'
-            '256966d791f94b9a8587cc314eef078277974ed2ff4b0c46b860d92b0d658366'
+            '308658cae1df8fa694ac406dd61b870bde826d976d7eb8d8f5fda2e6ece5781f'
             '631cd984e0b77f58be2cee48748a49eab2c56d51622e397defbf464574aec0f4')
 
 package() {

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors.timer
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors.timer
@@ -4,9 +4,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Timer]
-OnBootSec=10min
-RandomizedDelaySec=50s
-OnUnitActiveSec=5d
+OnUnitActiveSec=10d
+RandomizedDelaySec=6h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
Archlinux Mirror hoster are reporting that they get too much traffic from us. 

Add more randomization and run the timer only every 10 days. Maybe we can also reduce the number of ranked archlinux mirrors too.