### PR TITLE
Correct format for CachyOS mirrorlist

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -3,115 +3,154 @@
 ####        CachyOS Repository Mirrorlist         ####
 ####                                              ####
 ######################################################
-## CDN77 (World Wide Datacenters)
-## tier=1 code=GLOBAL
+## Worldwide
+# CDN77 (World Wide Datacenters) | tier=1 code=GLOBAL
 Server = https://cdn77.cachyos.org/repo/$arch/$repo
-## Rerouted to mirror
-## tier=1 code=GLOBAL
+
+## Worldwide
+# Rerouted to mirror | tier=1 code=GLOBAL
 # Server = https://cdn.cachyos.org/repo/$arch/$repo
-## Germany, disabled due Netcup issues:
-## : OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0"
-## tier=1 code=DE
+
+## Germany
+# Germany Mirror, disabled due to Netcup issues: OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0 | tier=1 code=DE
 # Server = https://mirror.cachyos.org/repo/$arch/$repo
-## USA Mirror much thanks to corpdecker!
-## tier=2 code=US
+
+## United States
+# USA Mirror much thanks to corpdecker! | tier=2 code=US
 Server = https://us.cachyos.org/repo/$arch/$repo
-## India Mirror much thanks to https://github.com/albonycal
-## Disabled due issues at installation
-## tier=1 code=IN
-## Server = https://mirror.albony.xyz/cachylinux/repo/$arch/$repo
-## France Mirror much thanks to Antoine Viallon (aviallon)
-## tier=1 code=FR
+
+## India
+# India Mirror much thanks to https://github.com/albonycal (Disabled due to installation issues) | tier=1 code=IN
+# Server = https://mirror.albony.xyz/cachylinux/repo/$arch/$repo
+
+## France
+# France Mirror much thanks to Antoine Viallon (aviallon) | tier=1 code=FR
 Server = https://mirror.lesviallon.fr/cachy/repo/$arch/$repo
-## Russia Mirror # Removed till sync issue is resolved
-## tier=1 code=RU
+
+## Russia
+# Russia Mirror (Removed until sync issue is resolved) | tier=1 code=RU
 # Server = https://mirror.truenetwork.ru/cachy/repo/$arch/$repo
-## Norway Mirror much thanks to QuadFeed
-## tier=1 code=NO
+
+## Norway
+# Norway Mirror much thanks to QuadFeed | tier=1 code=NO
 # Server = https://mirror.fast0ne.com/repo/$arch/$repo
-## Norway,Netherlands,Canada Mirror much thanks to innoix
-## tier=1 code=NO
+
+## Norway
+# Norway Mirror much thanks to innoix | tier=1 code=NO
 Server = https://no.mirror.cx/cachyos/repo/$arch/$repo
-## tier=1 code=NL
+
+## Netherlands
+# Netherlands Mirror much thanks to innoix | tier=1 code=NL
 Server = https://nl.mirror.cx/cachyos/repo/$arch/$repo
-## tier=1 code=CA
+
+## Canada
+# Canada Mirror much thanks to innoix | tier=1 code=CA
 Server = https://ca.mirror.cx/cachyos/repo/$arch/$repo
-## Sweden Mirror much thanks to Zyner!
-## tier=1 code=SE
+
+## Sweden
+# Sweden Mirror much thanks to Zyner! | tier=1 code=SE
 Server = https://mirror.zyner.org/mirror/cachyos/repo/$arch/$repo
-## South Korea much thanks to Mihate Hiura!
-## tier=2 code=KR
+
+## South Korea
+# South Korea Mirror much thanks to Mihate Hiura! | tier=2 code=KR
 # Server = https://mirror.funami.tech/cachy/repo/$arch/$repo
-## Austria Mirror much thanks to Soulharsh!
-## tier=1 code=AT
+
+## Austria
+# Austria Mirror much thanks to Soulharsh! | tier=1 code=AT
 Server = https://at.cachyos.org/repo/$arch/$repo
-## Germany Mirror much thanks to Soulharsh!
-## tier=1 code=DE
+
+## Germany
+# Germany Mirror much thanks to Soulharsh! | tier=1 code=DE
 # Server = https://de-nue.soulharsh007.dev/cachyos/repo/$arch/$repo
-## Germany Mirror much thanks to MergedEyes!
-## tier=1 code=DE
+
+## Germany
+# Germany Mirror much thanks to MergedEyes! | tier=1 code=DE
 Server = https://mirror.mergedcloud.de/cachyos/repo/$arch/$repo
-## USA Mirror much thanks to Soulharsh!
-## tier=1 code=US
+
+## United States
+# USA Mirror much thanks to Soulharsh! | tier=1 code=US
 Server = https://us-mnz.soulharsh007.dev/cachyos/repo/$arch/$repo
-## USA Mirror & CDN mirror provided by Lansing 2600 in Lansing, MI, USA
-## tier=1 code=US
+
+## United States
+# USA Mirror provided by Lansing 2600 in Lansing, MI, USA | tier=1 code=US
 Server = https://mirrors.lansing2600.org/cachyos/repo/$arch/$repo
-## tier=1 code=GLOBAL
+
+## Worldwide
+# CDN mirror provided by Lansing 2600 in Lansing, MI, USA | tier=1 code=GLOBAL
 Server = https://cdn.lansing2600.org/cachyos/repo/$arch/$repo
-## China Mirror 10GBs much thanks to eScience Center, Nanjing University!
-## tier=2 code=CN
+
+## China
+# China Mirror 10GBs much thanks to eScience Center, Nanjing University! | tier=2 code=CN
 Server = https://mirror.nju.edu.cn/cachyos/repo/$arch/$repo
