### PR TITLE
cachyos-drm-awaiter: emit target on NVIDIA-only systems

### DIFF
--- a/cachyos-drm-awaiter/.SRCINFO
+++ b/cachyos-drm-awaiter/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cachyos-drm-awaiter
 	pkgdesc = Configuration for proper systemd chain-loading of DRM modules
 	pkgver = 1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/CachyOS/CachyOS-PKGBUILDS/tree/master/cachyos-drm-awaiter
 	arch = any
 	license = GPL-3.0-or-later
@@ -9,7 +9,7 @@ pkgbase = cachyos-drm-awaiter
 	depends = systemd
 	source = drm-module-awaiter-generator
 	source = 30-drm-awaiter.rules
-	sha256sums = a2f6e87c96113fb995cd51f70c0042e55bae790a4ee3aa8be870c00b3208907d
-	sha256sums = 4457ec33251aa019a83a4637e24851aef6fbb4828c74126fad74b7203b1c3f13
+	sha256sums = bf0cbb8e5dd4aa604bfb58249f7fe65cc59a01b3e6eafb006637ac0257c2dae9
+	sha256sums = fefbe1ce8012f0f0b9063d4cfdb8b31a7292f931f5069465b5646e5c5fa5f083
 
 pkgname = cachyos-drm-awaiter

--- a/cachyos-drm-awaiter/PKGBUILD
+++ b/cachyos-drm-awaiter/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Vasiliy Stelmachenok <ventureo@cachyos.org>
 pkgname=cachyos-drm-awaiter
 pkgver=1
-pkgrel=1
+pkgrel=2
 pkgdesc="Configuration for proper systemd chain-loading of DRM modules"
 arch=('any')
 license=('GPL-3.0-or-later')
@@ -13,7 +13,7 @@ source=(
     30-drm-awaiter.rules
 )
 sha256sums=(
-    'a2f6e87c96113fb995cd51f70c0042e55bae790a4ee3aa8be870c00b3208907d'
+    'bf0cbb8e5dd4aa604bfb58249f7fe65cc59a01b3e6eafb006637ac0257c2dae9'
     'fefbe1ce8012f0f0b9063d4cfdb8b31a7292f931f5069465b5646e5c5fa5f083'
 )
 

--- a/cachyos-drm-awaiter/drm-module-awaiter-generator
+++ b/cachyos-drm-awaiter/drm-module-awaiter-generator
@@ -102,17 +102,15 @@ function generate_load_target() {
         esac
     done < <(grep -l "0x030[0-9]00" /sys/bus/pci/devices/*/class)
 
-    if [ -z "${modules[0]}" ]; then
-        return 0
+    if [ -n "$nvidia_module" ]; then
+        for module in "${modules[@]}"; do
+            postpone_nvidia_module "$module" "$nvidia_module"
+        done
+        modules+=("$nvidia_module")
     fi
 
-    if [ -n "$nvidia_module" ]; then
-        modules+=("$nvidia_module")
-        for module in "${modules[@]}"; do
-            if [[ "$module" != "$nvidia_module" ]]; then
-                postpone_nvidia_module "$module" "$nvidia_module"
-            fi
-        done
+    if [ -z "${modules[0]}" ]; then
+        return 0
     fi
 
     local -a devices=()


### PR DESCRIPTION
On a machine where the only GPU is NVIDIA, the generator never writes `drm-module-load.target`. It stores the NVIDIA module in `nvidia_module` (so it can be ordered after an iGPU driver) and only appends it to `modules` after the `[ -z "${modules[0]}" ]` early return. With no AMD or Intel GPU that array is empty, so the function returns before the append.

This patch moves the NVIDIA merge above the early return. The postpone loop runs before the append now, so the `!= nvidia_module` guard goes away. Hybrid and AMD/Intel-only machines produce the same output as before.

How I hit it: installed 1-1 on my desktop (RTX 5070 Ti, proprietary driver, no iGPU), rebooted, and `/run/systemd/generator/` had no target and no `.wants` dirs. `sys-module-nvidia_drm.device` was there, so the udev half works. Running the script by hand with `bash -x` shows `nvidia_module=nvidia_drm` followed straight by `return 0`. With the patch installed and a real reboot, `/run/systemd/generator/drm-module-load.target` is there with `After=sys-module-nvidia_drm.device` and both symlinks, the target went active at 4.2s and plasmalogin started 3ms after it. No change in boot time since the module is still in the initramfs here.

Also bumped pkgrel and regenerated .SRCINFO. The old .SRCINFO had a different checksum for the udev rule than the PKGBUILD did, so that gets corrected as a side effect.

Two things I noticed but left alone, since they are separate bugs: `is_module_loadable nouveau` can never match because nouveau's aliases use `d*` wildcards and the check greps for the exact device id, so the nouveau branch is dead; and `generator_dir` is not validated, so running the script with no argument writes into `/`. Happy to send those separately if you want.

I used an LLM to help find and draft this. The repro and the test above are from my own machine.
