### PR TITLE
Add KR (mirror.pileus.kr) mirror to cachyos-mirrorlist

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -127,3 +127,6 @@ Server = https://repo.c48.uk/cachyos/repo/$arch/$repo
 ## US East mirror provided by UMBC LUG (University)
 ## tier=2 code=US
 Server = https://mirror.lug.umbc.edu/cachyos/repo/$arch/$repo
+## Republic of Korea Mirror provided by Woojin Lim (Pileus)
+## tier=2 code=KR
+Server = https://mirror.pileus.kr/cachyos/repo/$arch/$repo


### PR DESCRIPTION
We are syncing CachyOS every 1 hours from rsync://ca.mirror.cx/cachyos/

Accessible at:
https://mirror.pileus.kr/cachyos

We would also be interested in becoming a Tier 2 Mirror.