### PR TITLE
cachyos-rate-mirrors: add bounded retry on failure to service

### DIFF
--- a/cachyos-rate-mirrors/.SRCINFO
+++ b/cachyos-rate-mirrors/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-rate-mirrors
 	pkgdesc = CachyOS - Rate mirrors service
 	pkgver = 24
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/CachyOS
 	install = cachyos-rate-mirrors.install
 	arch = any
@@ -13,7 +13,7 @@ pkgbase = cachyos-rate-mirrors
 	source = cachyos-rate-mirrors.timer
 	source = cachyos-rate-mirrors.hook
 	sha256sums = 47eff7dd429e17b5445f3b47c46bdc51aa6145496d82650b46420310d9b1dcc0
-	sha256sums = 8d702520276cb77f138efae2c89d82ef62f9445a3a9e8405509a141645f382bc
+	sha256sums = 5037453fbf7c737c1efd83e0e5050b6290b3655f103e499862852a2d9b5e897a
 	sha256sums = e9f368a137bc20c54beea4ca349400e9a5903860cb830b5658a219546e5085f0
 	sha256sums = 631cd984e0b77f58be2cee48748a49eab2c56d51622e397defbf464574aec0f4
 

--- a/cachyos-rate-mirrors/PKGBUILD
+++ b/cachyos-rate-mirrors/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cachyos-rate-mirrors
 pkgver=24
-pkgrel=1
+pkgrel=2
 groups=(cachyos)
 arch=('any')
 install=$pkgname.install
@@ -18,7 +18,7 @@ source=(
     cachyos-rate-mirrors.hook
 )
 sha256sums=('47eff7dd429e17b5445f3b47c46bdc51aa6145496d82650b46420310d9b1dcc0'
-            '8d702520276cb77f138efae2c89d82ef62f9445a3a9e8405509a141645f382bc'
+            '5037453fbf7c737c1efd83e0e5050b6290b3655f103e499862852a2d9b5e897a'
             'e9f368a137bc20c54beea4ca349400e9a5903860cb830b5658a219546e5085f0'
             '631cd984e0b77f58be2cee48748a49eab2c56d51622e397defbf464574aec0f4')
 

--- a/cachyos-rate-mirrors/cachyos-rate-mirrors.service
+++ b/cachyos-rate-mirrors/cachyos-rate-mirrors.service
@@ -2,6 +2,8 @@
 Description=Refresh arch / cachyos mirror lists
 Documentation=https://github.com/CachyOS/CachyOS-PKGBUILDS/tree/master/cachyos-rate-mirrors
 After=network-online.target nss-lookup.target
+StartLimitIntervalSec=1h
+StartLimitBurst=6
 
 [Service]
 Type=oneshot
@@ -9,3 +11,5 @@ StandardOutput=null
 StandardError=journal
 ExecStart=/usr/bin/cachyos-rate-mirrors
 IPAccounting=yes
+Restart=on-failure
+RestartSec=5min


### PR DESCRIPTION
Fixes #1739

### Description

Adds bounded retry-on-failure semantics to `cachyos-rate-mirrors.service`:

- `Restart=on-failure`
- `RestartSec=5min`
- `StartLimitIntervalSec=1h`
- `StartLimitBurst=6`

This permits six service starts total within the one-hour rate-limit window:
the initial activation plus up to five delayed retries.

The package release is bumped to `pkgrel=2`, with the service checksum and
`.SRCINFO` updated accordingly.

### Verification

- `systemd-analyze verify` passes on systemd 261
- `bash -n cachyos-rate-mirrors/cachyos-rate-mirrors` passes
- package source checksums match `PKGBUILD` and `.SRCINFO`
- `.SRCINFO` regenerates cleanly
- `git diff --check` passes
- retry/timer semantics were independently reviewed by Codex and approved
