### PR TITLE
nvidia-utils: Add patch to replace obsolete use of screen_info symbol

### DIFF
--- a/nvidia/nvidia-utils/.SRCINFO
+++ b/nvidia/nvidia-utils/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nvidia-utils
 	pkgver = 610.43.03
-	pkgrel = 3
+	pkgrel = 2
 	url = http://www.nvidia.com/
 	arch = x86_64
 	license = custom
@@ -16,6 +16,7 @@ pkgbase = nvidia-utils
 	source = https://us.download.nvidia.com/XFree86/Linux-x86_64/610.43.03/NVIDIA-Linux-x86_64-610.43.03.run
 	source = https://download.nvidia.com/XFree86/NVIDIA-kernel-module-source/NVIDIA-kernel-module-source-610.43.03.tar.xz
 	source = 0001-make-Add-support-for-7.2-Kernel.patch
+	source = 0002-Replace-obsolete-use-of-screen_info-symbol.patch
 	source = limit-vram-usage
 	source = cuda-no-stable-perf-limit
 	sha256sums = be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d
@@ -28,6 +29,7 @@ pkgbase = nvidia-utils
 	sha256sums = 45e2d4c134a23c35e50f253a4aa63e7e5e8d17e3d185d4a07c8a58e9612ed392
 	sha256sums = 7e118923c7a23edc36114d63273a46e3e04e9af98695a42203e7ac2dfe9fc1dc
 	sha256sums = 85d925cde698d2cff444c13e0ad42875dc0eb9391287efe335d0c3eadedc0b8f
+	sha256sums = d83ffe80aee6c6ac62e1022b15c76659d16dae9ac5557f7e0adb736cca1a1b23
 	sha256sums = b14f7a65359c05c373ddfc750cd4cf086a48e815489d93ad5cbe1dbf84bf8f5a
 	sha256sums = 6264d279bbae8eae6554ed78dd6e562da00cf71ffa5601ce5208099a98cd2c4d
 

