### PR TITLE
cachyos-hypr-noctalia: bump ver to 1.2.5

### DIFF
--- a/cachyos-hypr-noctalia/.SRCINFO
+++ b/cachyos-hypr-noctalia/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-hypr-noctalia
 	pkgdesc = CachyOS Hyprland Noctalia settings
-	pkgver = 1.2.4
-	pkgrel = 2
+	pkgver = 1.2.5
+	pkgrel = 1
 	url = https://github.com/cachyos/cachyos-hypr-noctalia
 	install = cachyos-hypr-noctalia.install
 	arch = any
@@ -34,7 +34,7 @@ pkgbase = cachyos-hypr-noctalia
 	depends = xorg-xhost
 	provides = cachyos-desktop-settings
 	conflicts = cachyos-desktop-settings
-	source = cachyos-hypr-noctalia-1.2.4.tar.gz::https://github.com/cachyos/cachyos-hypr-noctalia/archive/1.2.4.tar.gz
-	sha256sums = e019262f43c12612aaf63e5a1ed9973d8c8d250d7bd6542d7801713646476013
+	source = cachyos-hypr-noctalia-1.2.5.tar.gz::https://github.com/cachyos/cachyos-hypr-noctalia/archive/1.2.5.tar.gz
+	sha256sums = 6bc2160a2e95c7d9e567682789385a09e24c759529a55b9e32115ebfd5fb4d3d
 
 pkgname = cachyos-hypr-noctalia

--- a/cachyos-hypr-noctalia/.SRCINFO
+++ b/cachyos-hypr-noctalia/.SRCINFO
@@ -34,6 +34,7 @@ pkgbase = cachyos-hypr-noctalia
 	depends = xorg-xhost
 	provides = cachyos-desktop-settings
 	conflicts = cachyos-desktop-settings
+	backup = var/lib/noctalia-greeter/greeter.toml
 	source = cachyos-hypr-noctalia-1.2.5.tar.gz::https://github.com/cachyos/cachyos-hypr-noctalia/archive/1.2.5.tar.gz
 	sha256sums = 6bc2160a2e95c7d9e567682789385a09e24c759529a55b9e32115ebfd5fb4d3d
 

--- a/cachyos-hypr-noctalia/PKGBUILD
+++ b/cachyos-hypr-noctalia/PKGBUILD
@@ -10,7 +10,7 @@ license=(GPL-1.0-only)
 makedepends=('coreutils')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
 sha256sums=('6bc2160a2e95c7d9e567682789385a09e24c759529a55b9e32115ebfd5fb4d3d')
-backup=(var/lib/noctalia-greeter/greeter.toml)
+backup=('var/lib/noctalia-greeter/greeter.toml')
 depends=(
 	adw-gtk-theme
 	awesome-terminal-fonts

--- a/cachyos-hypr-noctalia/PKGBUILD
+++ b/cachyos-hypr-noctalia/PKGBUILD
@@ -10,6 +10,7 @@ license=(GPL-1.0-only)
 makedepends=('coreutils')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
 sha256sums=('6bc2160a2e95c7d9e567682789385a09e24c759529a55b9e32115ebfd5fb4d3d')
+backup=(var/lib/noctalia-greeter/greeter.toml)
 depends=(
 	adw-gtk-theme
 	awesome-terminal-fonts

--- a/cachyos-hypr-noctalia/PKGBUILD
+++ b/cachyos-hypr-noctalia/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=cachyos-hypr-noctalia
 pkgdesc='CachyOS Hyprland Noctalia settings'
-pkgver=1.2.4
-pkgrel=2
+pkgver=1.2.5
+pkgrel=1
 arch=('any')
 url="https://github.com/cachyos/$pkgname"
 license=(GPL-1.0-only)
 makedepends=('coreutils')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
-sha256sums=('e019262f43c12612aaf63e5a1ed9973d8c8d250d7bd6542d7801713646476013')
+sha256sums=('6bc2160a2e95c7d9e567682789385a09e24c759529a55b9e32115ebfd5fb4d3d')
 depends=(
 	adw-gtk-theme
 	awesome-terminal-fonts


### PR DESCRIPTION
* fixes config changes in noct beta8

https://github.com/CachyOS/cachyos-hypr-noctalia/releases/tag/1.2.5