### PR TITLE
handheld: update steamdeck-dsp to 1.02

### DIFF
--- a/handheld/steamdeck-dsp/.SRCINFO
+++ b/handheld/steamdeck-dsp/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = steamdeck-dsp
 	pkgdesc = Steamdeck Audio Processing
-	pkgver = 1.01
+	pkgver = 1.02
 	pkgrel = 1
 	url = https://github.com/evlaV/valve-hardware-audio-processing
 	arch = any
@@ -16,7 +16,7 @@ pkgbase = steamdeck-dsp
 	makedepends = linux-api-headers
 	makedepends = qt5-base
 	depends = pipewire
-	source = git+https://github.com/evlaV/valve-hardware-audio-processing.git#tag=1.01
-	sha512sums = b31ab1d85fc25529f3e734568a48b9bd4533d96496eae31311e92d7c474118f5e22a9b4aa617207c75ce9475df52fbfb02c359d664f39dcaa41ee3f9386b761d
+	source = git+https://github.com/evlaV/valve-hardware-audio-processing.git#tag=1.02
+	sha512sums = 76b5d3dbf98879f5bde2855dfc162ba99c42383784fe4386c99671ab58ec61f2b0fc21ad75139af4177823878c9f8471c8d3dcbbd8156d49f3f2af6d424e566a
 
 pkgname = steamdeck-dsp

--- a/handheld/steamdeck-dsp/PKGBUILD
+++ b/handheld/steamdeck-dsp/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer Ethan Geller (ethang@valvesoftware.com)
 
 pkgname=steamdeck-dsp
-pkgver=1.01
+pkgver=1.02
 pkgrel=1
 arch=('any')
 url="https://github.com/evlaV/valve-hardware-audio-processing"
@@ -10,7 +10,7 @@ license=('GPL-2.0-or-later')
 depends=('pipewire')
 makedepends=('git' 'openssh' 'base-devel' 'glibc' 'faust' 'ladspa' 'lv2' 'boost' 'linux-api-headers' 'qt5-base')
 source=("git+https://github.com/evlaV/valve-hardware-audio-processing.git#tag=${pkgver}")
-sha512sums=('b31ab1d85fc25529f3e734568a48b9bd4533d96496eae31311e92d7c474118f5e22a9b4aa617207c75ce9475df52fbfb02c359d664f39dcaa41ee3f9386b761d')
+sha512sums=('76b5d3dbf98879f5bde2855dfc162ba99c42383784fe4386c99671ab58ec61f2b0fc21ad75139af4177823878c9f8471c8d3dcbbd8156d49f3f2af6d424e566a')
 
 build() {
   cd valve-hardware-audio-processing


### PR DESCRIPTION
## Summary
Update steamdeck-dsp to upstream release 1.02.

## Changes
- Bump handheld/steamdeck-dsp from 1.01 to 1.02.
- Refresh the source tag and sha512 checksum.
- Regenerate the matching .SRCINFO metadata.

## Validation
- makepkg --verifysource
- makepkg --printsrcinfo matches .SRCINFO
- namcap PKGBUILD (pre-existing Missing Maintainer tag warning)
- git diff --check

Fixes #1778