--- a/nvidia/nvidia-utils/0002-Replace-obsolete-use-of-screen_info-symbol.patch
+++ b/nvidia/nvidia-utils/0002-Replace-obsolete-use-of-screen_info-symbol.patch
@@ -1,0 +1,88 @@
+From e8cba7bc747a70f2709c360c1a76d64e58c52789 Mon Sep 17 00:00:00 2001
+From: Vasiliy Stelmachenok <ventureo@cachyos.org>
+Date: Sun, 15 Feb 2026 11:31:28 +0000
+Subject: [PATCH] Replace obsolete use of screen_info symbol
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Based on patch from the Joan Bruguera
+
+Co-authored-by: Joan Bruguera Micó <joanbrugueram@gmail.com>
+Signed-off-by: Vasiliy Stelmachenok <ventureo@cachyos.org>
+---
+ common/inc/nv-linux.h |  3 +++
+ nvidia/nv.c           | 25 ++++++++++++++++---------
+ 2 files changed, 19 insertions(+), 9 deletions(-)
+
+diff --git a/common/inc/nv-linux.h b/common/inc/nv-linux.h
+index 1a70b9f..7a113b8 100644
+--- a/common/inc/nv-linux.h
++++ b/common/inc/nv-linux.h
+@@ -169,6 +169,9 @@
+ #include <linux/efi.h>              /* efi_enabled                      */
+ #include <linux/fb.h>               /* fb_info struct                   */
+ #include <linux/screen_info.h>      /* screen_info                      */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 20, 0)
++#include <linux/sysfb.h>            /* sysfb_primary_display            */
++#endif
+ 
+ #if !defined(CONFIG_PCI)
+ #warning "Attempting to build driver for a platform with no PCI support!"
+diff --git a/nvidia/nv.c b/nvidia/nv.c
+index b771a00..348a098 100644
+--- a/nvidia/nv.c
++++ b/nvidia/nv.c
+@@ -6375,8 +6375,15 @@ void NV_API_CALL nv_get_screen_info(
+      * After commit b8466fe82b79 ("efi: move screen_info into efi init code")
+      * in v6.7, 'screen_info' is exported as GPL licensed symbol for ARM64.
+      */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 20, 0)
++    // Rel. commit "sysfb: Replace screen_info with sysfb_primary_display" (Thomas Zimmermann, 26 Nov 2025)
++    const struct screen_info *si = &sysfb_primary_display.screen;
++#elif NV_CHECK_EXPORT_SYMBOL(screen_info)
++    const struct screen_info *si = &screen_info;
++#endif
+ 
+-#if NV_CHECK_EXPORT_SYMBOL(screen_info)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 20, 0)) || \
++    NV_CHECK_EXPORT_SYMBOL(screen_info)
+     /*
+      * If there is not a framebuffer console, return 0 size.
+      *
+@@ -6384,13 +6391,13 @@ void NV_API_CALL nv_get_screen_info(
+      * initialization, and then will be set to a value, such as
+      * VIDEO_TYPE_VLFB or VIDEO_TYPE_EFI if an fbdev console is used.
+      */
+-    if (screen_info.orig_video_isVGA > 1)
++    if (si->orig_video_isVGA > 1)
+     {
+-        NvU64 physAddr = screen_info.lfb_base;
++        NvU64 physAddr = si->lfb_base;
+ #if defined(VIDEO_CAPABILITY_64BIT_BASE)
+-        if  (screen_info.capabilities & VIDEO_CAPABILITY_64BIT_BASE)
++        if  (si->capabilities & VIDEO_CAPABILITY_64BIT_BASE)
+         {
+-            physAddr |= (NvU64)screen_info.ext_lfb_base << 32;
++            physAddr |= (NvU64)si->ext_lfb_base << 32;
+         }
+ #endif
+         /*
+@@ -6402,10 +6409,10 @@ void NV_API_CALL nv_get_screen_info(
+             NV_IS_CONSOLE_MAPPED(nv, physAddr))
+         {
+             *pPhysicalAddress = physAddr;
+-            *pFbWidth = screen_info.lfb_width;
+-            *pFbHeight = screen_info.lfb_height;
+-            *pFbDepth = screen_info.lfb_depth;
+-            *pFbPitch = screen_info.lfb_linelength;
++            *pFbWidth = si->lfb_width;
++            *pFbHeight = si->lfb_height;
++            *pFbDepth = si->lfb_depth;
++            *pFbPitch = si->lfb_linelength;
+             *pFbSize = (NvU64)(*pFbHeight) * (NvU64)(*pFbPitch);
+             return;
+         }
+-- 
+2.55.0
+

--- a/nvidia/nvidia-utils/PKGBUILD
+++ b/nvidia/nvidia-utils/PKGBUILD
@@ -7,7 +7,7 @@
 pkgbase=nvidia-utils
 pkgname=('nvidia-utils' 'opencl-nvidia' 'nvidia-open-dkms')
 pkgver=610.43.03
-pkgrel=1
+pkgrel=2
 arch=('x86_64')
 url="http://www.nvidia.com/"
 license=('custom')
@@ -25,6 +25,7 @@ source=('nvidia-drm-outputclass.conf'
         "https://us.download.nvidia.com/XFree86/Linux-x86_64/${pkgver}/${_pkg}.run"
         "https://download.nvidia.com/XFree86/NVIDIA-kernel-module-source/${_pkg_open}.tar.xz"
         '0001-make-Add-support-for-7.2-Kernel.patch'
+        '0002-Replace-obsolete-use-of-screen_info-symbol.patch'
         'limit-vram-usage'
         'cuda-no-stable-perf-limit')
 sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
@@ -37,6 +38,7 @@ sha256sums=('be99ff3def641bb900c2486cce96530394c5dc60548fc4642f19d3a4c784134d'
             '45e2d4c134a23c35e50f253a4aa63e7e5e8d17e3d185d4a07c8a58e9612ed392'
             '7e118923c7a23edc36114d63273a46e3e04e9af98695a42203e7ac2dfe9fc1dc'
             '85d925cde698d2cff444c13e0ad42875dc0eb9391287efe335d0c3eadedc0b8f'
+            'd83ffe80aee6c6ac62e1022b15c76659d16dae9ac5557f7e0adb736cca1a1b23'
             'b14f7a65359c05c373ddfc750cd4cf086a48e815489d93ad5cbe1dbf84bf8f5a'
             '6264d279bbae8eae6554ed78dd6e562da00cf71ffa5601ce5208099a98cd2c4d')
 
@@ -60,6 +62,7 @@ prepare() {
 #    patch -Np1 -i "${srcdir}/0002-fix-dsc-use-bits_per_component-for-flatnessDetThresh.patch" -d "${srcdir}/${_pkg_open}/"
 #    patch -Np1 -i "${srcdir}/0003-fix-dp-add-Bigscreen-Beyond-VR-headset-to-WAR-databa.patch" -d "${srcdir}/${_pkg_open}/"
     patch -Np1 -i "${srcdir}/0001-make-Add-support-for-7.2-Kernel.patch" -d "${srcdir}/${_pkg_open}/"
+    patch -Np1 -i "${srcdir}/0002-Replace-obsolete-use-of-screen_info-symbol.patch" -d "${srcdir}/${_pkg_open}/kernel-open"
 
     # Attempt to make builds reproducible
     sed -i "s/^  HOSTNAME.*/  HOSTNAME = echo cachyos/" "${srcdir}/${_pkg_open}/utils.mk"


### PR DESCRIPTION
Fixes: https://github.com/CachyOS/linux-cachyos/issues/940