### PR TITLE
Update fakeroot link to Arch Wiki man page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In order to use these PKGBUILD scripts, you will need to have the following tool
 - [make](https://www.gnu.org/software/make/)
 - [gcc](https://gcc.gnu.org/)
 - [binutils](https://www.gnu.org/software/binutils/)
-- [fakeroot](https://wiki.archlinux.org/index.php/Fakeroot)
+- [fakeroot](https://man.archlinux.org/man/fakeroot.1)
 
 ## Usage
 


### PR DESCRIPTION
Prerequisites state you need fakeroot and links to the Arch Wiki, which only shows "There is currently no text in this page. You can search for this page title in other pages, or search the related logs, but you do not have permission to create this page". Instead i changed it to link to the Arch Wiki man page with real information about it.