### PR TITLE
tuned-cachy: update to 2.28.0

### DIFF
--- a/tuned/.SRCINFO
+++ b/tuned/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = tuned-cachy
 	license = GPL-2.0-or-later
 	makedepends = desktop-file-utils
 	makedepends = git
+	makedepends = python-pyinotify
 	depends = ethtool
 	depends = gawk
 	depends = hdparm

--- a/tuned/.SRCINFO
+++ b/tuned/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = tuned-cachy
 	pkgdesc = Daemon that performs monitoring and adaptive configuration of devices in the system
-	pkgver = 2.27.0
+	pkgver = 2.28.0
 	pkgrel = 2
 	url = https://github.com/redhat-performance/tuned
 	arch = any
@@ -17,8 +17,8 @@ pkgbase = tuned-cachy
 	depends = python-gobject
 	depends = python-linux-procfs
 	depends = python-pyudev
-	source = git+https://github.com/cachyos/tuned#commit=8e1829346cae8b3b7aec02516556c4179bcfc4d2
-	sha512sums = aca94f2eca7f6f5423861382e89e2fd579cfd7925510d19ef5e29558f5d35734b3a8a35ceae397832204387dd57054760fbb21ab7641678fd65e367e21706712
+	source = git+https://github.com/cachyos/tuned#commit=71854de54954a33e6787aa9578d8f4d6298d6bca
+	sha512sums = fe2ad49085a5229aa252bb678be295cc7e51cf132ec30cd364803ddb6ae1ad31d4d47269e29840fed97c29bf82a2c4635b6bd3be220bbf730bef720ce48ddb0e
 
 pkgname = tuned-cachy
 	optdepends = virt-what: Virtual machine detection

--- a/tuned/PKGBUILD
+++ b/tuned/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgbase=tuned-cachy
 pkgname=("${pkgbase}" "${pkgbase}-ppd")
-pkgver=2.27.0
+pkgver=2.28.0
 pkgrel=2
 pkgdesc='Daemon that performs monitoring and adaptive configuration of devices in the system'
 arch=('any')
@@ -15,8 +15,8 @@ license=('GPL-2.0-or-later')
 depends=('ethtool' 'gawk' 'hdparm' 'polkit' 'perf' 'python-configobj'
          'python-dbus' 'python-gobject' 'python-linux-procfs' 'python-pyudev')
 makedepends=('desktop-file-utils' git)
-source=("git+https://github.com/cachyos/tuned#commit=8e1829346cae8b3b7aec02516556c4179bcfc4d2")
-sha512sums=('aca94f2eca7f6f5423861382e89e2fd579cfd7925510d19ef5e29558f5d35734b3a8a35ceae397832204387dd57054760fbb21ab7641678fd65e367e21706712')
+source=("git+https://github.com/cachyos/tuned#commit=71854de54954a33e6787aa9578d8f4d6298d6bca")
+sha512sums=('fe2ad49085a5229aa252bb678be295cc7e51cf132ec30cd364803ddb6ae1ad31d4d47269e29840fed97c29bf82a2c4635b6bd3be220bbf730bef720ce48ddb0e')
 
 prepare() {
   cd "tuned"

--- a/tuned/PKGBUILD
+++ b/tuned/PKGBUILD
@@ -14,7 +14,7 @@ url="https://github.com/redhat-performance/tuned"
 license=('GPL-2.0-or-later')
 depends=('ethtool' 'gawk' 'hdparm' 'polkit' 'perf' 'python-configobj'
          'python-dbus' 'python-gobject' 'python-linux-procfs' 'python-pyudev')
-makedepends=('desktop-file-utils' git)
+makedepends=('desktop-file-utils' 'git' 'python-pyinotify')
 source=("git+https://github.com/cachyos/tuned#commit=71854de54954a33e6787aa9578d8f4d6298d6bca")
 sha512sums=('fe2ad49085a5229aa252bb678be295cc7e51cf132ec30cd364803ddb6ae1ad31d4d47269e29840fed97c29bf82a2c4635b6bd3be220bbf730bef720ce48ddb0e')
 


### PR DESCRIPTION
Closes #1749

Updates tuned-cachy from 2.27.0 to 2.28.0 using the CachyOS tuned fork commit 71854de54954a33e6787aa9578d8f4d6298d6bca and regenerated .SRCINFO/checksum metadata.

Validation:
- makepkg source retrieval and SHA-512 integrity verification passed
- makepkg --printsrcinfo matches .SRCINFO
- bash -n and git diff --check passed
- Full package build attempted; fakeroot/filesystem ownership preservation failed during cp -a, so no package was installed
- namcap reports the pre-existing split-package python-pyinotify makedepends issue