### PR TITLE
Set paru's RepoOnly option

### DIFF
--- a/paru/PKGBUILD
+++ b/paru/PKGBUILD
@@ -59,4 +59,5 @@ package() {
 
   install -d "$pkgdir/usr/share/"
   cp -r locale "$pkgdir/usr/share/"
+  sed -i 16a\RepoOnly "$pkgdir/etc/paru.conf"
 }


### PR DESCRIPTION
Arch, which is significantly less often recommend to and used by linux beginners, won't even allow AUR helpers in its repos, let alone install one by default. CachyOS should put up at least this tiny barrier between the AUR and people who absolutely shouldn't get their packages from it. Not sure if that's the correct way to do that though.