### PR TITLE
asusctl: update repository location

### DIFF
--- a/asusctl/.SRCINFO
+++ b/asusctl/.SRCINFO
@@ -16,7 +16,7 @@ pkgbase = asusctl
 	makedepends = rust
 	makedepends = seatd
 	makedepends = systemd
-	source = git+https://gitlab.com/asus-linux/asusctl.git#tag=6.3.8
+	source = git+https://github.com/OpenGamingCollective/asusctl.git#tag=6.3.8
 	b2sums = 01269bc9fe63c1ce37568f9085c25dbcaaaa5cd9f51339d4c6904600d179ec826dace289d6e4e3501988fce5800da98e9cfa18b21c40da152d91c4f7fe821ffe
 
 pkgname = asusctl

--- a/asusctl/.nvchecker.toml
+++ b/asusctl/.nvchecker.toml
@@ -1,4 +1,4 @@
 [asusctl]
 source = "git"
-git = "https://gitlab.com/asus-linux/asusctl.git"
+git = "https://github.com/OpenGamingCollective/asusctl.git"
 

--- a/asusctl/PKGBUILD
+++ b/asusctl/PKGBUILD
@@ -25,7 +25,7 @@ makedepends=(
   seatd
   systemd
 )
-source=("git+https://gitlab.com/asus-linux/asusctl.git#tag=$pkgver")
+source=("git+https://github.com/OpenGamingCollective/asusctl.git#tag=$pkgver")
 b2sums=('01269bc9fe63c1ce37568f9085c25dbcaaaa5cd9f51339d4c6904600d179ec826dace289d6e4e3501988fce5800da98e9cfa18b21c40da152d91c4f7fe821ffe')
 
 prepare() {

--- a/asusctl/asusctl.install
+++ b/asusctl/asusctl.install
@@ -3,7 +3,7 @@ post_install() {
   printf ":: startup. Please reboot the system or run\n"
   printf ":: # systemctl start asusd.service\n"
   printf ":: to make it work.\n"
-  printf ":: See https://gitlab.com/asus-linux/asusctl#kernel-support.\n"
+  printf ":: See https://github.com/OpenGamingCollective/asusctl#kernel-support.\n"
   printf ":: for latest required kernel patches/versions\n"
 }
 
@@ -14,6 +14,6 @@ post_upgrade() {
       systemctl daemon-reload
       systemctl restart asusd.service
   fi
-  printf ":: See https://gitlab.com/asus-linux/asusctl#kernel-support.\n"
+  printf ":: See https://github.com/OpenGamingCollective/asusctl#kernel-support.\n"
   printf ":: for latest required kernel patches/versions\n"
 }


### PR DESCRIPTION
The asusctl project has been moved to https://github.com/OpenGamingCollective/asusctl. No new versions were published in the new location as of now, so this just updates the URL.