### PR TITLE
mesa-git: fix llvm32.native

### DIFF
--- a/mesa/mesa-git/llvm32.native
+++ b/mesa/mesa-git/llvm32.native
@@ -1,2 +1,3 @@
 [binaries]
 llvm-config = '/usr/bin/llvm-config32'
+rust = ['rustc', '--target=i686-unknown-linux-gnu']


### PR DESCRIPTION
The PKGBUILD hash already matched these contents, from Frogging-Family repo.