### PR TITLE
dracut-cachyos: update to 112

### DIFF
--- a/dracut-cachyos/PKGBUILD
+++ b/dracut-cachyos/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: SoulHarsh007 <admin@soulharsh007.dev>
 
 pkgname=dracut-cachyos
-pkgver=111
+pkgver=112
 pkgrel=1
 pkgdesc="An event driven initramfs infrastructure"
 arch=('x86_64')
@@ -94,7 +94,7 @@ source=("${pkgname}-${pkgver}::git+${url}#tag=${pkgver}"
   "snapshot-overlay.sh"
   "module-setup.sh")
 
-sha512sums=('79c82ba011736bd39dc45e6b32a35debbde061ed6ef96d9bcc8983f35967202d36d6c5ea7ae3fc9accf6fa66d095b5098237278b7554e5b0c4a212c1ad56b83a'
+sha512sums=('c06703a3685a1ce4edd8bb19beb0a32e4832c08cdcf9427593be6dd02ecc20c37de035e3b31f289a58fc4162e244e0275fe663c72dbfbe0b9df8c2f7d7b646f7'
             '8a4c9ac056bee6e7e22057cbf7179a32759767694a955372f68d43b26be62e9e8381c6264fc4884c4b04e39ffd6c1a2cc0d7e947b5796b4d89278455f3843cb9'
             'f298693ee1a637329b1a38c746151c2ae8d2ae431f894c3001f55d812a2a20a68907ffa0b04ba748c18a2898cc30e0f49e75d0d13c7dd453129304f3cfd4621e'
             '13e3faab40ae0e13f7933fcf5e1b028b4af2010d91b5d6c4dcda164bc9ab62cdcdde21f4945f28f564546a8700bd285cca6a19f1575fcf1925dbde54fba9078a'


### PR DESCRIPTION
Fixes #1665

- Bump `pkgver` 111 → 112
- Regenerated git-source sha512sum for tag `112`

Verified locally: `makepkg` built `dracut-cachyos-112-1-x86_64.pkg.tar.zst` successfully.