### PR TITLE
pacutils: preserve DisableSandbox compatibility

### DIFF
--- a/pacutils/0001-Add-support-for-pacman-7.1.0.patch
+++ b/pacutils/0001-Add-support-for-pacman-7.1.0.patch
@@ -4,130 +4,151 @@ Date: Mon, 10 Nov 2025 04:14:47 +0400
 Subject: [PATCH] Add support for pacman 7.1.0
 
 ---
- lib/pacutils/config.c | 22 +++++++++++++++-------
- lib/pacutils/config.h |  6 ++++--
- src/pacconf.c         |  9 ++++++---
- 3 files changed, 25 insertions(+), 12 deletions(-)
+ lib/pacutils/config.c | 36 +++++++++++++++++++++++++++++-------
+ lib/pacutils/config.h |  7 ++++++-
+ src/pacconf.c         | 14 ++++++++++++--
+ 3 files changed, 47 insertions(+), 10 deletions(-)
 
 diff --git a/lib/pacutils/config.c b/lib/pacutils/config.c
-index 9f306a0..99290b0 100644
+index 9f306a0..056c63a 100644
 --- a/lib/pacutils/config.c
 +++ b/lib/pacutils/config.c
-@@ -56,7 +56,8 @@ struct _pu_config_setting {
+@@ -56,8 +56,11 @@ struct _pu_config_setting {
    {"DisableDownloadTimeout", PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT},
    {"ParallelDownloads",      PU_CONFIG_OPTION_PARALLELDOWNLOADS},
  
 -  {"DisableSandbox", PU_CONFIG_OPTION_DISABLESANDBOX},
+-  {"DownloadUser",   PU_CONFIG_OPTION_DOWNLOADUSER},
++  {"DisableSandbox",           PU_CONFIG_OPTION_DISABLESANDBOX},
 +  {"DisableSandboxFilesystem", PU_CONFIG_OPTION_DISABLESANDBOXFILESYSTEM},
-+  {"DisableSandboxSyscalls", PU_CONFIG_OPTION_DISABLESANDBOXSYSCALLS},
-   {"DownloadUser",   PU_CONFIG_OPTION_DOWNLOADUSER},
- 
++  {"DisableSandboxSyscalls",   PU_CONFIG_OPTION_DISABLESANDBOXSYSCALLS},
++  {"DisableSandboxNetwork",    PU_CONFIG_OPTION_DISABLESANDBOXNETWORK},
++  {"DownloadUser",             PU_CONFIG_OPTION_DOWNLOADUSER},
+
    {"SigLevel",        PU_CONFIG_OPTION_SIGLEVEL},
-@@ -268,7 +269,8 @@ pu_config_t *pu_config_new(void) {
+   {"LocalFileSigLevel",  PU_CONFIG_OPTION_LOCAL_SIGLEVEL},
+@@ -268,7 +271,9 @@ pu_config_t *pu_config_new(void) {
    config->color = PU_CONFIG_BOOL_UNSET;
    config->noprogressbar = PU_CONFIG_BOOL_UNSET;
    config->disabledownloadtimeout = PU_CONFIG_BOOL_UNSET;
 -  config->disablesandbox = PU_CONFIG_BOOL_UNSET;
 +  config->disablesandboxfilesystem = PU_CONFIG_BOOL_UNSET;
 +  config->disablesandboxsyscalls = PU_CONFIG_BOOL_UNSET;
++  config->disablesandboxnetwork = PU_CONFIG_BOOL_UNSET;
    config->ilovecandy = PU_CONFIG_BOOL_UNSET;
    config->usesyslog = PU_CONFIG_BOOL_UNSET;
    config->verbosepkglists = PU_CONFIG_BOOL_UNSET;
-@@ -393,7 +395,8 @@ alpm_handle_t *pu_initialize_handle_from_config(pu_config_t *config) {
+@@ -393,7 +398,9 @@ alpm_handle_t *pu_initialize_handle_from_config(pu_config_t *config) {
    alpm_option_set_architectures(handle, config->architectures);
    alpm_option_set_disable_dl_timeout(handle, config->disabledownloadtimeout);
  
 -  alpm_option_set_disable_sandbox(handle, config->disablesandbox);
 +  alpm_option_set_disable_sandbox_filesystem(handle, config->disablesandboxfilesystem);
 +  alpm_option_set_disable_sandbox_syscalls(handle, config->disablesandboxsyscalls);
++  alpm_option_set_disable_sandbox_network(handle, config->disablesandboxnetwork);
    alpm_option_set_sandboxuser(handle, config->downloaduser);
  
    alpm_option_set_default_siglevel(handle, config->siglevel);
-@@ -526,7 +529,8 @@ int pu_config_resolve(pu_config_t *config) {
+@@ -526,7 +533,9 @@ int pu_config_resolve(pu_config_t *config) {
    SETBOOL(config->color);
    SETBOOL(config->noprogressbar);
    SETBOOL(config->disabledownloadtimeout);
 -  SETBOOL(config->disablesandbox);
 +  SETBOOL(config->disablesandboxfilesystem);
 +  SETBOOL(config->disablesandboxsyscalls);
++  SETBOOL(config->disablesandboxnetwork);
    SETBOOL(config->ilovecandy);
    SETBOOL(config->usesyslog);
    SETBOOL(config->verbosepkglists);
-@@ -571,7 +575,8 @@ void pu_config_merge(pu_config_t *dest, pu_config_t *src) {
+@@ -571,7 +580,9 @@ void pu_config_merge(pu_config_t *dest, pu_config_t *src) {
    MERGEBOOL(dest->noprogressbar, src->noprogressbar);
    MERGEBOOL(dest->ilovecandy, src->ilovecandy);
    MERGEBOOL(dest->disabledownloadtimeout, src->disabledownloadtimeout);
 -  MERGEBOOL(dest->disablesandbox, src->disablesandbox);
 +  MERGEBOOL(dest->disablesandboxfilesystem, src->disablesandboxfilesystem);
 +  MERGEBOOL(dest->disablesandboxsyscalls, src->disablesandboxsyscalls);
++  MERGEBOOL(dest->disablesandboxnetwork, src->disablesandboxnetwork);
  
    MERGEVAL(dest->cleanmethod, src->cleanmethod);
    MERGEVAL(dest->paralleldownloads, src->paralleldownloads);
-@@ -905,8 +910,11 @@ int pu_config_reader_next(pu_config_reader_t *reader) {
-         case PU_CONFIG_OPTION_DISABLEDOWNLOADTIMEOUT:
+@@ -906,7 +917,18 @@ int pu_config_reader_next(pu_config_reader_t *reader) {
            config->disabledownloadtimeout = 1;
            break;
 -        case PU_CONFIG_OPTION_DISABLESANDBOX:
 -          config->disablesandbox = 1;
++        case PU_CONFIG_OPTION_DISABLESANDBOX:
++          config->disablesandboxfilesystem = 1;
++          config->disablesandboxsyscalls = 1;
++          config->disablesandboxnetwork = 1;
++          break;
 +        case PU_CONFIG_OPTION_DISABLESANDBOXFILESYSTEM:
 +          config->disablesandboxfilesystem = 1;
 +          break;
 +        case PU_CONFIG_OPTION_DISABLESANDBOXSYSCALLS:
 +          config->disablesandboxsyscalls = 1;
++          break;
++        case PU_CONFIG_OPTION_DISABLESANDBOXNETWORK:
++          config->disablesandboxnetwork = 1;
            break;
          default:
            reader->status = PU_CONFIG_READER_STATUS_UNKNOWN_OPTION;
 diff --git a/lib/pacutils/config.h b/lib/pacutils/config.h
-index 3a6d631..8fde02d 100644
+index 3a6d631..6983126 100644
 --- a/lib/pacutils/config.h
 +++ b/lib/pacutils/config.h
-@@ -64,7 +64,8 @@ typedef enum pu_config_option_t {
-   PU_CONFIG_OPTION_USAGE,
+@@ -65,6 +65,9 @@ typedef enum pu_config_option_t {
  
    PU_CONFIG_OPTION_DOWNLOADUSER,
--  PU_CONFIG_OPTION_DISABLESANDBOX,
+   PU_CONFIG_OPTION_DISABLESANDBOX,
 +  PU_CONFIG_OPTION_DISABLESANDBOXFILESYSTEM,
 +  PU_CONFIG_OPTION_DISABLESANDBOXSYSCALLS,
++  PU_CONFIG_OPTION_DISABLESANDBOXNETWORK,
  
    PU_CONFIG_OPTION_INCLUDE
  } pu_config_option_t;
-@@ -98,7 +99,8 @@ typedef struct pu_config_t {
+@@ -98,7 +101,9 @@ typedef struct pu_config_t {
    pu_config_bool_t usesyslog;
    pu_config_bool_t verbosepkglists;
    pu_config_bool_t disabledownloadtimeout;
 -  pu_config_bool_t disablesandbox;
 +  pu_config_bool_t disablesandboxfilesystem;
 +  pu_config_bool_t disablesandboxsyscalls;
++  pu_config_bool_t disablesandboxnetwork;
  
    pu_config_bool_t prettyprogressbar;
  
 diff --git a/src/pacconf.c b/src/pacconf.c
-index 15483ce..ec37d69 100644
+index 15483ce..a3b9e7a 100644
 --- a/src/pacconf.c
 +++ b/src/pacconf.c
-@@ -303,7 +303,8 @@ void dump_options(void) {
+@@ -303,7 +303,9 @@ void dump_options(void) {
  
    show_str("XferCommand", config->xfercommand);
    show_str("DownloadUser", config->downloaduser);
 -  show_bool("DisableSandbox", config->disablesandbox);
 +  show_bool("DisableSandboxFilesystem", config->disablesandboxfilesystem);
 +  show_bool("DisableSandboxSyscalls", config->disablesandboxsyscalls);
++  show_bool("DisableSandboxNetwork", config->disablesandboxnetwork);
  
    show_bool("UseSyslog", config->usesyslog);
    show_bool("Color", config->color);
-@@ -436,8 +437,10 @@ int list_directives(alpm_list_t *directives) {
-       show_bool("VerbosePkgLists", config->verbosepkglists);
+@@ -437,7 +439,15 @@ int list_directives(alpm_list_t *directives) {
      } else if (strcasecmp(i->data, "DisableDownloadTimeout") == 0) {
        show_bool("DisableDownloadTimeout", config->disabledownloadtimeout);
 -    } else if (strcasecmp(i->data, "DisableSandbox") == 0) {
 -      show_bool("DisableSandbox", config->disablesandbox);
++    } else if (strcasecmp(i->data, "DisableSandbox") == 0) {
++      show_bool("DisableSandboxFilesystem", config->disablesandboxfilesystem);
++      show_bool("DisableSandboxSyscalls", config->disablesandboxsyscalls);
++      show_bool("DisableSandboxNetwork", config->disablesandboxnetwork);
 +    } else if (strcasecmp(i->data, "DisableSandboxFilesystem") == 0) {
 +      show_bool("DisableSandboxFilesystem", config->disablesandboxfilesystem);
 +    } else if (strcasecmp(i->data, "DisableSandboxSyscalls") == 0) {
 +      show_bool("DisableSandboxSyscalls", config->disablesandboxsyscalls);
++    } else if (strcasecmp(i->data, "DisableSandboxNetwork") == 0) {
++      show_bool("DisableSandboxNetwork", config->disablesandboxnetwork);
  
      } else if (strcasecmp(i->data, "CleanMethod") == 0) {
        show_cleanmethod("CleanMethod", config->cleanmethod);
 -- 
 2.51.2
-

--- a/pacutils/PKGBUILD
+++ b/pacutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pacutils
 pkgver=0.15.0
-pkgrel=3
+pkgrel=4
 pkgdesc='Helper tools for libalpm'
 url='https://github.com/andrewgregory/pacutils'
 arch=('x86_64')
@@ -20,7 +20,7 @@ source=("git+https://github.com/andrewgregory/pacutils.git?signed#tag=v${pkgver}
         0001-Add-support-for-pacman-7.1.0.patch)
 sha256sums=('789b1ce9dfa6e6d6e0495651019cba121defa75eec598a63745c910de3371ac5'
             '8b1bc6f26b53f584d94cf323e654942a38a87dc99fc97a715df0e7eb1d92ace4'
-            '54eead8b4c633aaf2c152be1c46c07bae929c87402633ce2ddaa0b7faf296f74')
+            'a58ea6a7cb141a11419300d583a8f4238877527cea00ff7373b92f552e2ff851')
 validpgpkeys=('0016846EDD8432261C62CB63DF3891463C352040')
 
 prepare() {


### PR DESCRIPTION
## Summary

- retain pacman's `DisableSandbox` compatibility alias
- add the missing `DisableSandboxNetwork` state and libalpm accessor
- keep the filesystem, syscall, and network directives independent
- bump pkgrel for the rebuilt package

`DisableSandbox` remains equivalent to enabling all three fine-grained disable flags, matching CachyOS pacman's parser and `pacman-conf` output. This also removes the false unknown-option warning emitted by pacutils 0.15.0-3.

## Testing

- built `pacutils 0.15.0-4` against `pacman 7.1.0.r9.g54d9411-4` in a clean Arch container
- upstream `make check`: 16 files, 370 tests, PASS
- verified the singular alias reports Filesystem, Syscalls, and Network with no warning
- verified each fine-grained directive reports only itself
- verified a config containing `DisableSandbox` parses without warnings
- verified this patch applies with `--fuzz=0` after the existing PrettyProgressBar patch