### PR TITLE
re-enable krfoss and krfoss5 mirrors

### DIFF
--- a/cachyos-mirrorlist/cachyos-mirrorlist
+++ b/cachyos-mirrorlist/cachyos-mirrorlist
@@ -109,9 +109,9 @@ Server = https://mirror.keiminem.com/cachyos/repo/$arch/$repo
 Server = https://mirror2.keiminem.com/cachyos/repo/$arch/$repo
 ## Republic of Korea Mirror much thanks to ROKFOSS
 ## tier=2 code=GLOBAL
-# Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
+Server = https://mirror.krfoss.org/cachyos/repo/$arch/$repo
 ## tier=2 code=GLOBAL
-# Server = https://mirror5.krfoss.org/cachyos/repo/$arch/$repo
+Server = https://mirror5.krfoss.org/cachyos/repo/$arch/$repo
 ## USA mirror in Las Vegas, NV provided by hjk321
 ## tier=1 code=US
 Server = https://mirror.hjk.gg/cachyos/repo/$arch/$repo


### PR DESCRIPTION
Revert #1856 / commit 001587540b67d66deaddd248b9ac8c179a960c82. to re-enable mirror.krfoss.org and mirror5.krfoss.org.