### PR TITLE
[cachyos-rate-mirrors] RandomizedDelaySec + more elegant synthax

### DIFF
--- a/cachyos-rate-mirrors/.SRCINFO
+++ b/cachyos-rate-mirrors/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-rate-mirrors
 	pkgdesc = CachyOS - Rate mirrors service
 	pkgver = 23
-	pkgrel = 3
+	pkgrel = 4
 	url = https://github.com/CachyOS
 	install = cachyos-rate-mirrors.install
 	arch = any
@@ -14,7 +14,7 @@ pkgbase = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors.hook
 	sha256sums = c8eefdede7b115ee7f4a59d6f631e491a0698c3a930c2fc2d2e9e710b4feaad2
 	sha256sums = a70233ee2e082e2e5a11503f048d06c80f566be4b7d664e4afee7051befc5420
-	sha256sums = e9f368a137bc20c54beea4ca349400e9a5903860cb830b5658a219546e5085f0
+	sha256sums = e44b277a3a1d93e6101b5baa3d97e915d9bc51e50f8747fec8d762d32b7d3590
 	sha256sums = 631cd984e0b77f58be2cee48748a49eab2c56d51622e397defbf464574aec0f4
 
 pkgname = cachyos-rate-mirrors

--- a/cachyos-rate-mirrors/PKGBUILD
+++ b/cachyos-rate-mirrors/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cachyos-rate-mirrors
 pkgver=23
-pkgrel=3
+pkgrel=4
 groups=(cachyos)
 arch=('any')
 install=$pkgname.install
@@ -19,7 +19,7 @@ source=(
 )
 sha256sums=('c8eefdede7b115ee7f4a59d6f631e491a0698c3a930c2fc2d2e9e710b4feaad2'
             'a70233ee2e082e2e5a11503f048d06c80f566be4b7d664e4afee7051befc5420'
-            'e9f368a137bc20c54beea4ca349400e9a5903860cb830b5658a219546e5085f0'
+            'e44b277a3a1d93e6101b5baa3d97e915d9bc51e50f8747fec8d762d32b7d3590'
             '631cd984e0b77f58be2cee48748a49eab2c56d51622e397defbf464574aec0f4')
 
 package() {

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors.timer
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors.timer
@@ -4,8 +4,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Timer]
-OnCalendar=*-*-01,11,21 00:00:00
+OnCalendar=*-*-01..21/10 00:00:00
 RandomizedOffsetSec=10d
+RandomizedDelaySec=1h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
As it is now, if the system is off when the timer would have fired, the service starts immediately after boot.
Re-added RandomizedDelaySec (since this option is carried to the next boot) to further delay it (1h maximum) and avoid any problems.
Also, cleaner synthax for OnCalendar (funcionally the same).