### PR TITLE
cachyos-plymouth-theme: ship corrected keymap render

### DIFF
--- a/cachyos-plymouth-theme/PKGBUILD
+++ b/cachyos-plymouth-theme/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=cachyos-plymouth-theme
 pkgver=1
-pkgrel=1
+pkgrel=2
 groups=("cachyos")
 arch=("any")
 url="https://github.com/CachyOS/${pkgname}"
@@ -11,7 +11,9 @@ pkgdesc="CachyOS plymouth theme"
 depends=("plymouth")
 makedepends=('git')
 optdepends=("plymouth-kcm: for KDE settings integration")
-source=("${pkgname}::git+${url}.git")
+# Pin the source so the packaged theme is reproducible.  This revision includes
+# the corrected keymap-render.png used by Plymouth's password prompt.
+source=("${pkgname}::git+${url}.git#commit=27c453a1d65597d9773af349836bd67665267e87")
 sha256sums=("SKIP")
 
 package() {


### PR DESCRIPTION
## Summary
- pin the theme source to upstream revision `27c453a1d65597d9773af349836bd67665267e87`
- bump `pkgrel` to 2 so the corrected `keymap-render.png` is delivered to installed systems

The selected upstream revision includes the keymap-render synchronization, making the image consistent with the bootanimation theme and current Plymouth assets. Pinning it also makes this git-based package reproducible.

Closes #1822

## Validation
- `bash -n cachyos-plymouth-theme/PKGBUILD`
- ran `package()` in an isolated staging directory
- verified the installed keymap image matches the pinned source and the license is installed
- `git diff --check`