### PR TITLE
lenovolegionlinux: update to 0.0.22

### DIFF
--- a/lenovolegionlinux-dkms/.SRCINFO
+++ b/lenovolegionlinux-dkms/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lenovolegionlinux-dkms
 	pkgdesc = LenovoLegionLinux (LLL) DKMS module
-	pkgver = 0.0.20
+	pkgver = 0.0.22
 	pkgrel = 1
 	url = https://github.com/johnfanv2/LenovoLegionLinux
 	install = lenovolegionlinux.install

--- a/lenovolegionlinux-dkms/.SRCINFO
+++ b/lenovolegionlinux-dkms/.SRCINFO
@@ -12,7 +12,7 @@ pkgbase = lenovolegionlinux-dkms
 	makedepends = git
 	depends = dkms
 	depends = lenovolegionlinux
-	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git
+	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.22
 	sha256sums = SKIP
 
 pkgname = lenovolegionlinux-dkms

--- a/lenovolegionlinux-dkms/PKGBUILD
+++ b/lenovolegionlinux-dkms/PKGBUILD
@@ -20,7 +20,7 @@ depends=(
     dkms
     lenovolegionlinux
 )
-source=("${_pkgname}::git+https://github.com/johnfanv2/LenovoLegionLinux.git")
+source=("${_pkgname}::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v$pkgver")
 sha256sums=('SKIP')
 install="lenovolegionlinux.install"
 

--- a/lenovolegionlinux-dkms/PKGBUILD
+++ b/lenovolegionlinux-dkms/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=lenovolegionlinux-dkms
 _pkgname=lenovolegionlinux
-pkgver=0.0.20
+pkgver=0.0.22
 pkgrel=1
 pkgdesc="LenovoLegionLinux (LLL) DKMS module"
 arch=("x86_64")

--- a/lenovolegionlinux/.SRCINFO
+++ b/lenovolegionlinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lenovolegionlinux
 	pkgdesc = LenovoLegionLinux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. PLEASE READ THE REPO BEFORE INSTALL THIS PACKAGE!!!
-	pkgver = 0.0.20
+	pkgver = 0.0.22
 	pkgrel = 1
 	url = https://github.com/johnfanv2/LenovoLegionLinux
 	install = lenovolegionlinux.install
@@ -17,8 +17,9 @@ pkgbase = lenovolegionlinux
 	depends = python-pyqt6
 	depends = polkit
 	depends = python-darkdetect
+	depends = python-pillow
 	optdepends = lenovolegionlinux-dkms: DKMS module
-	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.20
-	sha256sums = 08bae6daef717a9b289bd1fffbef2e1ba52bb8588a7c0db015ad87a6e58f8aa7
+	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git
+	sha256sums = SKIP
 
 pkgname = lenovolegionlinux

--- a/lenovolegionlinux/.SRCINFO
+++ b/lenovolegionlinux/.SRCINFO
@@ -19,7 +19,7 @@ pkgbase = lenovolegionlinux
 	depends = python-darkdetect
 	depends = python-pillow
 	optdepends = lenovolegionlinux-dkms: DKMS module
-	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git
+	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.22
 	sha256sums = SKIP
 
 pkgname = lenovolegionlinux

--- a/lenovolegionlinux/PKGBUILD
+++ b/lenovolegionlinux/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: johnfanv2 <https://github.com/johnfanv2>
 
 pkgname=lenovolegionlinux
-pkgver=0.0.20
+pkgver=0.0.22
 pkgrel=1
 pkgdesc="LenovoLegionLinux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. PLEASE READ THE REPO BEFORE INSTALL THIS PACKAGE!!!"
 arch=("x86_64")
@@ -15,6 +15,7 @@ depends=(
   python-pyqt6
   polkit
   python-darkdetect
+  python-pillow
 )
 makedepends=(
   python-build

--- a/lenovolegionlinux/PKGBUILD
+++ b/lenovolegionlinux/PKGBUILD
@@ -29,7 +29,7 @@ optdepends=(
   "lenovolegionlinux-dkms: DKMS module"
 )
 
-source=(lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git)
+source=(lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v$pkgver)
 sha256sums=('SKIP')
 install="lenovolegionlinux.install"
 


### PR DESCRIPTION
## Summary

- Update `lenovolegionlinux` and `lenovolegionlinux-dkms` from `0.0.20` to `0.0.22`.
- Add the required `python-pillow` runtime dependency to `lenovolegionlinux`.
- Regenerate `.SRCINFO`; no patch or install-file changes.

## Validation

- Upstream annotated `v0.0.22` tag and source verified.
- Upstream metadata declares `Pillow`; the `python-pillow` dependency is therefore justified.
- Source fetching: PASS.
- `lenovolegionlinux` bounded package build: PASS.
- `lenovolegionlinux-dkms` bounded package build: PASS.
- PKGBUILD syntax, regenerated `.SRCINFO`, `namcap` PKGBUILD checks, and `git diff --check`: PASS.
- Package artifact inspection: PASS; the artifact contains the expected `/usr` and `/etc` paths and no temporary build-environment paths.
- Lenovo Legion hardware/runtime validation was not performed.

The artifact-level `namcap` scan reports existing packaging diagnostics outside this update’s scope, including the existing `libinih` runtime declaration and systemd path findings. No unrelated packaging changes are included.

Fixes #1688
