### PR TITLE
bump lenovolegionlinux to 0.0.25

### DIFF
--- a/lenovolegionlinux-dkms/.SRCINFO
+++ b/lenovolegionlinux-dkms/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lenovolegionlinux-dkms
 	pkgdesc = LenovoLegionLinux (LLL) DKMS module
-	pkgver = 0.0.22
+	pkgver = 0.0.25
 	pkgrel = 1
 	url = https://github.com/johnfanv2/LenovoLegionLinux
 	install = lenovolegionlinux.install
@@ -12,7 +12,7 @@ pkgbase = lenovolegionlinux-dkms
 	makedepends = git
 	depends = dkms
 	depends = lenovolegionlinux
-	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.22
+	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.25
 	sha256sums = SKIP
 
 pkgname = lenovolegionlinux-dkms

--- a/lenovolegionlinux-dkms/PKGBUILD
+++ b/lenovolegionlinux-dkms/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=lenovolegionlinux-dkms
 _pkgname=lenovolegionlinux
-pkgver=0.0.22
+pkgver=0.0.25
 pkgrel=1
 pkgdesc="LenovoLegionLinux (LLL) DKMS module"
 arch=("x86_64")

--- a/lenovolegionlinux/.SRCINFO
+++ b/lenovolegionlinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lenovolegionlinux
 	pkgdesc = LenovoLegionLinux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. PLEASE READ THE REPO BEFORE INSTALL THIS PACKAGE!!!
-	pkgver = 0.0.22
+	pkgver = 0.0.25
 	pkgrel = 1
 	url = https://github.com/johnfanv2/LenovoLegionLinux
 	install = lenovolegionlinux.install
@@ -19,7 +19,7 @@ pkgbase = lenovolegionlinux
 	depends = python-darkdetect
 	depends = python-pillow
 	optdepends = lenovolegionlinux-dkms: DKMS module
-	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.22
+	source = lenovolegionlinux::git+https://github.com/johnfanv2/LenovoLegionLinux.git#tag=v0.0.25
 	sha256sums = SKIP
 
 pkgname = lenovolegionlinux

--- a/lenovolegionlinux/PKGBUILD
+++ b/lenovolegionlinux/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: johnfanv2 <https://github.com/johnfanv2>
 
 pkgname=lenovolegionlinux
-pkgver=0.0.22
+pkgver=0.0.25
 pkgrel=1
 pkgdesc="LenovoLegionLinux (LLL) brings additional drivers and tools for Lenovo Legion series laptops to Linux. PLEASE READ THE REPO BEFORE INSTALL THIS PACKAGE!!!"
 arch=("x86_64")


### PR DESCRIPTION
Bump `lenovolegionlinux` and `lenovolegionlinux-dkms` to upstream **v0.0.25** (released Sep 7, 2026).

The package is currently stuck at 0.0.22. The `.nvchecker.toml` should have detected v0.0.25 already, but the PKGBUILDs were never regenerated since Aug 27.

**Changes:**
- `lenovolegionlinux/PKGBUILD` + `.SRCINFO`: pkgver `0.0.22` → `0.0.25`, source tag `v0.0.22` → `v0.0.25`
- `lenovolegionlinux-dkms/PKGBUILD` + `.SRCINFO`: same

v0.0.25 upstream notes: Python/GUI/legiond static-analysis fixes, kernel module warning fixes, T3CN model support, and more.