### PR TITLE
nodejs: update to 26.8.1

### DIFF
--- a/nodejs/.SRCINFO
+++ b/nodejs/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nodejs
 	pkgdesc = Evented I/O for V8 javascript ("Current" release)
-	pkgver = 26.7.0
+	pkgver = 26.8.1
 	pkgrel = 2
 	url = https://nodejs.org/
 	arch = x86_64
@@ -23,13 +23,13 @@ pkgbase = nodejs
 	depends = zlib
 	depends = zstd
 	optdepends = npm: nodejs package manager
-	source = git+https://github.com/nodejs/node.git#tag=v26.7.0?signed
+	source = git+https://github.com/nodejs/node.git#tag=v26.8.1?signed
 	validpgpkeys = 8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600
 	validpgpkeys = 890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4
 	validpgpkeys = C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C
 	validpgpkeys = C0D6248439F1D5604AAFFB4021D900FFDB233756
 	validpgpkeys = 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356
 	validpgpkeys = 108F52B48DB57BB0CC439B2997B01419BD92F80A
-	sha512sums = 73b6c236d41ada03af22d0e5526bcad38516f4d300b51673b02f39002e9cb69d06cf935d67ec121fd75a50fc9944c8b2ee0a726ef16c3c438be5420664310b8e
+	sha512sums = a77b026bd2cc84f948d8bbf5b16e3d3c2da3ff4b7676051991b3528965901b51a6bbc930c51120a04855ea7a0f463725781dc69fa4042ace24bb2a9cf08da45a
 
 pkgname = nodejs

--- a/nodejs/PKGBUILD
+++ b/nodejs/PKGBUILD
@@ -9,7 +9,7 @@
 # Contributor: TIanyi Cui <tianyicui@gmail.com>
 
 pkgname=nodejs
-pkgver=26.7.0
+pkgver=26.8.1
 pkgrel=2
 pkgdesc='Evented I/O for V8 javascript ("Current" release)'
 arch=('x86_64')
@@ -42,7 +42,7 @@ makedepends=(
 optdepends=('npm: nodejs package manager')
 source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed")
 
-sha512sums=('73b6c236d41ada03af22d0e5526bcad38516f4d300b51673b02f39002e9cb69d06cf935d67ec121fd75a50fc9944c8b2ee0a726ef16c3c438be5420664310b8e')
+sha512sums=('a77b026bd2cc84f948d8bbf5b16e3d3c2da3ff4b7676051991b3528965901b51a6bbc930c51120a04855ea7a0f463725781dc69fa4042ace24bb2a9cf08da45a')
 validpgpkeys=(
   '8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600' # Michaël Zasso (Targos) <targos@protonmail.com>
   '890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4' # RafaelGSS <rafael.nunu@hotmail.com>


### PR DESCRIPTION
Node.js 26.8.1 is now available upstream while the CachyOS package is still pinned to 26.7.0.

This updates:
- `pkgver` to 26.8.1
- the signed source tag/checksum
- regenerated `.SRCINFO`

No dependencies, build flags, or unrelated packaging behavior are changed.

Fixes #1773

Validation:
- `bash -n nodejs/PKGBUILD`
- `namcap nodejs/PKGBUILD`
- regenerated `.SRCINFO` matches `makepkg --printsrcinfo`
- `git diff --check`
- upstream signed tag `v26.8.1` verified
- checksum cross-checked against current authoritative Arch Linux nodejs packaging metadata

A full package build was not run during the bounded validation pass because refreshing the large Node.js Git source cache stalled; no build result is claimed.