### PR TITLE
cachyos-mirrorlist: enable limda mirror

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -75,9 +75,8 @@ Server = https://cachyos.next-works.it/repo/$arch/$repo
 ## tier=2 code=IT
 Server = https://cachyos-mirror.m1k.cloud/repo/$arch/$repo
 ## Bangladesh 10 GBs much thanks to Limda!
-## Disabled due slow sync
 ## tier=2 code=BD
-# Server = https://mirror.limda.net/cachy/repo/$arch/$repo
+Server = https://mirror.limda.net/cachy/repo/$arch/$repo
 ## Finland Mirror much thanks to doridian!
 ## tier=2 code=FI
 Server = https://cachyos.doridian.net/repo/$arch/$repo


### PR DESCRIPTION
This commit enables Limda Host mirror. The mirror is syncing regularly.
Status can be found : https://mirror.limda.net/status/#syncing-status