### PR TITLE
dms-shell: fix empty shell completions

### DIFF
--- a/dms-shell/PKGBUILD
+++ b/dms-shell/PKGBUILD
@@ -4,7 +4,7 @@ pkgbase=dms-shell
 _pkg1=DankMaterialShell
 pkgname=$pkgbase
 pkgver=1.5.2
-pkgrel=1
+pkgrel=2
 pkgdesc='A Quickshell-based desktop shell with Material 3 design principles'
 arch=(x86_64)
 url="https://github.com/AvengeMedia/$_pkg1"
@@ -47,7 +47,6 @@ build() {
 }
 
 _completion() {
-	cd "$_archive"
 	core/dms completion $1
 }
 


### PR DESCRIPTION
`dms-shell` ships **three empty (0-byte) completion files**, so `dms <TAB>` gives no suggestions in bash, zsh or fish:

```console
$ pacman -Qo /usr/share/fish/vendor_completions.d/dms.fish
/usr/share/fish/vendor_completions.d/dms.fish is owned by dms-shell 1.5.2-1

$ ls -l /usr/share/bash-completion/completions/dms \
        /usr/share/zsh/site-functions/_dms \
        /usr/share/fish/vendor_completions.d/dms.fish
-rw-r--r-- 1 root root 0 Jul 18 18:34 /usr/share/bash-completion/completions/dms
-rw-r--r-- 1 root root 0 Jul 18 18:34 /usr/share/zsh/site-functions/_dms
-rw-r--r-- 1 root root 0 Jul 18 18:34 /usr/share/fish/vendor_completions.d/dms.fish
```

The installed binary is fine — `dms completion fish` emits 9417 bytes — so nothing is wrong upstream.

## Root cause

```bash
_completion() {
	cd "$_archive"
	core/dms completion $1
}

package() {
	cd "$_archive"
	...
	install -Dm0644 <(_completion bash) "$pkgdir/usr/share/bash-completion/completions/dms"
```

`package()` has **already** `cd`'d into `$_archive`. The process substitution `<(_completion bash)` runs in a subshell that inherits that working directory, so `cd "$_archive"` tries to enter `$srcdir/$_archive/$_archive`, which does not exist. Under makepkg's `set -e` the subshell aborts before `core/dms` ever runs, `install` reads EOF from the fd, and writes a 0-byte file — without failing, so the build stays green and the breakage is silent.

Minimal reproduction:

```console
$ bash -c '
set -e
_archive="DankMaterialShell-1.5.2"
_completion() { cd "$_archive"; core/dms completion "$1"; }
cd "$_archive"
install -Dm0644 <(_completion bash) ./out 2>/dev/null
wc -c < ./out'
0

# with the cd dropped:
15973
```

## Fix

Drop the redundant `cd`. This is exactly what Arch did in [`8c6b5b6b`](https://gitlab.archlinux.org/archlinux/packaging/packages/dms-shell/-/commit/8c6b5b6b) after [issue #4 "faulty completions installation"](https://gitlab.archlinux.org/archlinux/packaging/packages/dms-shell/-/issues/4); this PKGBUILD was forked before that fix and never picked it up. `pkgrel` is bumped so the fixed package actually reaches users.

## Verification

Same upstream version, same binary — the only difference is the PKGBUILD:

| file | CachyOS `1.5.2-1` | Arch `1.5.2-1` (has the fix) |
|---|---|---|
| `bash-completion/completions/dms` | 0 B | 15973 B |
| `zsh/site-functions/_dms` | 0 B | 7640 B |
| `fish/vendor_completions.d/dms.fish` | 0 B | 9417 B |

The Arch sizes match `dms completion <shell>` byte for byte.

Worth noting for fish users specifically: the empty file is *worse* than no file, because `carapace` registers a generic `complete --no-files dms` that suppresses both the native completion autoload and the filename fallback — the result is zero suggestions of any kind.
