### PR TITLE
cachyos-mango-noctalia: Add at v1.0.0

### DIFF
--- a/cachyos-mango-noctalia/.SRCINFO
+++ b/cachyos-mango-noctalia/.SRCINFO
@@ -1,0 +1,30 @@
+pkgbase = cachyos-mango-noctalia
+	pkgdesc = CachyOS Mango (+Noctalia) settings
+	pkgver = 1.0.0
+	pkgrel = 1
+	url = https://github.com/cachyos/cachyos-mango-noctalia
+	install = cachyos-mango-noctalia.install
+	arch = any
+	license = GPL-3.0-only
+	makedepends = coreutils
+	makedepends = git
+	depends = adw-gtk-theme
+	depends = cachyos-alacritty-config
+	depends = capitaine-cursors
+	depends = dolphin
+	depends = gnome-keyring
+	depends = mangowm
+	depends = noctalia
+	depends = noto-fonts
+	depends = noto-fonts-emoji
+	depends = qt6ct
+	depends = wl-clipboard
+	depends = wlr-randr
+	depends = xdg-desktop-portal-gtk
+	depends = xdg-desktop-portal-wlr
+	provides = cachyos-desktop-settings
+	conflicts = cachyos-desktop-settings
+	source = git+https://github.com/cachyos/cachyos-mango-noctalia#tag=1.0.0
+	sha512sums = 8a595cb679a893d8c86ef0c328af01ba995cea24b26e82bcc8820b46918ebbfd1f7008f1647748df7aedfcf9d434037df526db80f0daa075b4e896d661076618
+
+pkgname = cachyos-mango-noctalia

--- a/cachyos-mango-noctalia/.nvchecker.toml
+++ b/cachyos-mango-noctalia/.nvchecker.toml
@@ -1,0 +1,3 @@
+[git]
+source = 'git'
+git = 'https://github.com/cachyos/cachyos-mango-noctalia'

--- a/cachyos-mango-noctalia/PKGBUILD
+++ b/cachyos-mango-noctalia/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: witchlliee <witchlliee@tuta.io>
+
+pkgname=cachyos-mango-noctalia
+pkgdesc='CachyOS Mango (+Noctalia) settings'
+pkgver=1.0.0
+pkgrel=1
+arch=('any')
+url="https://github.com/cachyos/$pkgname"
+license=(GPL-3.0-only)
+makedepends=('coreutils' 'git')
+source=(
+  git+https://github.com/cachyos/cachyos-mango-noctalia#tag=1.0.0
+)
+install=cachyos-mango-noctalia.install
+sha512sums=('8a595cb679a893d8c86ef0c328af01ba995cea24b26e82bcc8820b46918ebbfd1f7008f1647748df7aedfcf9d434037df526db80f0daa075b4e896d661076618')
+depends=(
+  adw-gtk-theme
+  cachyos-alacritty-config
+  capitaine-cursors
+  dolphin
+  gnome-keyring
+  mangowm
+  noctalia
+  noto-fonts
+  noto-fonts-emoji
+  qt6ct
+  wl-clipboard
+  wlr-randr
+  xdg-desktop-portal-gtk
+  xdg-desktop-portal-wlr
+)
+provides=('cachyos-desktop-settings')
+conflicts=('cachyos-desktop-settings')
+
+package() {
+  install -d "${pkgdir}/etc"
+  cp -rf "${srcdir}/${pkgname}/etc" "${pkgdir}"
+}

--- a/cachyos-mango-noctalia/cachyos-mango-noctalia.install
+++ b/cachyos-mango-noctalia/cachyos-mango-noctalia.install
@@ -1,0 +1,11 @@
+post_install() {
+  mkdir $HOME/.config/menus/
+  curl -L https://raw.githubusercontent.com/KDE/plasma-workspace/master/menu/desktop/plasma-applications.menu -o $HOME/.config/menus/applications.menu
+  kbuildsycoca6
+}
+
+post_upgrade() {
+  mkdir $HOME/.config/menus/
+  curl -L https://raw.githubusercontent.com/KDE/plasma-workspace/master/menu/desktop/plasma-applications.menu -o $HOME/.config/menus/applications.menu
+  kbuildsycoca6
+}


### PR DESCRIPTION
~~Mainly waiting for a rename on https://github.com/CachyOS/cachyos-mangowc-dms.~~ I did included qt6ct-kde because it's needed for theming dolphin, else the theme on it doesn't work quite right. 