### PR TITLE
ci: validate PR PKGBUILDs from merge base

### DIFF
--- a/.github/scripts/validate-pkgbuilds.js
+++ b/.github/scripts/validate-pkgbuilds.js
@@ -7,7 +7,7 @@ const pkgbuildsDir = join(import.meta.dir, "..", "..");
 
 async function getChangedPkgbuilds() {
   const { stdout } =
-    await $`git diff --diff-filter=d --name-only ${process.env.BASE_REF} ${process.env.HEAD_REF} "*/PKGBUILD"`
+    await $`git diff --diff-filter=d --name-only ${process.env.BASE_REF}...${process.env.HEAD_REF} "*/PKGBUILD"`
       .nothrow()
       .quiet();
 


### PR DESCRIPTION
PR validation currently compares the base and head trees directly when determining which PKGBUILDs changed.

If the target branch advances after a contributor branch diverges, that comparison also includes PKGBUILDs changed only on the target branch. This can cause unrelated packages to be validated and fail the PR.

Use Git's three-dot diff syntax so changed PKGBUILDs are selected from the merge base to the PR head, matching the effective PR delta.

This was reproduced on #1786:
- direct base/head comparison selected 7 PKGBUILDs
- merge-base comparison selected only the intended Node.js PKGBUILD

The workflow already checks out full history (`fetch-depth: 0`), so the merge base is available.

Validation:
- `node --check .github/scripts/validate-pkgbuilds.js`
- `git diff --check`
- stale-branch reproduction
- fresh/rebased/deleted/renamed PKGBUILD cases