### PR TITLE
Cachy-Update: Update to v4.1.0

### DIFF
--- a/cachy-update/.SRCINFO
+++ b/cachy-update/.SRCINFO
@@ -1,11 +1,13 @@
 pkgbase = cachy-update
-	pkgdesc = An update notifier & applier that assists you with important pre / post update tasks
-	pkgver = 3.20.5
+	pkgdesc = An interactive update notifier & applier that assists you with important pre / post update tasks
+	pkgver = 4.1.0
 	pkgrel = 1
 	url = https://github.com/CachyOS/cachy-update
-	arch = any
+	arch = x86_64
+	arch = aarch64
 	license = GPL-3.0-or-later
 	checkdepends = bats
+	makedepends = cargo
 	makedepends = scdoc
 	makedepends = git
 	depends = bash
@@ -19,9 +21,8 @@ pkgbase = cachy-update
 	depends = htmlq
 	depends = diffutils
 	depends = hicolor-icon-theme
-	depends = python
-	depends = python-pyqt6
-	depends = qt6-svg
+	depends = glibc
+	depends = libgcc
 	depends = glib2
 	depends = xdg-utils
 	optdepends = paru: AUR Packages support
@@ -36,7 +37,7 @@ pkgbase = cachy-update
 	optdepends = sudo-rs: Privilege elevation
 	optdepends = opendoas: Privilege elavation
 	conflicts = arch-update
-	source = git+https://github.com/CachyOS/cachy-update#commit=675d1d29447b6400f0eb9e52acf66a0b0049aa61
-	sha256sums = 081b8f5bf9347d0ae31bbaecff71012f952399eec4770fce32edd4dd25000e9f
+	source = git+https://github.com/CachyOS/cachy-update#commit=2d7199a22fcc9f8fd768b3da622600e1604dadb7
+	sha256sums = a52f04b2f51312614a6ca0850070e73ff7ea6fc4f1bd049b8f2f9f8b63bdac27
 
 pkgname = cachy-update

--- a/cachy-update/PKGBUILD
+++ b/cachy-update/PKGBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Robin Candau <antiz@archlinux.org>
 
 pkgname=cachy-update
-pkgver=3.20.5
+pkgver=4.1.0
 pkgrel=1
-pkgdesc="An update notifier & applier that assists you with important pre / post update tasks"
+pkgdesc="An interactive update notifier & applier that assists you with important pre / post update tasks"
 url="https://github.com/CachyOS/cachy-update"
-arch=('any')
+arch=('x86_64' 'aarch64')
 license=('GPL-3.0-or-later')
 depends=('bash' 'systemd' 'pacman' 'pacman-contrib' 'archlinux-contrib' 'curl' 'fakeroot' 'util-linux'
-         'htmlq' 'diffutils' 'hicolor-icon-theme' 'python' 'python-pyqt6' 'qt6-svg' 'glib2' 'xdg-utils')
-makedepends=('scdoc' 'git')
+         'htmlq' 'diffutils' 'hicolor-icon-theme' 'glibc' 'libgcc' 'glib2' 'xdg-utils')
+makedepends=('cargo' 'scdoc' 'git')
 checkdepends=('bats')
 conflicts=('arch-update')
 optdepends=('paru: AUR Packages support'
@@ -23,8 +23,8 @@ optdepends=('paru: AUR Packages support'
             'sudo: Privilege elevation'
             'sudo-rs: Privilege elevation'
             'opendoas: Privilege elavation')
-source=("git+https://github.com/CachyOS/cachy-update#commit=675d1d29447b6400f0eb9e52acf66a0b0049aa61")
-sha256sums=('081b8f5bf9347d0ae31bbaecff71012f952399eec4770fce32edd4dd25000e9f')
+source=("git+https://github.com/CachyOS/cachy-update#commit=2d7199a22fcc9f8fd768b3da622600e1604dadb7")
+sha256sums=('a52f04b2f51312614a6ca0850070e73ff7ea6fc4f1bd049b8f2f9f8b63bdac27')
 
 prepare() {
     cd "${pkgname}"
@@ -45,5 +45,6 @@ package() {
     cd "${pkgname}"
     make PREFIX=/usr DESTDIR="${pkgdir}" install
 
+    install -Dm 644 res/desktop/arch-update-tray.desktop "${pkgdir}/etc/xdg/autostart/arch-update-tray.desktop"
     ln -s arch-update "${pkgdir}/usr/bin/${pkgname}"
 }


### PR DESCRIPTION
- https://github.com/Antiz96/arch-update/releases/tag/v4.0.0
- https://github.com/Antiz96/arch-update/releases/tag/v4.0.1
- https://github.com/Antiz96/arch-update/releases/tag/v4.0.2
- https://github.com/Antiz96/arch-update/releases/tag/v4.1.0