### PR TITLE
cachyos-niri-noctalia: update to v1.3.0

### DIFF
--- a/cachyos-niri-noctalia/.SRCINFO
+++ b/cachyos-niri-noctalia/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cachyos-niri-noctalia
 	pkgdesc = CachyOS Niri (+Noctalia) settings
-	pkgver = 1.2.0
+	pkgver = 1.3.0
 	pkgrel = 1
 	url = https://github.com/cachyos/cachyos-niri-noctalia
 	arch = any
@@ -21,7 +21,7 @@ pkgbase = cachyos-niri-noctalia
 	depends = xwayland-satellite
 	provides = cachyos-desktop-settings
 	conflicts = cachyos-desktop-settings
-	source = git+https://github.com/cachyos/cachyos-niri-noctalia#tag=1.2.0
-	sha512sums = e0d174c0e8954119faab1c9e9f06cdc512fc105f16d50c57bb98a591d6f5cb0490d181d2bc4abfc01227ddfbf05accc5802707d5837b3b8f5e8f0563f7698a6a
+	source = git+https://github.com/cachyos/cachyos-niri-noctalia#tag=1.3.0
+	sha512sums = 9b545f31f47fd4390d988e82ba4327aca5881dd32411303c4229be87934300f1cc8f35f6756bcfe3c8bf349632adf896428cdc2d46658b9cb90604badd6f7fe9
 
 pkgname = cachyos-niri-noctalia

--- a/cachyos-niri-noctalia/.nvchecker.toml
+++ b/cachyos-niri-noctalia/.nvchecker.toml
@@ -1,0 +1,3 @@
+[cachyos-niri-noctalia]
+source = 'git'
+git = 'https://github.com/CachyOS/cachyos-niri-noctalia.git'

--- a/cachyos-niri-noctalia/PKGBUILD
+++ b/cachyos-niri-noctalia/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=cachyos-niri-noctalia
 pkgdesc='CachyOS Niri (+Noctalia) settings'
-pkgver=1.2.0
+pkgver=1.3.0
 pkgrel=1
 arch=('any')
 url="https://github.com/cachyos/$pkgname"
 license=(GPL-3.0-only)
 makedepends=('coreutils' 'git')
 source=(git+$url#tag=${pkgver})
-sha512sums=('e0d174c0e8954119faab1c9e9f06cdc512fc105f16d50c57bb98a591d6f5cb0490d181d2bc4abfc01227ddfbf05accc5802707d5837b3b8f5e8f0563f7698a6a')
+sha512sums=('9b545f31f47fd4390d988e82ba4327aca5881dd32411303c4229be87934300f1cc8f35f6756bcfe3c8bf349632adf896428cdc2d46658b9cb90604badd6f7fe9')
 depends=(
   adw-gtk-theme
   cachyos-alacritty-config


### PR DESCRIPTION
The new version replaces the old noctalia (quickshell) for the new v5. I also included `.nvchecker.toml` on this PR.