### PR TITLE
Add init7 mirror (Swiss ISP) to the mirrorlist

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -84,6 +84,9 @@ Server = https://cachyos.doridian.net/repo/$arch/$repo
 ## Switzerland Mirror much thanks to Fabian!
 ## tier=2 code=CH
 Server = https://mirror.hb9hil.org/cachyos/repo/$arch/$repo
+## Switzerland Mirror provided by init7 (ISP)
+## tier=2 code=CH
+Server = https://mirror.init7.net/cachyos/repo/$arch/$repo
 ## Russia Mirror from Yandex
 ## tier=2 code=RU
 # Server = https://mirror.yandex.ru/cachyos/repo/$arch/$repo


### PR DESCRIPTION
I noticed that init7 provides a mirror for CachyOS so it makes to add it here in my opinion.

Syncs every 4-8 hours.

### More information:

https://mirror.init7.net/
https://mirror.init7.net/packages.html


I did notify init7 support about this PR.