### PR TITLE
cachyos-hypr-noctalia: bumping pkgver / minor fixes

### DIFF
--- a/cachyos-hypr-noctalia/PKGBUILD
+++ b/cachyos-hypr-noctalia/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=cachyos-hypr-noctalia
 pkgdesc='CachyOS Hyprland Noctalia settings'
-pkgver=1.2.2
+pkgver=1.2.3
 pkgrel=1
 arch=('any')
 url="https://github.com/cachyos/$pkgname"
@@ -36,7 +36,6 @@ depends=(
 	satty
 	slurp
 	uwsm
-	wf-recorder
 	wl-clipboard
 	xdg-desktop-portal-hyprland
   	xorg-xhost


### PR DESCRIPTION
* Removed unused dep
* Bumping to v1.2.3
  * Fixes animation speed issue with Hyprland v0.56
  * Fixes swapped workspace/monitor traversal binds from Hyprland v0.56
  * Adds notification behavior for hyprpicker
  * Adds persistent size to generic floating windows
  * Adds window rule for xdg_tags with "game"

Full changes: https://github.com/CachyOS/cachyos-hypr-noctalia/compare/1.2.2...1.2.3