### PR TITLE
cachyos-settings: migrate X11 keyboard layout via localectl

### DIFF
--- a/cachyos-settings/.SRCINFO
+++ b/cachyos-settings/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-settings
 	pkgdesc = CachyOS - Settings
 	pkgver = 1.3.5
-	pkgrel = 1
+	pkgrel = 2
 	epoch = 1
 	url = https://github.com/CachyOS/CachyOS-Settings
 	install = cachyos-settings.install

--- a/cachyos-settings/PKGBUILD
+++ b/cachyos-settings/PKGBUILD
@@ -3,7 +3,7 @@
 _gitname=CachyOS-Settings
 pkgname=cachyos-settings
 pkgver=1.3.5
-pkgrel=1
+pkgrel=2
 epoch=1
 groups=(cachyos)
 arch=('any')

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -14,7 +14,7 @@ migrate_keyboard_layout() {
 
     layout=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbLayout"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
     model=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbModel"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
-    variant=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbVariant"/ { print $4; exit }' "$x11_conf")
+    variant=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbVariant"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
     options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { print $4; exit }' "$x11_conf")
 
     [[ -n "$layout" ]] || return 0

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -15,7 +15,7 @@ migrate_keyboard_layout() {
     layout=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbLayout"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
     model=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbModel"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
     variant=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbVariant"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
-    options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { print $4; exit }' "$x11_conf")
+    options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
 
     [[ -n "$layout" ]] || return 0
     [[ -n "$model" ]] || model="pc105"

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -20,7 +20,7 @@ migrate_keyboard_layout() {
     [[ -n "$layout" ]] || return 0
     [[ -n "$model" ]] || model="pc105"
 
-        localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
+    localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
     elif [[ -n "$variant" ]]; then
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
     else

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -22,7 +22,6 @@ migrate_keyboard_layout() {
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
     else
-    fi
 
     install -Dm644 /dev/null "$marker" 2>/dev/null || return 0
 }

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -42,5 +42,7 @@ post_upgrade() {
             systemctl restart "$service"
         fi
     done
-    migrate_keyboard_layout
+    if (( $(vercmp "$2" 1:1.3.5-2) < 0 )) && (( $(vercmp "$2" 1:1.3.5-1) >= 0 )); then
+        migrate_keyboard_layout
+    fi
 }

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -20,7 +20,6 @@ migrate_keyboard_layout() {
     [[ -n "$layout" ]] || return 0
 
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
-        localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
 
     install -Dm644 /dev/null "$marker" 2>/dev/null || return 0
 }

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -18,7 +18,6 @@ migrate_keyboard_layout() {
     options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
 
     [[ -n "$layout" ]] || return 0
-    [[ -n "$model" ]] || model="pc105"
 
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -23,7 +23,6 @@ migrate_keyboard_layout() {
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
     else
-        localectl set-x11-keymap "$layout" "$model" || return 0
     fi
 
     install -Dm644 /dev/null "$marker" 2>/dev/null || return 0

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -20,7 +20,6 @@ migrate_keyboard_layout() {
     [[ -n "$layout" ]] || return 0
     [[ -n "$model" ]] || model="pc105"
 
-    if [[ -n "$options" ]]; then
         localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
     elif [[ -n "$variant" ]]; then
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -2,10 +2,8 @@ SERVICES=("ananicy-cpp" "systemd-resolved" )
 
 migrate_keyboard_layout() {
     local x11_conf="/etc/X11/xorg.conf.d/00-keyboard.conf"
-    local marker="/var/lib/cachyos/keyboard-layout-migrated"
     local status layout model variant options
 
-    [[ -e "$marker" ]] && return 0
     [[ -r "$x11_conf" ]] || return 0
     status=$(localectl status 2>/dev/null) || return 0
     if ! grep -q '^[[:space:]]*X11 Layout:[[:space:]]*(unset)' <<< "$status"; then
@@ -20,8 +18,6 @@ migrate_keyboard_layout() {
     [[ -n "$layout" ]] || return 0
 
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
-
-    install -Dm644 /dev/null "$marker" 2>/dev/null || return 0
 }
 
 post_install() {

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -32,7 +32,6 @@ post_install() {
     if command -v iw >/dev/null 2>&1; then
         systemctl enable cachyos-iw-set-regdomain.path
     fi
-    migrate_keyboard_layout
 }
 
 post_upgrade() {

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -21,7 +21,6 @@ migrate_keyboard_layout() {
     [[ -n "$model" ]] || model="pc105"
 
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
-    elif [[ -n "$variant" ]]; then
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
     else
         localectl set-x11-keymap "$layout" "$model" || return 0

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -13,7 +13,7 @@ migrate_keyboard_layout() {
     fi
 
     layout=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbLayout"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
-    model=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbModel"/ { print $4; exit }' "$x11_conf")
+    model=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbModel"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
     variant=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbVariant"/ { print $4; exit }' "$x11_conf")
     options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { print $4; exit }' "$x11_conf")
 

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -12,7 +12,7 @@ migrate_keyboard_layout() {
         return 0
     fi
 
-    layout=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbLayout"/ { print $4; exit }' "$x11_conf")
+    layout=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbLayout"/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $4); print $4; exit }' "$x11_conf")
     model=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbModel"/ { print $4; exit }' "$x11_conf")
     variant=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbVariant"/ { print $4; exit }' "$x11_conf")
     options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { print $4; exit }' "$x11_conf")

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -21,7 +21,6 @@ migrate_keyboard_layout() {
 
     localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
         localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
-    else
 
     install -Dm644 /dev/null "$marker" 2>/dev/null || return 0
 }

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -28,8 +28,7 @@ migrate_keyboard_layout() {
         localectl set-x11-keymap "$layout" "$model" || return 0
     fi
 
-    install -d /var/lib/cachyos
-    : > "$marker"
+    install -Dm644 /dev/null "$marker" 2>/dev/null || return 0
 }
 
 post_install() {

--- a/cachyos-settings/cachyos-settings.install
+++ b/cachyos-settings/cachyos-settings.install
@@ -1,5 +1,37 @@
 SERVICES=("ananicy-cpp" "systemd-resolved" )
 
+migrate_keyboard_layout() {
+    local x11_conf="/etc/X11/xorg.conf.d/00-keyboard.conf"
+    local marker="/var/lib/cachyos/keyboard-layout-migrated"
+    local status layout model variant options
+
+    [[ -e "$marker" ]] && return 0
+    [[ -r "$x11_conf" ]] || return 0
+    status=$(localectl status 2>/dev/null) || return 0
+    if ! grep -q '^[[:space:]]*X11 Layout:[[:space:]]*(unset)' <<< "$status"; then
+        return 0
+    fi
+
+    layout=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbLayout"/ { print $4; exit }' "$x11_conf")
+    model=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbModel"/ { print $4; exit }' "$x11_conf")
+    variant=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbVariant"/ { print $4; exit }' "$x11_conf")
+    options=$(awk -F'"' '/^[[:space:]]*Option[[:space:]]+"XkbOptions"/ { print $4; exit }' "$x11_conf")
+
+    [[ -n "$layout" ]] || return 0
+    [[ -n "$model" ]] || model="pc105"
+
+    if [[ -n "$options" ]]; then
+        localectl set-x11-keymap "$layout" "$model" "$variant" "$options" || return 0
+    elif [[ -n "$variant" ]]; then
+        localectl set-x11-keymap "$layout" "$model" "$variant" || return 0
+    else
+        localectl set-x11-keymap "$layout" "$model" || return 0
+    fi
+
+    install -d /var/lib/cachyos
+    : > "$marker"
+}
+
 post_install() {
     echo "Enabling services..."
     for service in "${SERVICES[@]}"; do
@@ -8,6 +40,7 @@ post_install() {
     if command -v iw >/dev/null 2>&1; then
         systemctl enable cachyos-iw-set-regdomain.path
     fi
+    migrate_keyboard_layout
 }
 
 post_upgrade() {
@@ -18,4 +51,5 @@ post_upgrade() {
             systemctl restart "$service"
         fi
     done
+    migrate_keyboard_layout
 }


### PR DESCRIPTION
Move existing /etc/X11/xorg.conf.d/00-keyboard.conf keymap settings into systemd-localed when the localectl X11 layout is still unset. Run the migration on install and upgrade, and mark it as completed afterward.