### PR TITLE
xwayland-satellite: Add at v0.8.2

### DIFF
--- a/xwayland-satellite/.SRCINFO
+++ b/xwayland-satellite/.SRCINFO
@@ -1,0 +1,22 @@
+pkgbase = xwayland-satellite
+	pkgdesc = Xwayland outside your Wayland
+	pkgver = 0.8.2
+	pkgrel = 1
+	url = https://github.com/Supreeeme/xwayland-satellite
+	arch = x86_64
+	license = MPL-2.0
+	makedepends = clang
+	makedepends = rust
+	depends = glibc
+	depends = libgcc
+	depends = libxcb
+	depends = xcb-util-cursor
+	depends = xorg-xwayland
+	source = xwayland-satellite-0.8.2.tar.gz::https://github.com/Supreeeme/xwayland-satellite/archive/refs/tags/v0.8.2.tar.gz
+	source = https://github.com/Supreeeme/xwayland-satellite/commit/add2795134593faafce60e404a0a75df68e9ee0c.patch
+	sha512sums = a125fe92591c7c39c4ae05e5d7a5b737d4104419165b98e4d486c5e2208b30b95173f2793141ef897f23f22c87c15f80daf8dcc2dbb4327c2fdf3288d56acd80
+	sha512sums = 7d3de5ff6e9df2dab3a9b450fbcc47b9a19f75788e96879ad1ea8bede8d0f8bce3a08fe9c6a6556c9e0b092efb04eef18608d387dacacc3920075ff71b7e9f4e
+	b2sums = 3bd8880386f0b2f73d2587e9ad5803ded1e107be4f4b8fe75f17453a3e98624f9f34c15a2ef11a2bb8362809100b6d9ce4fd6e1d350af164b3cf954cae7653db
+	b2sums = dddb8c49af0edf22cf63d23769a5dddfe4b1d5a9973c34b3f2987d6a2ae9cfc365f2821e3a581e2a942013a0db53f8b6e8267f093590f192d4d8553e40f93c5c
+
+pkgname = xwayland-satellite

--- a/xwayland-satellite/.nvchecker.toml
+++ b/xwayland-satellite/.nvchecker.toml
@@ -1,0 +1,4 @@
+[xwayland-satellite]
+source = "git"
+git = "https://github.com/Supreeeme/xwayland-satellite"
+prefix = "v"

--- a/xwayland-satellite/PKGBUILD
+++ b/xwayland-satellite/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: witchlliee <witchlliee@proton.me>
+
+pkgname=xwayland-satellite
+pkgver=0.8.2
+pkgrel=1
+pkgdesc="Xwayland outside your Wayland"
+arch=(x86_64)
+url="https://github.com/Supreeeme/xwayland-satellite"
+license=(MPL-2.0)
+depends=(
+  glibc
+  libgcc
+  libxcb
+  xcb-util-cursor
+  xorg-xwayland
+)
+makedepends=(
+  clang
+  rust
+)
+source=(
+  "${pkgname}-${pkgver}.tar.gz::$url/archive/refs/tags/v${pkgver}.tar.gz"
+  "https://github.com/Supreeeme/xwayland-satellite/commit/add2795134593faafce60e404a0a75df68e9ee0c.patch"
+)
+sha512sums=('a125fe92591c7c39c4ae05e5d7a5b737d4104419165b98e4d486c5e2208b30b95173f2793141ef897f23f22c87c15f80daf8dcc2dbb4327c2fdf3288d56acd80'
+            '7d3de5ff6e9df2dab3a9b450fbcc47b9a19f75788e96879ad1ea8bede8d0f8bce3a08fe9c6a6556c9e0b092efb04eef18608d387dacacc3920075ff71b7e9f4e')
+b2sums=('3bd8880386f0b2f73d2587e9ad5803ded1e107be4f4b8fe75f17453a3e98624f9f34c15a2ef11a2bb8362809100b6d9ce4fd6e1d350af164b3cf954cae7653db'
+        'dddb8c49af0edf22cf63d23769a5dddfe4b1d5a9973c34b3f2987d6a2ae9cfc365f2821e3a581e2a942013a0db53f8b6e8267f093590f192d4d8553e40f93c5c')
+
+prepare() {
+  cd ${pkgname}-${pkgver}
+  patch -Np1 <../add2795134593faafce60e404a0a75df68e9ee0c.patch # fix steam popups
+
+  sed 's|/usr/local|/usr|' -i resources/${pkgname}.service
+  cargo fetch --locked --target "$(rustc --print host-tuple)"
+}
+
+build() {
+  cd ${pkgname}-${pkgver}
+  cargo build --frozen --release --features systemd
+}
+
+# check() {
+#  cd ${pkgname}-${pkgver}
+#  export XDG_RUNTIME_DIR="$(mktemp -d)"
+#  RUST_BACKTRACE=1 cargo test --frozen
+# }
+
+package() {
+  cd ${pkgname}-${pkgver}
+  install -vDm 755 target/release/${pkgname} -t "${pkgdir}/usr/bin/"
+  install -vDm 644 resources/${pkgname}.service -t "${pkgdir}/usr/lib/systemd/user/"
+  install -vDm 644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgdir}/"
+}


### PR DESCRIPTION
This adds xwayland-satellite and a patch for steam popups. I figure it might be better to just have a fork here, since we have so many compositors using it, so now and then I would like to have control over it to backport patches that may be needed, which is the case now.