### PR TITLE
aura: Update to 1.2.0

### DIFF
--- a/aura/.SRCINFO
+++ b/aura/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = aura
 	pkgdesc = A package manager for Arch Linux and its AUR
-	pkgver = 4.0.8
+	pkgver = 4.2.0
 	pkgrel = 2
 	url = https://github.com/fosskers/aura
 	arch = x86_64
@@ -22,9 +22,7 @@ pkgbase = aura
 	conflicts = aura-git
 	conflicts = aura3-bin
 	options = strip
-	source = aura-4.0.8.tar.gz::https://github.com/fosskers/aura/archive/refs/tags/v4.0.8.tar.gz
-	source = 0001-deps-use-latest-alpm-crate-commit.patch
-	sha256sums = 04d1919ad6a89b13ea618827af6678f298c70447ffa6d3f55635c231123b75ca
-	sha256sums = 745850c1b583a6e5d210d39ce4c9ccc5463c8e4271c41f7255a651bc09240167
+	source = aura-4.2.0.tar.gz::https://github.com/fosskers/aura/archive/refs/tags/v4.2.0.tar.gz
+	sha256sums = be62bd488d09b74c21d4780f31f98278bcd0cd001fdc124197caef1a2d132cf4
 
 pkgname = aura

--- a/aura/PKGBUILD
+++ b/aura/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Colin Woodbury <colin@fosskers.ca>
 
 pkgname=aura
-pkgver=4.0.8
+pkgver=4.2.0
 pkgrel=2
 pkgdesc="A package manager for Arch Linux and its AUR"
 url="https://github.com/fosskers/aura"
@@ -20,16 +20,11 @@ optdepends=(
 )
 conflicts=("aura-bin" "aura-git" "aura3-bin")
 options=("strip")
-source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz"
-        0001-deps-use-latest-alpm-crate-commit.patch)
-sha256sums=('04d1919ad6a89b13ea618827af6678f298c70447ffa6d3f55635c231123b75ca'
-            '745850c1b583a6e5d210d39ce4c9ccc5463c8e4271c41f7255a651bc09240167')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('be62bd488d09b74c21d4780f31f98278bcd0cd001fdc124197caef1a2d132cf4')
 
 prepare() {
   cd "${pkgname}-${pkgver}"
-
-  # patch for pacman 7.1.0
-  patch -Np1 -i ../0001-deps-use-latest-alpm-crate-commit.patch
 
   cd rust
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"


### PR DESCRIPTION
Does it even the patch anymore? I tested it here and it seems to work fine without it at the moment.