### PR TITLE
chafa: add package with smolscale AVX2 alignment fix for Zen 4/Zen 5

### DIFF
--- a/chafa/.SRCINFO
+++ b/chafa/.SRCINFO
@@ -1,0 +1,23 @@
+pkgbase = chafa
+	pkgdesc = Image-to-text converter supporting a wide range of symbols and palettes, transparency, animations, etc.
+	pkgver = 1.18.2
+	pkgrel = 2.1
+	url = https://hpjansson.org/chafa/
+	arch = x86_64
+	license = LGPL-3.0-or-later
+	makedepends = git
+	makedepends = gtk-doc
+	depends = libavif
+	depends = libheif
+	depends = libjxl
+	depends = librsvg
+	depends = libwebp
+	depends = libxslt
+	provides = libchafa.so
+	source = git+https://github.com/hpjansson/chafa.git#tag=1.18.2?signed
+	source = chafa-1.18.2-smolscale-avx2-alignment.patch
+	validpgpkeys = C01EDE5BB0D91E26D003662EC76BB9FEEAD12EA7
+	sha512sums = 93e1a44e2e5ec655f65e9f2b85be44e407429621a6b14b37f6cdf1db5c686d78c3b1c12d7b45791e12127d174da47fd69d151bb539f72f4449a8671c75f0a3ad
+	sha512sums = 4f09c1b2a9de80777f731c2fee1250cca6a3109d479f3074c59fa597135ffd91ac241db42ca3ce5d71986fe852a0937a76cf7b7ceed5bd43baa37fbbde633050
+
+pkgname = chafa

--- a/chafa/PKGBUILD
+++ b/chafa/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Vladislav Nepogodin <nepogodin.vlad@gmail.com>
+
+pkgname=chafa
+pkgver=1.18.2
+pkgrel=2.1
+pkgdesc="Image-to-text converter supporting a wide range of symbols and palettes, transparency, animations, etc."
+arch=("x86_64")
+url="https://hpjansson.org/chafa/"
+license=("LGPL-3.0-or-later")
+depends=('libavif' 'libheif' 'libjxl' 'librsvg' 'libwebp' 'libxslt')
+makedepends=('git' 'gtk-doc')
+provides=('libchafa.so')
+source=(
+  "git+https://github.com/hpjansson/chafa.git#tag=$pkgver?signed"
+  "chafa-1.18.2-smolscale-avx2-alignment.patch"
+)
+sha512sums=('93e1a44e2e5ec655f65e9f2b85be44e407429621a6b14b37f6cdf1db5c686d78c3b1c12d7b45791e12127d174da47fd69d151bb539f72f4449a8671c75f0a3ad'
+            '4f09c1b2a9de80777f731c2fee1250cca6a3109d479f3074c59fa597135ffd91ac241db42ca3ce5d71986fe852a0937a76cf7b7ceed5bd43baa37fbbde633050')
+validpgpkeys=('C01EDE5BB0D91E26D003662EC76BB9FEEAD12EA7')  # Hans Petter Jansson
+
+prepare() {
+  cd "$pkgname"
+  # Fix Zen 4/5 AVX2 smolscale unaligned streaming load crash (hpjansson/chafa#347, hpjansson/chafa#350)
+  patch -Np1 -i "$srcdir/chafa-1.18.2-smolscale-avx2-alignment.patch"
+}
+
+build() {
+  cd "$pkgname"
+  ./autogen.sh --prefix=/usr --enable-man --enable-gtk-doc
+  make
+}
+
+check() {
+  cd "$pkgname"
+  make check
+}
+
+package() {
+  cd "$pkgname"
+  make DESTDIR="$pkgdir" install
+  make -C tools/completions PREFIX="$pkgdir"/usr/share install-zsh-completion install-fish-completion install-bash-completion
+}

