### PR TITLE
Cachy-Update: Update to v3.20.3

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachy-update
 	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
-	pkgver = 3.20.2
+	pkgver = 3.20.3
 	pkgrel = 1
 	url = https://github.com/CachyOS/cachy-update
 	arch = any
@@ -36,7 +36,7 @@ pkgbase = cachy-update
 	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=62389486ad4c11aed8c2d349a5916928d45f8503
-	sha256sums = 476925eabe76af7360fc3a15213d66bc7d6ced5402d6a3f4a0cca5a7b07d8d2a
+	source = git+https://github.com/CachyOS/cachy-update#commit=7cd482f2dc58c325d511a462316d9bd6900a5e17
+	sha256sums = 8fbecab64e7f77c08812206d8e4b146bcb104e9bcb0f054b385159dee6a84f16
 
 pkgname = cachy-update

--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -36,7 +36,7 @@ pkgbase = cachy-update
 	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=7cd482f2dc58c325d511a462316d9bd6900a5e17
-	sha256sums = 8fbecab64e7f77c08812206d8e4b146bcb104e9bcb0f054b385159dee6a84f16
+	source = git+https://github.com/CachyOS/cachy-update#commit=b50fdd509e62fc04cbf8581bb7f79802c08e057f
+	sha256sums = bc342607f83ca402f01f7e1893097fe340678a313d106bcba635f6b0194ac776
 
 pkgname = cachy-update

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -23,8 +23,8 @@ optdepends=('paru: AUR Packages support'
             'sudo: Privilege elevation'
             'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=7cd482f2dc58c325d511a462316d9bd6900a5e17")
-sha256sums=('8fbecab64e7f77c08812206d8e4b146bcb104e9bcb0f054b385159dee6a84f16')
+source=("git+https://github.com/CachyOS/cachy-update#commit=b50fdd509e62fc04cbf8581bb7f79802c08e057f")
+sha256sums=('bc342607f83ca402f01f7e1893097fe340678a313d106bcba635f6b0194ac776')
 
 prepare() {
     cd "${pkgname}"

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Robin Candau <antiz@archlinux.org>
 
 pkgname=cachy-update
-pkgver=3.20.2
+pkgver=3.20.3
 pkgrel=1
 pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
@@ -23,8 +23,8 @@ optdepends=('paru: AUR Packages support'
             'sudo: Privilege elevation'
             'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=62389486ad4c11aed8c2d349a5916928d45f8503")
-sha256sums=('476925eabe76af7360fc3a15213d66bc7d6ced5402d6a3f4a0cca5a7b07d8d2a')
+source=("git+https://github.com/CachyOS/cachy-update#commit=7cd482f2dc58c325d511a462316d9bd6900a5e17")
+sha256sums=('8fbecab64e7f77c08812206d8e4b146bcb104e9bcb0f054b385159dee6a84f16')
 
 prepare() {
     cd "${pkgname}"


### PR DESCRIPTION
- https://github.com/Antiz96/arch-update/releases/tag/v3.20.3
- https://github.com/CachyOS/cachy-update/pull/32