### PR TITLE
Add UK (repo.c48.uk) mirror to cachyos-mirrorlist

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -118,3 +118,6 @@ Server = https://mirrors.nguyenhoang.cloud/cachyos/repo/$arch/$repo
 ## Hungary Mirror provided by bali0531
 ## tier=2 code=HU
 Server = https://mirror.bali0531.hu/repo/$arch/$repo
+## UK mirror on c48.uk by wilbur
+## tier=2 code=GB
+Server = https://repo.c48.uk/cachyos/repo/$arch/$repo


### PR DESCRIPTION
syncing half-hourly from nl.mirror.cx at present, i may need T0 access at some point if more mirrors are established under repo.c48.uk anytime soon