--- a/chafa/chafa-1.18.2-smolscale-avx2-alignment.patch
+++ b/chafa/chafa-1.18.2-smolscale-avx2-alignment.patch
@@ -1,0 +1,171 @@
+diff --git a/chafa/internal/smolscale/smolscale-avx2.c b/chafa/internal/smolscale/smolscale-avx2.c
+index a7165b4..598c5ea 100644
+--- a/chafa/internal/smolscale/smolscale-avx2.c
++++ b/chafa/internal/smolscale/smolscale-avx2.c
+@@ -1134,7 +1134,7 @@ SMOL_REPACK_ROW_DEF (1234, 128, 64, PREMUL16,      COMPRESSED,
+     while (dest_row != dest_row_max)
+     {
+         uint64_t t [2];
+-        uint8_t alpha = src_row [1];
++        uint8_t alpha = src_row [1] >> 8;
+         unpremul_p16_to_u_128bpp (src_row, t, alpha);
+         t [1] = (t [1] & 0xffffffff00000000ULL) | alpha;
+         *(dest_row++) = t [0] >> 32;
+diff --git a/chafa/internal/smolscale/smolscale-private.h b/chafa/internal/smolscale/smolscale-private.h
+index 93f8aec..368d254 100644
+--- a/chafa/internal/smolscale/smolscale-private.h
++++ b/chafa/internal/smolscale/smolscale-private.h
+@@ -88,6 +88,12 @@ typedef unsigned int SmolBool;
+ 
+ #define SMOL_ALIGNMENT 64
+ 
++#ifdef _MSC_VER
++# define SMOL_ALIGN __declspec (align (SMOL_ALIGNMENT))
++#else
++# define SMOL_ALIGN __attribute__((aligned (SMOL_ALIGNMENT)))
++#endif
++
+ #ifdef SMOL_DISABLE_ASSUME_ALIGNED
+ # define SMOL_ASSIGN_ALIGNED_TO(x, t, n) (t) (x)
+ #else
+@@ -99,11 +105,26 @@ typedef unsigned int SmolBool;
+ #define SMOL_ASSUME_ALIGNED_TO(x, t, n) (x) = SMOL_ASSIGN_ALIGNED_TO ((x), t, (n))
+ #define SMOL_ASSUME_ALIGNED(x, t) SMOL_ASSUME_ALIGNED_TO ((x), t, SMOL_ALIGNMENT)
+ 
+-/* Pointer to beginning of storage is stored in *r. This must be passed to smol_free() later. */
+-#define smol_alloc_aligned_to(s, a, r) \
+-  ({ void *p; *(r) = _SMOL_ALLOC ((s) + (a)); p = (void *) (((uintptr_t) (*(r)) + (a)) & ~((a) - 1)); (p); })
+-#define smol_alloc_aligned(s, r) smol_alloc_aligned_to ((s), SMOL_ALIGNMENT, (r))
+-#define smol_free(p) _SMOL_FREE(p)
++/* Allocates size bytes aligned to at least the requested power-of-two
++ * alignment. The pointer to the beginning of the storage is stored in
++ * *storage_out; that pointer must be passed to free() later. On
++ * allocation failure, both the returned pointer and *storage_out are
++ * NULL. */
++static inline void *
++smol_alloc_aligned_to (size_t size, size_t alignment, void **storage_out)
++{
++    void *m = malloc (size + alignment - 1);
++
++    *storage_out = m;
++    return (void *) (((uintptr_t) m + alignment - 1) & ~((uintptr_t) alignment - 1));
++}
++
++static inline void *
++smol_alloc_aligned (size_t size, void **storage_out)
++{
++    return smol_alloc_aligned_to (size, SMOL_ALIGNMENT, storage_out);
++}
++#define smol_free(p) free(p)
+ 
+ typedef enum
+ {
+@@ -204,9 +225,9 @@ typedef struct
+ {
+     uint32_t src_ofs;
+     uint64_t *parts_row [4];
+-    uint64_t *row_storage [4];
++    void *row_storage [4];
+     uint32_t *src_aligned;
+-    uint32_t *src_aligned_storage;
++    void *src_aligned_storage;
+ }
+ SmolLocalCtx;
+ 
+@@ -336,6 +357,9 @@ struct SmolScaleCtx
+ {
+     /* <private> */
+ 
++    /* Actual start of this SmolScaleCtx' allocation, so we can align within */
++    void *self_storage;
++
+     const char *src_pixels;
+     char *dest_pixels;
+ 
+@@ -381,7 +405,7 @@ struct SmolScaleCtx
+     /* A batch of color pixels in dest storage format. The batch size
+      * is in bytes, and chosen as an even multiple of 3, allowing 32 bytes wide
+      * operations (e.g. AVX2) to be used to clear packed RGB pixels. */
+-    unsigned char color_pixels_clear_batch [SMOL_CLEAR_BATCH_SIZE];
++    SMOL_ALIGN unsigned char color_pixels_clear_batch [SMOL_CLEAR_BATCH_SIZE];
+ };
+ 
+ /* Number of pixels to convert per batch. For some conversions, we perform
+diff --git a/chafa/internal/smolscale/smolscale.c b/chafa/internal/smolscale/smolscale.c
+index a7c152a..b21b364 100644
+--- a/chafa/internal/smolscale/smolscale.c
++++ b/chafa/internal/smolscale/smolscale.c
+@@ -878,7 +878,7 @@ out:
+ static void
+ populate_clear_batch (SmolScaleCtx *scale_ctx)
+ {
+-    uint8_t dest_color [16];
++    SMOL_ALIGN uint8_t dest_color [16];
+     int pixel_stride;
+     int i;
+ 
+@@ -1235,6 +1235,22 @@ smol_scale_finalize (SmolScaleCtx *scale_ctx)
+     free (scale_ctx->precalc_storage);
+ }
+ 
++/* SmolScaleCtx must be aligned */
++static SmolScaleCtx *
++alloc_scale_ctx (void)
++{
++    SmolScaleCtx *scale_ctx;
++    void *storage;
++
++    scale_ctx = smol_alloc_aligned (sizeof (SmolScaleCtx), &storage);
++    if (!storage)
++        return NULL;
++
++    memset (scale_ctx, 0, sizeof (SmolScaleCtx));
++    scale_ctx->self_storage = storage;
++    return scale_ctx;
++}
++
+ /* ---------- *
+  * Public API *
+  * ---------- */
+@@ -1254,7 +1270,10 @@ smol_scale_new_simple (const void *src_pixels,
+ {
+     SmolScaleCtx *scale_ctx;
+ 
+-    scale_ctx = calloc (1,sizeof (SmolScaleCtx));
++    scale_ctx = alloc_scale_ctx ();
++    if (!scale_ctx)
++        return NULL;
++
+     smol_scale_init (scale_ctx,
+                      src_pixels,
+                      src_pixel_type,
+@@ -1292,7 +1311,7 @@ smol_scale_simple (const void *src_pixels,
+                    uint32_t dest_rowstride,
+                    SmolFlags flags)
+ {
+-    SmolScaleCtx scale_ctx = { 0 };
++    SMOL_ALIGN SmolScaleCtx scale_ctx = { 0 };
+     int first_row, n_rows;
+ 
+     smol_scale_init (&scale_ctx,
+@@ -1354,7 +1373,10 @@ smol_scale_new_full (const void *src_pixels,
+ {
+     SmolScaleCtx *scale_ctx;
+ 
+-    scale_ctx = calloc (1, sizeof (SmolScaleCtx));
++    scale_ctx = alloc_scale_ctx ();
++    if (!scale_ctx)
++        return NULL;
++
+     smol_scale_init (scale_ctx,
+                      src_pixels,
+                      src_pixel_type,
+@@ -1383,7 +1405,7 @@ void
+ smol_scale_destroy (SmolScaleCtx *scale_ctx)
+ {
+     smol_scale_finalize (scale_ctx);
+-    free (scale_ctx);
++    free (scale_ctx->self_storage);
+ }
+ 
+ void


### PR DESCRIPTION
### Summary

Adds the `chafa` packaging recipe with an isolated upstream backport patch resolving segmentation faults (`SIGSEGV` / `#GP(0)`) on AMD Zen 4 and Zen 5 microarchitectures when using AVX2-optimized builds (e.g. `cachyos-extra-znver4`).

Fixes CachyOS/distribution#548

### Root Cause & Upstream Resolution

1. **Root cause**: In `chafa` 1.18.2, `chafa/internal/smolscale/smolscale-avx2.c` uses `_mm256_stream_load_si256` (`vmovntdqa`), which requires 32-byte alignment of memory operands. The context (`SmolScaleCtx`) and clearing batch storage lacked proper alignment guarantees, leading to general protection faults on Zen 4/5 hardware under AVX2 streaming instructions.
2. **Upstream fixes**: Backported isolated fixes from upstream `hpjansson/chafa#347` and `hpjansson/chafa#350`:
   - `2a718853df5704ca6a730e9eba22142632192f93` (smolscale: Improve portability of our aligned malloc)
   - `0faeeb4fc478d86af4bee9dce21804c5a9bca4cc` (smolscale: Align the clearing batch storage properly)
   - `2925534eeddb1fc1f6995e3e9e7734b1f69a755a` (smolscale: Fix alpha extraction in premul16 with AVX2)
   - `3e22476b7db02b80efd128df6c1dcfd5bbf72242` (smolscale: Free the right pointer on error paths)

### Packaging & Verification

- **Patch application**: `chafa-1.18.2-smolscale-avx2-alignment.patch` applies cleanly and deterministically to upstream 1.18.2.
- **Build verification**: Clean package build with CachyOS znver4 optimization passed (`-march=znver4 -O3 -flto=auto`).
- **Test suite**: Local unit and integration tests passed (`canvas-test`, `term-info-test`, format suite, loader suite, etc.).
- **Hardware validation scope**: Local testing was performed on AMD Ryzen (Zen 3 / AVX2 host) and passed cleanly; Zen 5 runtime fault resolution is supported by upstream maintainer and reporter verification on Zen 5 silicon in upstream issues #347 and #350.