### PR TITLE
cachyos/cachy-screen-enhancer: initial package v1.0.0

### DIFF
--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-'sha256sums=('d0ae4d00b259fc82389d2c958582671348f4b3fc397192cb837f50bf66638603'
+sha256sums=('d0ae4d00b259fc82389d2c958582671348f4b3fc397192cb837f50bf66638603'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('d0ae4d00b259fc82389d2c958582671348f4b3fc397192cb837f50bf66638603'
+sha256sums=('d0873e8752e30ac73536686409a3f4e1be13906170cba2e79e94e438cf7c2c69'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('c9c66f124c97f1e0f5c2b933a1b03b3c7f3c52972b2cbed8a54551081a610072'
+'sha256sums=('d0ae4d00b259fc82389d2c958582671348f4b3fc397192cb837f50bf66638603'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -11,21 +11,15 @@ url="https://github.com/galpt/cachy-screen-enhancer"
 depends=('python' 'colord' 'argyllcms')
 makedepends=('git')
 install="$pkgname.install"
-source=("$pkgname::git+$url.git#tag=v$pkgver")
-sha256sums=('f4ead5a448037bf561b5f38e2f0728eba5bf1c4cd6044786486391b444af8857')
+source=("$pkgname::git+$url.git#tag=v$pkgver"
+        "README.cachyos.md")
+sha256sums=('f4ead5a448037bf561b5f38e2f0728eba5bf1c4cd6044786486391b444af8857'
+            '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {
   cd "${srcdir}/${pkgname}"
 
   local sharedir="$pkgdir/usr/share/$pkgname"
-
-  install -d "$sharedir"
-  install -d "$sharedir/src"
-  install -d "$sharedir/profiles/icc"
-  install -d "$sharedir/profiles/cal"
-  install -d "$sharedir/tools"
-  install -d "$sharedir/docs"
-  install -d "$sharedir/data/edid"
 
   # Core files
   install -Dm755 safe-install.sh "$sharedir/safe-install.sh"
@@ -68,6 +62,7 @@ package() {
   # Docs
   install -Dm644 docs/HOW_IT_WORKS.md "$sharedir/docs/HOW_IT_WORKS.md"
   install -Dm644 docs/TROUBLESHOOTING.md "$sharedir/docs/TROUBLESHOOTING.md"
+  install -Dm644 "$srcdir/README.cachyos.md" "$sharedir/docs/README.cachyos.md"
 
   # Data
   install -Dm644 data/edid/len156fhd_2026-06-09.bin "$sharedir/data/edid/len156fhd_2026-06-09.bin"

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Galih Tama <galpt@v.recipes>
+
+pkgname=cachy-screen-enhancer
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='ICC color profiles that correct sRGB to pure gamma 2.2 for CachyOS/Linux'
+groups=('cachyos')
+arch=('any')
+license=('BSD-3-Clause')
+url="https://github.com/galpt/cachy-screen-enhancer"
+depends=('python' 'colord' 'argyllcms')
+makedepends=('git')
+install="$pkgname.install"
+source=("$pkgname::git+$url.git#tag=v$pkgver")
+sha256sums=('f4ead5a448037bf561b5f38e2f0728eba5bf1c4cd6044786486391b444af8857')
+
+package() {
+  cd "${srcdir}/${pkgname}"
+
+  local sharedir="$pkgdir/usr/share/$pkgname"
+
+  install -d "$sharedir"
+  install -d "$sharedir/src"
+  install -d "$sharedir/profiles/icc"
+  install -d "$sharedir/profiles/cal"
+  install -d "$sharedir/tools"
+  install -d "$sharedir/docs"
+  install -d "$sharedir/data/edid"
+
+  # Core files
+  install -Dm755 safe-install.sh "$sharedir/safe-install.sh"
+  install -Dm644 README.md "$sharedir/README.md"
+  install -Dm644 LICENSE "$sharedir/LICENSE"
+  install -Dm644 pyproject.toml "$sharedir/pyproject.toml"
+
+  # Python library
+  install -Dm644 src/cse-gen.py "$sharedir/src/cse-gen.py"
+  install -Dm644 src/cse_lib/__init__.py "$sharedir/src/cse_lib/__init__.py"
+  install -Dm644 src/cse_lib/gamma_math.py "$sharedir/src/cse_lib/gamma_math.py"
+  install -Dm644 src/cse_lib/edid_parser.py "$sharedir/src/cse_lib/edid_parser.py"
+  install -Dm644 src/cse_lib/gpu_detect.py "$sharedir/src/cse_lib/gpu_detect.py"
+  install -Dm644 src/cse_lib/vcgt_builder.py "$sharedir/src/cse_lib/vcgt_builder.py"
+  install -Dm644 src/cse_lib/icc_builder.py "$sharedir/src/cse_lib/icc_builder.py"
+
+  # Profiles
+  install -Dm644 profiles/icc/cse_080nits_amd.icc "$sharedir/profiles/icc/cse_080nits_amd.icc"
+  install -Dm644 profiles/icc/cse_100nits_amd.icc "$sharedir/profiles/icc/cse_100nits_amd.icc"
+  install -Dm644 profiles/icc/cse_120nits_amd.icc "$sharedir/profiles/icc/cse_120nits_amd.icc"
+  install -Dm644 profiles/icc/cse_200nits_amd.icc "$sharedir/profiles/icc/cse_200nits_amd.icc"
+  install -Dm644 profiles/icc/cse_300nits_amd.icc "$sharedir/profiles/icc/cse_300nits_amd.icc"
+  install -Dm644 profiles/icc/cse_400nits_amd.icc "$sharedir/profiles/icc/cse_400nits_amd.icc"
+  install -Dm644 profiles/icc/cse_480nits_amd.icc "$sharedir/profiles/icc/cse_480nits_amd.icc"
+  install -Dm644 profiles/cal/cse_080nits_amd.cal "$sharedir/profiles/cal/cse_080nits_amd.cal"
+  install -Dm644 profiles/cal/cse_100nits_amd.cal "$sharedir/profiles/cal/cse_100nits_amd.cal"
+  install -Dm644 profiles/cal/cse_120nits_amd.cal "$sharedir/profiles/cal/cse_120nits_amd.cal"
+  install -Dm644 profiles/cal/cse_200nits_amd.cal "$sharedir/profiles/cal/cse_200nits_amd.cal"
+  install -Dm644 profiles/cal/cse_300nits_amd.cal "$sharedir/profiles/cal/cse_300nits_amd.cal"
+  install -Dm644 profiles/cal/cse_400nits_amd.cal "$sharedir/profiles/cal/cse_400nits_amd.cal"
+  install -Dm644 profiles/cal/cse_480nits_amd.cal "$sharedir/profiles/cal/cse_480nits_amd.cal"
+
+  # Tools
+  install -Dm755 tools/install-profile.sh "$sharedir/tools/install-profile.sh"
+  install -Dm755 tools/remove-profile.sh "$sharedir/tools/remove-profile.sh"
+  install -Dm755 tools/dump-edid.sh "$sharedir/tools/dump-edid.sh"
+  install -Dm755 tools/inspect-profile.sh "$sharedir/tools/inspect-profile.sh"
+  install -Dm755 tools/verify.sh "$sharedir/tools/verify.sh"
+
+  # Docs
+  install -Dm644 docs/HOW_IT_WORKS.md "$sharedir/docs/HOW_IT_WORKS.md"
+  install -Dm644 docs/TROUBLESHOOTING.md "$sharedir/docs/TROUBLESHOOTING.md"
+
+  # Data
+  install -Dm644 data/edid/len156fhd_2026-06-09.bin "$sharedir/data/edid/len156fhd_2026-06-09.bin"
+}
+
+# vim:set sw=2 sts=2 et:

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('f4ead5a448037bf561b5f38e2f0728eba5bf1c4cd6044786486391b444af8857'
+sha256sums=('c9c66f124c97f1e0f5c2b933a1b03b3c7f3c52972b2cbed8a54551081a610072'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('6e8c4a503f283ed43674073d35eae8317d59f10121a7dfdcf8624b374de103af'
+sha256sums=('90f1a79e5961e4cab7fbd405b0b04d25025db9156f0029b059f71e3a01b39278'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('ed6bb8c11c1b491b3d775d8b64f7fe5196c2c3b0b91273152b8cce69bc30e2f7'
+sha256sums=('732fa8bdd9f57030a65a948adcbfcb17a0eebc3eb40dafb16c7954c593357d52'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('d0873e8752e30ac73536686409a3f4e1be13906170cba2e79e94e438cf7c2c69'
+sha256sums=('ed6bb8c11c1b491b3d775d8b64f7fe5196c2c3b0b91273152b8cce69bc30e2f7'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('4e61bb40dadedb7fa756b29da7d372ea8929462c86c07e9af9b57cc5806fbfd1'
+sha256sums=('a2c67f29f3a8ebfca7ab8ba904f49afb51a4dcb15c9b9f5f2b75aff5a694f015'
             'ad8bf4f25435a9fc17c9db7922779f72678b08b6495e59f2a77df14d9d116f01')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('732fa8bdd9f57030a65a948adcbfcb17a0eebc3eb40dafb16c7954c593357d52'
+sha256sums=('6e8c4a503f283ed43674073d35eae8317d59f10121a7dfdcf8624b374de103af'
             '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
 
 package() {

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,8 +13,8 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('90f1a79e5961e4cab7fbd405b0b04d25025db9156f0029b059f71e3a01b39278'
-            '81aada89faac5c7a4acb80e30ee7bbfbcf72bfd33fe66d088e9d1c6d4e7bd7bf')
+sha256sums=('4e61bb40dadedb7fa756b29da7d372ea8929462c86c07e9af9b57cc5806fbfd1'
+            'ad8bf4f25435a9fc17c9db7922779f72678b08b6495e59f2a77df14d9d116f01')
 
 package() {
   cd "${srcdir}/${pkgname}"
@@ -28,7 +28,7 @@ package() {
   install -Dm644 pyproject.toml "$sharedir/pyproject.toml"
 
   # Python library
-  install -Dm644 src/cse-gen.py "$sharedir/src/cse-gen.py"
+  install -Dm644 src/cse_gen.py "$sharedir/src/cse_gen.py"
   install -Dm644 src/cse_lib/__init__.py "$sharedir/src/cse_lib/__init__.py"
   install -Dm644 src/cse_lib/gamma_math.py "$sharedir/src/cse_lib/gamma_math.py"
   install -Dm644 src/cse_lib/edid_parser.py "$sharedir/src/cse_lib/edid_parser.py"

--- a/cachy-screen-enhancer/PKGBUILD
+++ b/cachy-screen-enhancer/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('git')
 install="$pkgname.install"
 source=("$pkgname::git+$url.git#tag=v$pkgver"
         "README.cachyos.md")
-sha256sums=('a2c67f29f3a8ebfca7ab8ba904f49afb51a4dcb15c9b9f5f2b75aff5a694f015'
+sha256sums=('5db55d1644025cfef443b3ad9ec8f8b169c91e6c3f0c9b1c40ce1e14b672b2f7'
             'ad8bf4f25435a9fc17c9db7922779f72678b08b6495e59f2a77df14d9d116f01')
 
 package() {

--- a/cachy-screen-enhancer/README.cachyos.md
+++ b/cachy-screen-enhancer/README.cachyos.md
@@ -1,0 +1,19 @@
+# cachy-screen-enhancer
+
+ICC color profiles that correct the sRGB transfer function to pure gamma 2.2 for CachyOS/Linux.
+
+## Usage
+
+```bash
+bash /usr/share/cachy-screen-enhancer/safe-install.sh
+```
+
+The script auto-detects your GPU, display, and brightness level, generates a custom profile, applies gamma correction to the GPU, and registers the profile with KDE.
+
+## Removal
+
+```bash
+sudo pacman -R cachy-screen-enhancer
+```
+
+The pre-remove hook cleans up gamma correction and profile files automatically.

--- a/cachy-screen-enhancer/README.cachyos.md
+++ b/cachy-screen-enhancer/README.cachyos.md
@@ -5,7 +5,7 @@ ICC color profiles that correct the sRGB transfer function to pure gamma 2.2 for
 ## Usage
 
 ```bash
-bash /usr/share/cachy-screen-enhancer/safe-install.sh
+/usr/share/cachy-screen-enhancer/safe-install.sh
 ```
 
 The script auto-detects your GPU, display, and brightness level, generates a custom profile, applies gamma correction to the GPU, and registers the profile with KDE.

--- a/cachy-screen-enhancer/README.cachyos.md
+++ b/cachy-screen-enhancer/README.cachyos.md
@@ -5,10 +5,19 @@ ICC color profiles that correct the sRGB transfer function to pure gamma 2.2 for
 ## Usage
 
 ```bash
-/usr/share/cachy-screen-enhancer/safe-install.sh
+bash /usr/share/cachy-screen-enhancer/safe-install.sh
 ```
 
 The script auto-detects your GPU, display, and brightness level, generates a custom profile, applies gamma correction to the GPU, and registers the profile with KDE.
+
+## Direct scanout
+
+Fullscreen video and games can scan out directly from the GPU with no extra
+compositing pass when you're on Linux kernel 6.19+ with a driver that exposes
+plane color pipelines (AMD RDNA2+, recent NVIDIA). Otherwise KWin composites
+fullscreen content while the profile is active. Colors stay correct, but
+fullscreen video and games get a little extra latency. The installer warns if
+your system is affected.
 
 ## Removal
 

--- a/cachy-screen-enhancer/cachy-screen-enhancer.install
+++ b/cachy-screen-enhancer/cachy-screen-enhancer.install
@@ -1,0 +1,18 @@
+post_install() {
+  echo ""
+  echo "  cachy-screen-enhancer installed."
+  echo ""
+  echo "  To apply the ICC profile and gamma correction, run:"
+  echo "    bash /usr/share/cachy-screen-enhancer/safe-install.sh"
+  echo ""
+}
+
+post_upgrade() {
+  post_install
+}
+
+pre_remove() {
+  if [ -f /usr/share/cachy-screen-enhancer/tools/remove-profile.sh ]; then
+    bash /usr/share/cachy-screen-enhancer/tools/remove-profile.sh
+  fi
+}

--- a/cachy-screen-enhancer/cachy-screen-enhancer.install
+++ b/cachy-screen-enhancer/cachy-screen-enhancer.install
@@ -3,7 +3,7 @@ post_install() {
   echo "  cachy-screen-enhancer installed."
   echo ""
   echo "  To apply the ICC profile and gamma correction, run:"
-  echo "    bash /usr/share/cachy-screen-enhancer/safe-install.sh"
+  echo "    /usr/share/cachy-screen-enhancer/safe-install.sh"
   echo ""
 }
 
@@ -12,7 +12,20 @@ post_upgrade() {
 }
 
 pre_remove() {
-  if [ -f /usr/share/cachy-screen-enhancer/tools/remove-profile.sh ]; then
-    bash /usr/share/cachy-screen-enhancer/tools/remove-profile.sh
+  CLEANUP="/usr/share/cachy-screen-enhancer/tools/remove-profile.sh"
+  [ -x "$CLEANUP" ] || return 0
+
+  # When pacman runs this hook, we're root. Detect the real desktop
+  # user so $HOME resolves correctly for user-local colord profiles.
+  REAL_USER="$(logname 2>/dev/null || echo "")"
+  if [ -n "$REAL_USER" ]; then
+    REAL_HOME="$(getent passwd "$REAL_USER" 2>/dev/null | cut -d: -f6 || echo "")"
+    if [ -n "$REAL_HOME" ]; then
+      HOME="$REAL_HOME" "$CLEANUP" || true
+      return 0
+    fi
   fi
-}
+
+  # Fallback: run as-is (system-wide cleanup only may miss user-local files)
+  "$CLEANUP" || true
+fi


### PR DESCRIPTION
## Description

Package for cachy-screen-enhancer — ICC color profiles that correct the sRGB transfer function to pure gamma 2.2 for CachyOS/Linux.

## Changes

- Adds `cachy-screen-enhancer/` directory with PKGBUILD, install script, and README
- Dependencies: `python`, `colord`, `argyllcms`
- Pre-remove hook runs `remove-profile.sh` to clean up gamma correction on package removal
- Source pinned to upstream git tag `v1.0.0`

## Testing

- Built successfully with `makepkg -f`
- Package contents verified (42 files across `/usr/share/cachy-screen-enhancer/`)
- safe-install.sh handles both git-clone and system-install (`/usr/share/`) paths
- SHA256 checksums generated and verified

## Checklist

- [x] Package follows CachyOS PKGBUILD conventions (`groups=('cachyos')`, maintainer header, vim modeline)
- [x] All dependencies declared
- [x] No unnecessary patches or deviations from upstream
- [x] Pre-remove hook included for clean removal