### PR TITLE
fix(alsa-ucm-conf): apply upstream patch for Turkish locale

### DIFF
--- a/core/alsa-ucm-conf/PKGBUILD
+++ b/core/alsa-ucm-conf/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+# Contributor: Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
+
+pkgname=alsa-ucm-conf
+pkgver=1.2.16.1
+pkgrel=2
+pkgdesc="ALSA Use Case Manager configuration (and topologies)"
+arch=(any)
+url="https://alsa-project.org/"
+license=(BSD-3-Clause)
+source=(
+  $url/files/pub/lib/$pkgname-$pkgver.tar.bz2{,.sig}
+  fix-turkish-locale.patch
+)
+sha512sums=('df25a29afc3b87347fa89f3fe60ebda68068acdaf68e081b58455ebee319c21e82af4076ba1f10781ba620a9e8efa6e65db27c5989d63a429d44a715dbd1d460'
+            'SKIP'
+            'c52f017b419b8565fc331738938b72aeb2374cac867b06065fcc609fa5eb93c16b3c453d4d0c039617af387afa14f9feed028e210cd77320409afdbb41f3a534')
+b2sums=('753e1775cd99c0f6289507d04760c7a87ead4a0d029a817aa3e6083a30eae123859a91432511f1e5f4daa25ddee960e8f3be130586a2761ee95bf4af40a76a13'
+        'SKIP'
+        '2dd55da81c8c4fe25fb9aa3373c6359f202e66f04fdde0d4222b4e8cd888a177d7404542390343fd19088d66dce0c3da57ea2e848181d50b9ebc12565b821255')
+validpgpkeys=('F04DF50737AC1A884C4B3D718380596DA6E59C91') # ALSA Release Team (Package Signing Key v1) <release@alsa-project.org>
+
+prepare() {
+  cd "$pkgname-$pkgver"
+  # Apply upstream regex fix for Turkish locale (Closes #533)
+  patch -Np1 -i "${srcdir}/fix-turkish-locale.patch"
+}
+
+package() {
+  cd $pkgname-$pkgver
+  install -vdm 755 "$pkgdir/usr/share/alsa/"
+  cp -av ucm2 "$pkgdir/usr/share/alsa/"
+  install -vDm 644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname"
+  install -vDm 644 README.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -vDm 644 ucm2/README.md -t "$pkgdir/usr/share/doc/$pkgname/ucm2"
+}

--- a/core/alsa-ucm-conf/PKGBUILD
+++ b/core/alsa-ucm-conf/PKGBUILD
@@ -27,7 +27,7 @@ prepare() {
 }
 
 package() {
-  cd $pkgname-$pkgver
+  cd "$pkgname-$pkgver"
   install -vdm 755 "$pkgdir/usr/share/alsa/"
   cp -av ucm2 "$pkgdir/usr/share/alsa/"
   install -vDm 644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname"

--- a/core/alsa-ucm-conf/fix-turkish-locale.patch
+++ b/core/alsa-ucm-conf/fix-turkish-locale.patch
@@ -1,0 +1,27 @@
+diff --git a/ucm2/sof-soundwire/sof-soundwire.conf b/ucm2/sof-soundwire/sof-soundwire.conf
+index 3ccf493..04a5f8b 100644
+--- a/ucm2/sof-soundwire/sof-soundwire.conf
++++ b/ucm2/sof-soundwire/sof-soundwire.conf
+@@ -23,7 +23,7 @@ Define {
+ 
+ DefineRegex {
+ 	SpeakerCodec {
+-		Regex " spk:([a-z0-9]+((-sdca)|(-spk)|(-bridge))?(\\+[a-z0-9]+((-spk)?))?)"
++		Regex " spk:([[:alnum:]]+((-sdca)|(-spk)|(-bridge))?(\\+[[:alnum:]]+((-spk)?))?)"
+ 		String "${CardComponents}"
+ 	}
+ 	SpeakerChannels {
+@@ -35,11 +35,11 @@ DefineRegex {
+ 		String "${CardComponents}"
+ 	}
+ 	HeadsetCodec {
+-		Regex " hs:([a-z0-9]+(-sdca)?)"
++		Regex " hs:([[:alnum:]]+(-sdca)?)"
+ 		String "${CardComponents}"
+ 	}
+ 	MicCodec {
+-		Regex " mic:([a-z0-9]+(-dmic)?+(-sdca)?)"
++		Regex " mic:([[:alnum:]]+(-dmic)?+(-sdca)?)"
+ 		String "${CardComponents}"
+ 	}
+ 	Mics {


### PR DESCRIPTION
Backports upstream regex fix from alsa-project/alsa-ucm-conf#824 to resolve Dummy Output issues on Meteor Lake hardware under tr_TR.UTF-8.

Resolves CachyOS/distribution#533