### PR TITLE
winboat: add a Russian Comment to the desktop entry

### DIFF
--- a/winboat/PKGBUILD
+++ b/winboat/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Matt Quintanilla <matt @ matt quintanilla .xyz>
 pkgname=winboat
 pkgver=0.9.0
-pkgrel=9
+pkgrel=10
 pkgdesc="Run Windows apps on Linux with seamless integration"
 arch=('x86_64')
 url="https://www.winboat.app"
@@ -69,5 +69,6 @@ Terminal=false
 Categories=System
 Type=Application
 Comment=Run Windows apps on Linux with seamless integration
+Comment[ru]=Запуск приложений Windows в Linux с бесшовной интеграцией
 EOF
 }


### PR DESCRIPTION
WinBoat sits in a Russian menu with an English one-liner under it — "Run Windows apps on Linux with seamless integration" — and that line is all a user sees before the program starts.

The entry is written by hand here in the PKGBUILD, so this adds a `Comment[ru]` next to the English one. Windows and Linux stay in Latin, as they are in Russian technical writing. pkgrel bumped so the change actually ships; drop that hunk if you would rather fold it into the next version bump.

I also sent a patch upstream (winboat-org/winboat#845) to make electron-builder put a proper `Comment` and `Comment[ru]` into the entry it generates, but that only affects their own deb/rpm/AppImage builds — the Arch packaging writes its own file, so it needs this separately.
