### PR TITLE
gcc: preserve standard target-prefixed compatibility names

### DIFF
--- a/toolchain/gcc/PKGBUILD
+++ b/toolchain/gcc/PKGBUILD
@@ -409,7 +409,7 @@ package_gcc() {
   # create cc-rs compatible symlinks
   # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
   for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
-    ln -s /usr/bin/"$binary" "$pkgdir"/usr/bin/$CARCH-linux-gnu-"$binary"
+    ln -s /usr/bin/"$binary" "$pkgdir"/usr/bin/${CARCH%_v[34]}-linux-gnu-"$binary"
   done
 
   # POSIX conformance launcher scripts for c89 and c99


### PR DESCRIPTION
CachyOS-v3 and CachyOS-v4 GCC packages currently derive compatibility
symlink names from `$CARCH`, which produces names such as
`x86_64_v4-linux-gnu-gcc`.

These names are non-standard and differ from the ordinary Arch/GCC target
prefix expected by build systems and packages.

Normalize only the compatibility-link prefix by stripping the CachyOS
optimization suffix from `x86_64_v3` / `x86_64_v4`, while leaving the actual
GCC build configuration unchanged.

This makes ordinary, v3, and v4 builds expose the standard
`x86_64-linux-gnu-*` compatibility names.

Fixes CachyOS/distribution#555

Validation:
- `bash -n toolchain/gcc/PKGBUILD`
- `git diff --check`
- `makepkg --printsrcinfo --dir toolchain/gcc`
- shell expansion check for `x86_64`, `x86_64_v3`, and `x86_64_v4`
- `namcap toolchain/gcc/PKGBUILD`

A full GCC rebuild was not run because this change only affects packaging-time
compatibility link names; the current live v4 package file list was inspected
to confirm the broken names.
