### PR TITLE
Add mono-launcher package

### DIFF
--- a/mono-launcher/.SRCINFO
+++ b/mono-launcher/.SRCINFO
@@ -1,0 +1,13 @@
+pkgbase = mono-launcher
+	pkgdesc = Desktop Minecraft modpack launcher (mrpack)
+	pkgrel = 1
+	url = https://github.com/n1orio/mono-launcher
+	arch = x86_64
+	license = MIT
+	depends = webkit2gtk-4.1
+	depends = gtk3
+	depends = librsvg
+	source = https://github.com/n1orio/mono-launcher/releases/download/launcher-v1.3.1/Mono.Launcher_1.3.1_amd64.deb
+	sha256sums = 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
+
+pkgname = mono-launcher

--- a/mono-launcher/PKGBUILD
+++ b/mono-launcher/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: NIO <nior1o@icloud.com>
+# Замечание: пакет переупаковывает официальный сборщик-артефакт (.deb) из
+# GitHub Releases. CachyOS обычно предпочитает сборку из исходников — при
+# ревью, вероятно, попросят вариант с build() из source (node+npm+rust+webkit).
+pkgname=mono-launcher
+pkgver=1.3.1
+pkgrel=1
+pkgdesc="Desktop Minecraft modpack launcher (mrpack)"
+arch=('x86_64')
+url="https://github.com/n1orio/mono-launcher"
+license=('MIT')
+depends=('webkit2gtk-4.1' 'gtk3' 'librsvg')
+source=("https://github.com/n1orio/mono-launcher/releases/download/launcher-v${pkgver}/Mono.Launcher_${pkgver}_amd64.deb")
+sha256sums=('0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5')
+
+package() {
+  # .deb содержит control.tar.gz и data.tar.gz (usr/bin, иконки, .desktop)
+  bsdtar -xf "${srcdir}/Mono.Launcher_${pkgver}_amd64.deb" -C "${srcdir}"
+  bsdtar -xf "${srcdir}/data.tar.gz" -C "${pkgdir}"
+}


### PR DESCRIPTION
Adds the **mono-launcher** desktop Minecraft modpack launcher as a repackaged package.

- Upstream: https://github.com/n1orio/mono-launcher
- Official release assets (.deb / AppImage / rpm) are built on GitHub Actions and uploaded to GitHub Releases.
- This PKGBUILD repackages the official `.deb` (contains `usr/bin/mono-launcher`, icons and a `.desktop` with deep-link `mono://`) so it installs cleanly as an Arch/CachyOS package.
- License: MIT.
- Depends: webkit2gtk-4.1, gtk3, librsvg (the deb declares libwebkit2gtk-4.1-0, libgtk-3-0).
- SHA-256 is pinned for the launcher-v1.3.1 release; version is bumpable per release.

If a source build is preferred over repackaging the binary artifact, I can add a `build()` variant (node + rust + webkit) — let me know.