-## China Mirror much thanks to University of Science and Technology of China!
-## tier=2 code=CN
+
+## China
+# China Mirror much thanks to University of Science and Technology of China! | tier=2 code=CN
 Server = https://mirrors.ustc.edu.cn/cachyos/repo/$arch/$repo
-## Hong Kong Mirror much thanks to Saren!
-## tier=1 code=HK
+
+## Hong Kong
+# Hong Kong Mirror much thanks to Saren! | tier=1 code=HK
 # Server = https://cachy-mirror.wtako.net/repo/$arch/$repo
-## Italy Mirror much thanks to NextWorks!
-## tier=1 code=IT
+
+## Italy
+# Italy Mirror much thanks to NextWorks! | tier=1 code=IT
 Server = https://cachyos.next-works.it/repo/$arch/$repo
-## Italy Mirror much thanks to ironashram!
-## tier=2 code=IT
+
+## Italy
+# Italy Mirror much thanks to ironashram! | tier=2 code=IT
 Server = https://cachyos-mirror.m1k.cloud/repo/$arch/$repo
-## Bangladesh 10 GBs much thanks to Limda!
-## Disabled due slow sync
-## tier=2 code=BD
+
+## Bangladesh
+# Bangladesh 10 GBs much thanks to Limda! (Disabled due to slow sync) | tier=2 code=BD
 # Server = https://mirror.limda.net/cachy/repo/$arch/$repo
-## Finland Mirror much thanks to doridian!
-## tier=2 code=FI
+
+## Finland
+# Finland Mirror much thanks to doridian! | tier=2 code=FI
 Server = https://cachyos.doridian.net/repo/$arch/$repo
-## Switzerland Mirror much thanks to Fabian!
-## tier=2 code=CH
+
+## Switzerland
+# Switzerland Mirror much thanks to Fabian! | tier=2 code=CH
 Server = https://mirror.hb9hil.org/cachyos/repo/$arch/$repo
-## Russia Mirror from Yandex
-## tier=2 code=RU
+
+## Russia
+# Russia Mirror from Yandex | tier=2 code=RU
 # Server = https://mirror.yandex.ru/cachyos/repo/$arch/$repo
-## Russia Mirror much thanks to quinowell and haku.host
-## tier=2 code=RU
+
+## Russia
+# Russia Mirror much thanks to quinowell and haku.host | tier=2 code=RU
 Server = https://archlinux.gay/cachy/repo/$arch/$repo
-## Russia Mirror much thanks to jura12
-## tier=2 code=RU
+
+## Russia
+# Russia Mirror much thanks to jura12 | tier=2 code=RU
 Server = https://mirror.jura12.ru/repo/$arch/$repo
-## Russia Mirror much thanks to cachy-arch.ru
-## tier=2 code=RU
+
+## Russia
+# Russia Mirror much thanks to cachy-arch.ru | tier=2 code=RU
 Server = https://mirror.cachy-arch.ru/cachyos/repo/$arch/$repo
-## Russia Mirror much thanks to wan666 from metrosg.ru
-## tier=2 code=RU
+
+## Russia
+# Russia Mirror much thanks to wan666 from metrosg.ru | tier=2 code=RU
 Server = https://wan.metrosg.ru/cachyos/repo/$arch/$repo
-## Republic of Korea Mirror much thanks to Keiminem from Keiverse
-## tier=2 code=KR
+
+## South Korea
+# Republic of Korea Mirror much thanks to Keiminem from Keiverse | tier=2 code=KR
 Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
-## tier=2 code=KR
+
+## South Korea
+# Republic of Korea Mirror much thanks to Keiminem from Keiverse | tier=2 code=KR
 Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo
-## Republic of Korea Mirror much thanks to ROKFOSS
-## tier=2 code=GLOBAL
+
+## South Korea
+# Republic of Korea Mirror much thanks to ROKFOSS | tier=2 code=GLOBAL
 Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
-## tier=2 code=GLOBAL
+
+## South Korea
+# Republic of Korea Mirror much thanks to ROKFOSS | tier=2 code=GLOBAL
 Server = https://mirror5.krfoss.org/cachyos/repo/$arch/$repo
-## USA mirror in Las Vegas, NV provided by hjk321
-## tier=1 code=US
+
+## United States
+# USA mirror in Las Vegas, NV provided by hjk321 | tier=1 code=US
 Server = https://mirror.hjk.gg/cachyos/repo/$arch/$repo
-## Vietnam Mirror provided by NguyenHoang.Cloud
-## tier=2 code=VN
+
+## Vietnam
+# Vietnam Mirror provided by NguyenHoang.Cloud | tier=2 code=VN
 Server = https://mirrors.nguyenhoang.cloud/cachyos/repo/$arch/$repo


### PR DESCRIPTION
### Description
This PR corrects the mirror country comment headers in `cachyos-mirrorlist`. 

Currently, `rate-mirrors` (which is called by `cachyos-rate-mirrors`) parses countries by looking for standard double-hash country headers directly preceding the mirror entries (e.g., `## United States` or `## Germany`). 

Because the current list uses custom credit strings (e.g., `## USA Mirror much thanks to corpdecker!`) and `## tier=2 code=US` on the `##` lines, `rate-mirrors` is unable to associate any CachyOS mirrors with their respective countries. This forces the tool to query all 28 mirrors as "unlabeled" regardless of user country configurations or neighbor limits.

### Changes Made
- Rewrote the `##` lines to contain only the official country name (which `rate-mirrors` maps to ISO codes).
- Moved the tier levels, codes, and credit notes to single-hash comments (`#`) directly below the country name to preserve existing metadata and contributor credits without confusing parser regex engines.

Let me know if I made any mistakes; I'm not sure how I'd add tests for this.