### PR TITLE
Update PKGBUILD for cachyos-gaming-meta removing lib32-mpg123

### DIFF
--- a/cachyos-gaming-meta/PKGBUILD
+++ b/cachyos-gaming-meta/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cachyos-gaming-meta
 pkgver=1.0.0
-pkgrel=8
+pkgrel=9
 epoch=1
 arch=(any)
 pkgdesc='Meta package for Gaming dependencies'
@@ -16,7 +16,6 @@ depends=(
   lib32-gtk3
   lib32-libjpeg-turbo
   lib32-libva
-  lib32-mpg123
   lib32-ocl-icd
   lib32-opencl-icd-loader
   libjpeg-turbo


### PR DESCRIPTION
Increment package release number from 8 to 9 and remove lib32-mpg123 from dependencies due to arch dropping it.