### PR TITLE
handheld: update gamescope to 3.16.28

### DIFF
--- a/handheld/gamescope/.SRCINFO
+++ b/handheld/gamescope/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = gamescope
 	pkgdesc = SteamOS session compositing window manager
-	pkgver = 3.16.25
+	pkgver = 3.16.28
 	pkgrel = 1
 	url = https://github.com/ValveSoftware/gamescope
 	arch = x86_64
@@ -52,7 +52,7 @@ pkgbase = gamescope
 	depends = xcb-util-wm
 	depends = xorg-server-xwayland
 	replaces = gamescope-plus
-	source = git+https://github.com/ValveSoftware/gamescope.git#tag=3.16.25
+	source = git+https://github.com/ValveSoftware/gamescope.git#tag=3.16.28
 	source = git+https://gitlab.freedesktop.org/emersion/libdisplay-info.git
 	source = git+https://gitlab.freedesktop.org/emersion/libliftoff.git
 	source = git+https://github.com/ValveSoftware/openvr.git
@@ -60,7 +60,7 @@ pkgbase = gamescope
 	source = git+https://github.com/KhronosGroup/SPIRV-Headers.git
 	source = git+https://github.com/Joshua-Ashton/vkroots.git
 	source = git+https://gitlab.freedesktop.org/wlroots/wlroots.git
-	b2sums = 71a287bf0327941b5fd4e4878b1514dbcf82c016b337f7f4298a7dfb54780d8678e7c3fda598ce3e15161a7af0a52e6889403104d632c0921a4256b75420f297
+	b2sums = f78220d752626a25625ddde5601c51d8795a1a54075e3cd8c9884d7cbe549902d4ad9bb58afd632dabd3003e263e134d86116ccc103654219ee15a048f31678f
 	b2sums = SKIP
 	b2sums = SKIP
 	b2sums = SKIP

--- a/handheld/gamescope/PKGBUILD
+++ b/handheld/gamescope/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: PedroHLC <root@pedrohlc.com>
 
 pkgname=gamescope
-pkgver=3.16.25
+pkgver=3.16.28
 pkgrel=1
 pkgdesc='SteamOS session compositing window manager'
 arch=(x86_64)
@@ -73,7 +73,7 @@ source=(
   git+https://github.com/Joshua-Ashton/vkroots.git
   git+https://gitlab.freedesktop.org/wlroots/wlroots.git
 )
-b2sums=('71a287bf0327941b5fd4e4878b1514dbcf82c016b337f7f4298a7dfb54780d8678e7c3fda598ce3e15161a7af0a52e6889403104d632c0921a4256b75420f297'
+b2sums=('f78220d752626a25625ddde5601c51d8795a1a54075e3cd8c9884d7cbe549902d4ad9bb58afd632dabd3003e263e134d86116ccc103654219ee15a048f31678f'
         'SKIP'
         'SKIP'
         'SKIP'


### PR DESCRIPTION
## Summary
Update gamescope to upstream release 3.16.28.

## Changes
- Bump handheld/gamescope from 3.16.25 to 3.16.28.
- Refresh the gamescope source tag and b2 checksum.
- Regenerate the matching .SRCINFO metadata.

## Validation
- makepkg --verifysource
- makepkg --printsrcinfo matches .SRCINFO
- namcap PKGBUILD
- git diff --check

Fixes #1775