### PR TITLE
cachyos-mirrorlist: add US East (mirror.lug.umbc.edu) mirror

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -124,3 +124,6 @@ Server = https://mirror.bali0531.hu/repo/$arch/$repo
 ## UK mirror on c48.uk by wilbur
 ## tier=2 code=GB
 Server = https://repo.c48.uk/cachyos/repo/$arch/$repo
+## US East mirror provided by UMBC LUG (University)
+## tier=2 code=US
+Server = https://mirror.lug.umbc.edu/cachyos/repo/$arch/$repo


### PR DESCRIPTION
I manage the following mirror for my University's LUG

We are syncing CachyOS every 2 hours from rsync://ca.mirror.cx/cachyos/

Accessible at:
https://mirror.lug.umbc.edu/cachyos

We would also be interested in becoming a Tier 1 Mirror.