### PR TITLE
regenerate cachyos-gaming-meta .SRCINFO from PKGBUILD

### DIFF
--- a/cachyos-gaming-meta/.SRCINFO
+++ b/cachyos-gaming-meta/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-gaming-meta
 	pkgdesc = Meta package for Gaming dependencies
 	pkgver = 1.0.0
-	pkgrel = 8
+	pkgrel = 9
 	epoch = 1
 	arch = any
 	depends = alsa-plugins
@@ -12,7 +12,6 @@ pkgbase = cachyos-gaming-meta
 	depends = lib32-gtk3
 	depends = lib32-libjpeg-turbo
 	depends = lib32-libva
-	depends = lib32-mpg123
 	depends = lib32-ocl-icd
 	depends = lib32-opencl-icd-loader
 	depends = libjpeg-turbo


### PR DESCRIPTION
Fixes the missmatch .SRCINFO for cachyos-gaming-meta that was missed in the previous PR.