### PR TITLE
winboat: update to 0.9.2

### DIFF
--- a/winboat/.SRCINFO
+++ b/winboat/.SRCINFO
@@ -1,11 +1,10 @@
 pkgbase = winboat
 	pkgdesc = Run Windows apps on Linux with seamless integration
-	pkgver = 0.9.0
-	pkgrel = 8
+	pkgver = 0.9.2
+	pkgrel = 1
 	url = https://www.winboat.app
 	arch = x86_64
 	license = MIT
-	makedepends = git
 	makedepends = libxcrypt-compat
 	makedepends = npm
 	makedepends = go
@@ -18,9 +17,9 @@ pkgbase = winboat
 	optdepends = docker: To use docker as a container runtime
 	optdepends = podman-compose: To use podman as a container runtime
 	options = !strip
-	source = git+https://github.com/TibixDev/winboat.git#tag=v0.9.0
+	source = winboat-0.9.2.tar.gz::https://github.com/winboat-org/winboat/archive/refs/tags/v0.9.2.tar.gz
 	source = winboat.install
-	sha256sums = 11051ae91c399ccc75ef69910d4e8a526f6cc50210f9c70525829d5017715cce
+	sha256sums = 8db3e1c2ed196ef0ef7c9e4c15b9557db46ee2840e870ec77e4e1ad8f30d3e82
 	sha256sums = 28a16c9651a8283793d4ed0f8a8358ada22a467cd1a1a4ed091eb6a9674da41d
 
 pkgname = winboat

--- a/winboat/.nvchecker.toml
+++ b/winboat/.nvchecker.toml
@@ -1,5 +1,5 @@
 [winboat]
 source = "github"
-github = "TibixDev/winboat"
+github = "winboat-org/winboat"
 use_latest_release = true
 prefix = "v"

--- a/winboat/PKGBUILD
+++ b/winboat/PKGBUILD
@@ -1,7 +1,8 @@
 # Maintainer: Matt Quintanilla <matt @ matt quintanilla .xyz>
 pkgname=winboat
-pkgver=0.9.0
-pkgrel=9
+pkgver=0.9.2
+pkgrel=1
+_commit=ce73d18
 pkgdesc="Run Windows apps on Linux with seamless integration"
 arch=('x86_64')
 url="https://www.winboat.app"
@@ -13,7 +14,6 @@ depends=(
   'nss'
 )
 makedepends=(
-  'git'
   'libxcrypt-compat'
   'npm'
   'go'
@@ -22,15 +22,22 @@ makedepends=(
 )
 optdepends=('docker: To use docker as a container runtime' 'podman-compose: To use podman as a container runtime')
 options=('!strip')
-source=("git+https://github.com/TibixDev/winboat.git#tag=v$pkgver" "winboat.install")
-sha256sums=('11051ae91c399ccc75ef69910d4e8a526f6cc50210f9c70525829d5017715cce'
+source=("$pkgname-$pkgver.tar.gz::https://github.com/winboat-org/winboat/archive/refs/tags/v$pkgver.tar.gz"
+        "winboat.install")
+sha256sums=('8db3e1c2ed196ef0ef7c9e4c15b9557db46ee2840e870ec77e4e1ad8f30d3e82'
             '28a16c9651a8283793d4ed0f8a8358ada22a467cd1a1a4ed091eb6a9674da41d')
-prepare(){
-cd "$pkgname"
-sed -i 's/"rpm",//g' electron-builder.json
+
+prepare() {
+  cd "$pkgname-$pkgver"
+  # rpm target needs rpm tooling that is not available in the build environment
+  sed -i 's/"rpm",//g' electron-builder.json
+  # the guest server build script derives the commit hash from git, which is
+  # unavailable when building from a release tarball
+  sed -i "s|\$(git rev-parse --short HEAD)|$_commit|" build-guest-server.sh
 }
+
 build() {
-  cd "$pkgname"
+  cd "$pkgname-$pkgver"
   export npm_config_cache="$srcdir/npm_cache"
   export GOPATH="$srcdir/gopath"
   export CGO_CPPFLAGS="${CPPFLAGS}"
@@ -46,7 +53,7 @@ build() {
 }
 
 package() {
-  cd "$pkgname"
+  cd "$pkgname-$pkgver"
   install -d "$pkgdir/opt/$pkgname/"
   cp -a dist/linux-unpacked/* "$pkgdir/opt/$pkgname/"
 


### PR DESCRIPTION
Updates `winboat` from 0.9.0 to [0.9.2](https://github.com/winboat-org/winboat/releases/tag/v0.9.2), and switches the source to the official `winboat-org/winboat` release.

Changes:
- Build from the `winboat-org/winboat` v0.9.2 release source tarball (`archive/refs/tags/v0.9.2.tar.gz`) instead of the old `TibixDev/winboat` git checkout
- `pkgver` -> `0.9.2`, `pkgrel` -> `1`; `sha256sums` verified with `makepkg -g`
- Patch `build-guest-server.sh` in `prepare()` to use the release commit hash (`ce73d18`) since git metadata is unavailable in a release tarball
- Drop the now-unused `git` makedepend
- Point `.nvchecker.toml` at `winboat-org/winboat`
- Regenerate `.SRCINFO`

Source extraction and `prepare()` verified locally; a full package build was not run in this environment (no `go`/`zip` available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)