### PR TITLE
cachyos-gaming-applications: Remove lutris in favor of faugus-launcher

### DIFF
--- a/cachyos-gaming-applications/.SRCINFO
+++ b/cachyos-gaming-applications/.SRCINFO
@@ -9,7 +9,6 @@ pkgbase = cachyos-gaming-applications
 	depends = heroic-games-launcher
 	depends = faugus-launcher
 	depends = lib32-mangohud
-	depends = lutris
 	depends = mangohud
 	depends = steam
 	depends = wqy-zenhei

--- a/cachyos-gaming-applications/PKGBUILD
+++ b/cachyos-gaming-applications/PKGBUILD
@@ -13,7 +13,6 @@ depends=(
   heroic-games-launcher
   faugus-launcher
   lib32-mangohud
-  lutris
   mangohud
   steam
   wqy-zenhei


### PR DESCRIPTION
Lutris doesn't hold well against faugus-launcher. Faugus already does a way better job and fills the gap which once lutris did. I don't think it has a space in the cachyos-gaming-applications anymore.