### PR TITLE
cachyos-hypr-noctalia: fixed typo

### DIFF
--- a/cachyos-hypr-noctalia/.SRCINFO
+++ b/cachyos-hypr-noctalia/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-hypr-noctalia
 	pkgdesc = CachyOS Hyprland Noctalia settings
-	pkgver = 1.2.1
+	pkgver = 1.2.2
 	pkgrel = 1
 	url = https://github.com/cachyos/cachyos-hypr-noctalia
 	install = cachyos-hypr-noctalia.install
@@ -35,7 +35,7 @@ pkgbase = cachyos-hypr-noctalia
 	depends = xorg-xhost
 	provides = cachyos-desktop-settings
 	conflicts = cachyos-desktop-settings
-	source = cachyos-hypr-noctalia-1.2.1.tar.gz::https://github.com/cachyos/cachyos-hypr-noctalia/archive/1.2.1.tar.gz
-	sha256sums = 47466b48659263b2ffabc14fcea1ab7a86a1f9b445b669b86f0d82f95074ecda
+	source = cachyos-hypr-noctalia-1.2.2.tar.gz::https://github.com/cachyos/cachyos-hypr-noctalia/archive/1.2.2.tar.gz
+	sha256sums = 8e6b6269713e3bb8fcac5f062dc613dbaf08e101388bead7ffaef4fa6aa7d0a5
 
 pkgname = cachyos-hypr-noctalia

--- a/cachyos-hypr-noctalia/PKGBUILD
+++ b/cachyos-hypr-noctalia/PKGBUILD
@@ -5,14 +5,14 @@
 
 pkgname=cachyos-hypr-noctalia
 pkgdesc='CachyOS Hyprland Noctalia settings'
-pkgver=1.2.1
+pkgver=1.2.2
 pkgrel=1
 arch=('any')
 url="https://github.com/cachyos/$pkgname"
 license=(GPL-1.0-only)
 makedepends=('coreutils')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
-sha256sums=('8e6b6269713e3bb8fcac5f062dc613dbaf08e101388bead7ffaef4fa6aa7d0a5')
+sha256sums=('e019262f43c12612aaf63e5a1ed9973d8c8d250d7bd6542d7801713646476013')
 depends=(
 	adw-gtk-theme
 	awesome-terminal-fonts


### PR DESCRIPTION
I made a typo for v1.2.1. Reinstalled cachy in a VM to verify this is the only fix needed.