### PR TITLE
cachyos-zsh-config: remove unnecessary vim dependency

### DIFF
--- a/cachyos-zsh-config/.SRCINFO
+++ b/cachyos-zsh-config/.SRCINFO
@@ -10,7 +10,6 @@ pkgbase = cachyos-zsh-config
 	depends = oh-my-zsh-git
 	depends = pkgfile
 	depends = powerline-fonts
-	depends = vim
 	depends = zsh
 	depends = zsh-autosuggestions
 	depends = zsh-completions

--- a/cachyos-zsh-config/PKGBUILD
+++ b/cachyos-zsh-config/PKGBUILD
@@ -12,7 +12,6 @@ depends=(
   oh-my-zsh-git
   pkgfile
   powerline-fonts
-  vim
   zsh
   zsh-autosuggestions
   zsh-completions


### PR DESCRIPTION
## Summary

Remove the unnecessary `vim` runtime dependency from `cachyos-zsh-config`.

## Reason

The package only installs:

- `/usr/share/cachyos-zsh-config/cachyos-config.zsh`
- `/etc/skel/.zshrc`

After inspecting both files, there are no references to:

- `vim`
- `vi`
- `vimdiff`
- `view`
- `EDITOR=vim`
- `VISUAL=vim`

The package does not invoke Vim or require it for any functionality.

Fixes #1436