### PR TITLE
zfs-utils: update to 2.4.4

### DIFF
--- a/zfs/zfs-utils/.SRCINFO
+++ b/zfs/zfs-utils/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zfs-utils
 	pkgdesc = Userspace utilities for the Zettabyte File System.
-	pkgver = 2.4.3
+	pkgver = 2.4.4
 	pkgrel = 2
 	url = https://zfsonlinux.org/
 	arch = i686
@@ -11,14 +11,14 @@ pkgbase = zfs-utils
 	optdepends = python: for arcstat/arc_summary/dbufstat
 	backup = etc/default/zfs
 	backup = etc/zfs/zed.d/zed.rc
-	source = git+https://github.com/cachyos/zfs.git#commit=c681af76c5a6a15caada25eb13090e41218c7831
+	source = git+https://github.com/cachyos/zfs.git#commit=71a9f9578616a90c3c14bb59629fb4d31bfd68d1
 	source = zfs-node-permission.conf
 	source = zfs.initcpio.install
 	source = zfs.initcpio.hook
 	source = zfs.initcpio.zfsencryptssh.install
 	validpgpkeys = 4F3BA9AB6D1F8D683DC2DFB56AD860EED4598027
 	validpgpkeys = C33DF142657ED1F7C328A2960AB9E991C6AF658B
-	sha256sums = a5a24eef1a06cffc200ae2b5e0b93a3f2a37031fd1d32ec77974d4903d2a43ce
+	sha256sums = 6774962dfcf1e4f815e278e9ef70ffb616fc0b2ac476520181a6fffe188cb4f5
 	sha256sums = 7ad45fd291aa582639725f14d88d7da5bd3d427012b25bddbe917ca6d1a07c1a
 	sha256sums = 2f09c742287f4738c7c09a9669f8055cd63d3b9474cd1f6d9447152d11a1b913
 	sha256sums = 15b5acea44225b4364ec6472a08d3d48666d241fe84c142e1171cd3b78a5584f

--- a/zfs/zfs-utils/PKGBUILD
+++ b/zfs/zfs-utils/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Iacopo Isimbaldi <isiachi@rhye.it>
 
 pkgname=zfs-utils
-pkgver=2.4.3
+pkgver=2.4.4
 pkgrel=2
 pkgdesc="Userspace utilities for the Zettabyte File System."
 arch=("i686" "x86_64" "aarch64")
@@ -12,13 +12,13 @@ url="https://zfsonlinux.org/"
 license=('CDDL')
 makedepends=('git')
 optdepends=('python: for arcstat/arc_summary/dbufstat')
-_commit=c681af76c5a6a15caada25eb13090e41218c7831
+_commit=71a9f9578616a90c3c14bb59629fb4d31bfd68d1
 source=("git+https://github.com/cachyos/zfs.git#commit=$_commit"
         "zfs-node-permission.conf"
         "zfs.initcpio.install"
         "zfs.initcpio.hook"
         "zfs.initcpio.zfsencryptssh.install")
-sha256sums=('a5a24eef1a06cffc200ae2b5e0b93a3f2a37031fd1d32ec77974d4903d2a43ce'
+sha256sums=('6774962dfcf1e4f815e278e9ef70ffb616fc0b2ac476520181a6fffe188cb4f5'
             '7ad45fd291aa582639725f14d88d7da5bd3d427012b25bddbe917ca6d1a07c1a'
             '2f09c742287f4738c7c09a9669f8055cd63d3b9474cd1f6d9447152d11a1b913'
             '15b5acea44225b4364ec6472a08d3d48666d241fe84c142e1171cd3b78a5584f'


### PR DESCRIPTION
Closes #1746

Updates zfs-utils from 2.4.3 to 2.4.4 using the CachyOS ZFS fork tag commit 71a9f9578616a90c3c14bb59629fb4d31bfd68d1. The existing CachyOS initcpio hooks, permission adjustment, configuration, and split-package metadata remain unchanged.

Validation:
- makepkg source retrieval and SHA-256 integrity verification passed
- pinned source extracted at the expected zfs-2.4.4 commit
- makepkg --printsrcinfo matches .SRCINFO
- bash -n, namcap, and git diff --check passed
- Full ZFS build intentionally not run because kernel/module compilation is disproportionate for this bounded userspace package bump