### PR TITLE
nvidia-610xx: re-enable VESA-DS, BSB patches

### DIFF
--- a/nvidia/nvidia-utils/PKGBUILD
+++ b/nvidia/nvidia-utils/PKGBUILD
@@ -26,7 +26,9 @@ source=('nvidia-drm-outputclass.conf'
         "https://download.nvidia.com/XFree86/NVIDIA-kernel-module-source/${_pkg_open}.tar.xz"
         '0001-make-Add-support-for-7.2-Kernel.patch'
         'limit-vram-usage'
-        'cuda-no-stable-perf-limit')
+        'cuda-no-stable-perf-limit'
+        '0001-fix-dsc-correct-RC-parameter-tables-to-match-VESA-DS.patch'
+        '0003-fix-dp-add-Bigscreen-Beyond-VR-headset-to-WAR-databa.patch')
 sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
             'f77a5247a3ba63e9fad3a3b2822d0fcfa51e0f79b5a90bd79bf08ea34b64ab07'
             '0e54249a7754b668b436f0f7aa7e95fff68edbb12a93dbee4660e09a8c695f84'
@@ -38,7 +40,9 @@ sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
             '7e118923c7a23edc36114d63273a46e3e04e9af98695a42203e7ac2dfe9fc1dc'
             '85d925cde698d2cff444c13e0ad42875dc0eb9391287efe335d0c3eadedc0b8f'
             'b14f7a65359c05c373ddfc750cd4cf086a48e815489d93ad5cbe1dbf84bf8f5a'
-            '6264d279bbae8eae6554ed78dd6e562da00cf71ffa5601ce5208099a98cd2c4d')
+            '6264d279bbae8eae6554ed78dd6e562da00cf71ffa5601ce5208099a98cd2c4d'
+            'f6561a5cfbf3bb16cc0f4ecc05fde609c5668f84f4e1e4dc6e2879962e7feca8'
+            '17b5a9d3d14bdaac0cb3b04322f3e0b9e8190c8dcdf80bf1db72515f5dac0960')
 
 
 create_links() {
@@ -56,9 +60,9 @@ prepare() {
     cd "${_pkg}"
     bsdtar -xf nvidia-persistenced-init.tar.bz2
 
-#    patch -Np1 -i "${srcdir}/0001-fix-dsc-correct-RC-parameter-tables-to-match-VESA-DS.patch" -d "${srcdir}/${_pkg_open}/"
+    patch -Np1 -i "${srcdir}/0001-fix-dsc-correct-RC-parameter-tables-to-match-VESA-DS.patch" -d "${srcdir}/${_pkg_open}/"
 #    patch -Np1 -i "${srcdir}/0002-fix-dsc-use-bits_per_component-for-flatnessDetThresh.patch" -d "${srcdir}/${_pkg_open}/"
-#    patch -Np1 -i "${srcdir}/0003-fix-dp-add-Bigscreen-Beyond-VR-headset-to-WAR-databa.patch" -d "${srcdir}/${_pkg_open}/"
+    patch -Np1 -i "${srcdir}/0003-fix-dp-add-Bigscreen-Beyond-VR-headset-to-WAR-databa.patch" -d "${srcdir}/${_pkg_open}/"
     patch -Np1 -i "${srcdir}/0001-make-Add-support-for-7.2-Kernel.patch" -d "${srcdir}/${_pkg_open}/"
 
     # Attempt to make builds reproducible


### PR DESCRIPTION
Hey, I wanted to suggest reactivating the patch.

I re-enabled the VESA-DS and BSB patches this way for now. We were informed at [nvidia-all](https://github.com/Frogging-Family/nvidia-all/issues/382) that the two patches still fix the problem.

`0002` could probably be dropped entirely, and the remaining `000*` patch numbers could be adjusted afterwards to keep things tidy.

Let me know how you prefer this to be handled, or if you prefer it handled at all. :P

KISS
